### PR TITLE
Fix import of 'modulemap' for Commoncrypto

### DIFF
--- a/web3swift.xcodeproj/project.pbxproj
+++ b/web3swift.xcodeproj/project.pbxproj
@@ -1072,8 +1072,8 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/web3swift/lib/**";
-				"SWIFT_INCLUDE_PATHS[sdk=*]" = "$(SRCROOT)/web3swift/lib/**";
-				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(SRCROOT)/web3swift/lib/**";
+				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(SRCROOT)/web3swift/lib/** $(SRCROOT)/web3swift/frameworks/CommonCrypto/iphoneos";
+				"SWIFT_INCLUDE_PATHS[sdk=iphonesimulator*]" = "$(SRCROOT)/web3swift/lib/** $(SRCROOT)/web3swift/frameworks/CommonCrypto/iphonesimulator";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.0;
@@ -1101,8 +1101,8 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/web3swift/lib/**";
-				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(SRCROOT)/web3swift/lib/**";
-				"SWIFT_INCLUDE_PATHS[sdk=iphonesimulator*]" = "$(SRCROOT)/web3swift/lib/**";
+				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(SRCROOT)/web3swift/lib/** $(SRCROOT)/web3swift/frameworks/CommonCrypto/iphoneos/**";
+				"SWIFT_INCLUDE_PATHS[sdk=iphonesimulator*]" = "$(SRCROOT)/web3swift/lib/** $(SRCROOT)/web3swift/frameworks/CommonCrypto/iphonesimulator";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
I couldn't compile the library (simulator nor device) as the include was not configured in project.

It's correctly configured in the `podspec` though, so duplicated it to be able to work standalone.