### PR TITLE
**DO NOT MERGE** Decoding of fixed size type

### DIFF
--- a/web3swift/src/Contract/Statically Typed/ABIRawType+Static.swift
+++ b/web3swift/src/Contract/Statically Typed/ABIRawType+Static.swift
@@ -10,18 +10,29 @@ import Foundation
 import BigInt
 
 public protocol ABIType { }
+
 extension String: ABIType { }
 extension Bool: ABIType { }
 extension EthereumAddress: ABIType { }
 extension BigInt: ABIType { }
 extension BigUInt: ABIType { }
 extension Data: ABIType { }
-// TODO (U)Double. Function. Array. Other Int sizes. Fixed binary type (byte<M>)
+// TODO (U)Double. Function. Array. Other Int sizes
 extension Array: ABIType { }
 extension UInt8: ABIType { }
 extension UInt16: ABIType { }
 extension UInt32: ABIType { }
 extension UInt64: ABIType { }
+
+public protocol ABIFixedSizeDataType : ABIType {
+    static var fixedSize: Int { get }
+}
+
+public struct Data32 : ABIFixedSizeDataType {
+    public static var fixedSize: Int {
+        return 32
+    }
+}
 
 extension ABIRawType {
     init?(type: ABIType.Type) {
@@ -36,6 +47,9 @@ extension ABIRawType {
         case is UInt32.Type: self = ABIRawType.FixedUInt(32)
         case is UInt64.Type: self = ABIRawType.FixedUInt(64)
         case is Data.Type: self = ABIRawType.DynamicBytes
+        case is ABIFixedSizeDataType.Type:
+            guard let fixed = type as? ABIFixedSizeDataType.Type else { return nil }
+            self = ABIRawType.FixedBytes(fixed.fixedSize)
         default: return nil
         }
     }

--- a/web3swift/src/Contract/Statically Typed/ABIRawType+Static.swift
+++ b/web3swift/src/Contract/Statically Typed/ABIRawType+Static.swift
@@ -28,6 +28,187 @@ public protocol ABIFixedSizeDataType : ABIType {
     static var fixedSize: Int { get }
 }
 
+public struct Data1 : ABIFixedSizeDataType {
+    public static var fixedSize: Int {
+        return 1
+    }
+}
+
+public struct Data2 : ABIFixedSizeDataType {
+    public static var fixedSize: Int {
+        return 2
+    }
+}
+
+public struct Data3 : ABIFixedSizeDataType {
+    public static var fixedSize: Int {
+        return 3
+    }
+}
+
+public struct Data4 : ABIFixedSizeDataType {
+    public static var fixedSize: Int {
+        return 4
+    }
+}
+
+public struct Data5 : ABIFixedSizeDataType {
+    public static var fixedSize: Int {
+        return 5
+    }
+}
+
+public struct Data6 : ABIFixedSizeDataType {
+    public static var fixedSize: Int {
+        return 6
+    }
+}
+
+public struct Data7 : ABIFixedSizeDataType {
+    public static var fixedSize: Int {
+        return 7
+    }
+}
+public struct Data8 : ABIFixedSizeDataType {
+    public static var fixedSize: Int {
+        return 8
+    }
+}
+
+public struct Data9 : ABIFixedSizeDataType {
+    public static var fixedSize: Int {
+        return 9
+    }
+}
+
+public struct Data10 : ABIFixedSizeDataType {
+    public static var fixedSize: Int {
+        return 10
+    }
+}
+
+public struct Data11 : ABIFixedSizeDataType {
+    public static var fixedSize: Int {
+        return 11
+    }
+}
+
+public struct Data12 : ABIFixedSizeDataType {
+    public static var fixedSize: Int {
+        return 12
+    }
+}
+
+public struct Data13 : ABIFixedSizeDataType {
+    public static var fixedSize: Int {
+        return 13
+    }
+}
+
+public struct Data14 : ABIFixedSizeDataType {
+    public static var fixedSize: Int {
+        return 14
+    }
+}
+
+public struct Data15 : ABIFixedSizeDataType {
+    public static var fixedSize: Int {
+        return 15
+    }
+}
+
+public struct Data16 : ABIFixedSizeDataType {
+    public static var fixedSize: Int {
+        return 16
+    }
+}
+
+public struct Data17 : ABIFixedSizeDataType {
+    public static var fixedSize: Int {
+        return 17
+    }
+}
+
+public struct Data18 : ABIFixedSizeDataType {
+    public static var fixedSize: Int {
+        return 18
+    }
+}
+
+public struct Data19 : ABIFixedSizeDataType {
+    public static var fixedSize: Int {
+        return 19
+    }
+}
+
+public struct Data20 : ABIFixedSizeDataType {
+    public static var fixedSize: Int {
+        return 20
+    }
+}
+public struct Data21 : ABIFixedSizeDataType {
+    public static var fixedSize: Int {
+        return 21
+    }
+}
+
+public struct Data22 : ABIFixedSizeDataType {
+    public static var fixedSize: Int {
+        return 22
+    }
+}
+public struct Data23 : ABIFixedSizeDataType {
+    public static var fixedSize: Int {
+        return 23
+    }
+}
+public struct Data24 : ABIFixedSizeDataType {
+    public static var fixedSize: Int {
+        return 24
+    }
+}
+
+public struct Data25 : ABIFixedSizeDataType {
+    public static var fixedSize: Int {
+        return 25
+    }
+}
+public struct Data26 : ABIFixedSizeDataType {
+    public static var fixedSize: Int {
+        return 26
+    }
+}
+
+public struct Data27 : ABIFixedSizeDataType {
+    public static var fixedSize: Int {
+        return 27
+    }
+}
+
+public struct Data28 : ABIFixedSizeDataType {
+    public static var fixedSize: Int {
+        return 28
+    }
+}
+
+public struct Data29 : ABIFixedSizeDataType {
+    public static var fixedSize: Int {
+        return 29
+    }
+}
+
+public struct Data30 : ABIFixedSizeDataType {
+    public static var fixedSize: Int {
+        return 30
+    }
+}
+
+public struct Data31 : ABIFixedSizeDataType {
+    public static var fixedSize: Int {
+        return 31
+    }
+}
+
 public struct Data32 : ABIFixedSizeDataType {
     public static var fixedSize: Int {
         return 32


### PR DESCRIPTION
A small PR after I've been thinking how the API to express fixed bytes would look like.

Currently we use native Swift types like `Int32` or `Data` to drive the decoding through API in a type-safe manner.
Adding decoding for fixed byte types from Solidity we can't use the `Data` type directly as it's interpreted as dynamic-size bytes.

Solidity has specific types for fixed-sized byte arrays: `byte1`, `byte2`, `bytes3`...`bytes32`. This enforces the fact that ABI defines a max number of 32 bytes for fixed-sized byte arrays.

To express this through types and avoid runtime parsing I take the approach to define a Swift protocol for every fixed-size byte array. I couldn't find a way to express type constraints involving the *value* of some integer (something like FixedSizeData<2>).

Here the code is modified to only include a `Data32` type. Final changes would have a lot of boilerplate involving declaration of `Data1`, `Data2`,..., `Data32`. 

I've tested parsing and works fine with real contract. Let me know what you think.