### PR TITLE
Fix tests compiling

### DIFF
--- a/web3sTests/Account/EthereumAccountTests.swift
+++ b/web3sTests/Account/EthereumAccountTests.swift
@@ -62,7 +62,7 @@ class EthereumAccountTests: XCTestCase {
         
         let expectedSignature = "8152ada8bece83905602d6b9a8a0f137dace41cd6a2da9d3fb26baa9fb79e2080e871937b634213a0e4cd7dee00c119567fa53096532e88ddf0fb183097bb4d701"
         
-        XCTAssertEqual(signature?.hexString.noHexPrefix, expectedSignature)
+        XCTAssertEqual(signature.hexString.noHexPrefix, expectedSignature)
     }
     
     func testSignTxHash() {

--- a/web3sTests/Account/EthereumAccountTests.swift
+++ b/web3sTests/Account/EthereumAccountTests.swift
@@ -35,7 +35,7 @@ class EthereumAccountTests: XCTestCase {
         
         let expectedSignature = "7f89b86ee3ca79d32324b9c2ede02385b5a32ecd7c0caf5d7ceb0b34cf7c90697627d1cb3435c16bb72866273eb14bd9f387d74591382add29d4e39b8c11167300"
         
-        XCTAssertEqual(signature!.hexString.noHexPrefix, expectedSignature)
+        XCTAssertEqual(signature.hexString.noHexPrefix, expectedSignature)
     }
     
     func testSignData() {
@@ -53,7 +53,7 @@ class EthereumAccountTests: XCTestCase {
         
         let expectedSignature = "16f89ddb9bf9ec08ff696bc766e675da7cfcb4f0b10bc8ce7c1a87a414a65a4f19c05c207e1b59f2e1cd18053cb8406fb7c6d22cec5e348d6217febbff8fc19801"
         
-        XCTAssertEqual(signature!.hexString.noHexPrefix, expectedSignature)
+        XCTAssertEqual(signature.hexString.noHexPrefix, expectedSignature)
     }
     
     func testSignHex() {
@@ -62,7 +62,7 @@ class EthereumAccountTests: XCTestCase {
         
         let expectedSignature = "8152ada8bece83905602d6b9a8a0f137dace41cd6a2da9d3fb26baa9fb79e2080e871937b634213a0e4cd7dee00c119567fa53096532e88ddf0fb183097bb4d701"
         
-        XCTAssertEqual(signature!.hexString.noHexPrefix, expectedSignature)
+        XCTAssertEqual(signature?.hexString.noHexPrefix, expectedSignature)
     }
     
     func testSignTxHash() {
@@ -70,7 +70,7 @@ class EthereumAccountTests: XCTestCase {
         let signature = try! account.sign(hash: "0xdaf5a779ae972f972197303d7b574746c7ef83eadac0f2791ad23db92e4c8e53")
         let expectedSignature = "28ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa63627667cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d8300"
         
-         XCTAssertEqual(signature?.hexString.noHexPrefix, expectedSignature)
+         XCTAssertEqual(signature.hexString.noHexPrefix, expectedSignature)
      }
     
     

--- a/web3swift/src/Account/EthereumAccount.swift
+++ b/web3swift/src/Account/EthereumAccount.swift
@@ -20,6 +20,7 @@ protocol EthereumAccountProtocol {
     
     func sign(data: Data) throws -> Data
     func sign(hash: String) throws -> Data
+    func sign(hex: String) throws -> Data
     func sign(message: Data) throws -> Data
     func sign(message: String) throws -> Data
     func sign(_ transaction: EthereumTransaction) throws -> SignedTransaction
@@ -87,7 +88,7 @@ public class EthereumAccount: EthereumAccountProtocol {
         return try KeyUtil.sign(message: data, with: self.privateKeyData, hashing: true)
     }
     
-    public func sign(hex: String) throws -> Data? {
+    public func sign(hex: String) throws -> Data {
         if let data = Data.init(hex: hex) {
             return try KeyUtil.sign(message: data, with: self.privateKeyData, hashing: true)
         } else {


### PR DESCRIPTION
Also unified the return type to be non-optional for all `sign` APIs in the client