### PR TITLE
Improvement: Use XCTAssertEqual for comparison

### DIFF
--- a/web3sTests/Account/EthereumAccountTests.swift
+++ b/web3sTests/Account/EthereumAccountTests.swift
@@ -21,12 +21,12 @@ class EthereumAccountTests: XCTestCase {
     
     func testLoadAccountAndAddress() {
         let account = try! EthereumAccount(keyStorage: TestEthereumKeyStorage(privateKey: TestConfig.privateKey))
-        XCTAssert(account.address == TestConfig.publicKey)
+        XCTAssertEqual(account.address, TestConfig.publicKey)
     }
     
     func testCreateAccount() {
         let account = try? EthereumAccount.create(keyStorage: EthereumKeyLocalStorage(), keystorePassword: "PASSWORD")
-        XCTAssert(account != nil)
+        XCTAssertNotNil(account)
     }
     
     func testSignMessage() {

--- a/web3sTests/Account/EthereumAccountTests.swift
+++ b/web3sTests/Account/EthereumAccountTests.swift
@@ -21,7 +21,7 @@ class EthereumAccountTests: XCTestCase {
     
     func testLoadAccountAndAddress() {
         let account = try! EthereumAccount(keyStorage: TestEthereumKeyStorage(privateKey: TestConfig.privateKey))
-        XCTAssertEqual(account.address, TestConfig.publicKey)
+        XCTAssertEqual(account.address.lowercased(), TestConfig.publicKey.lowercased())
     }
     
     func testCreateAccount() {

--- a/web3sTests/Account/EthereumKeyStorageTests.swift
+++ b/web3sTests/Account/EthereumKeyStorageTests.swift
@@ -37,7 +37,7 @@ class EthereumKeyStorageTests: XCTestCase {
         do {
             try keyStorage.storePrivateKey(key: randomData)
             let storedData = try keyStorage.loadPrivateKey()
-            XCTAssert(randomData == storedData, "Stored and Received data do not match")
+            XCTAssertEqual(randomData, storedData)
         } catch {
             XCTFail()
         }

--- a/web3sTests/Client/EthereumClientTests.swift
+++ b/web3sTests/Client/EthereumClientTests.swift
@@ -29,7 +29,7 @@ class EthereumClientTests: XCTestCase {
     func testEthGetBalance() {
         let expectation = XCTestExpectation(description: "get remote balance")
         client?.eth_getBalance(address: account!.address, block: .Latest, completion: { (error, balance) in
-            XCTAssert(balance != nil, "Balance not available: \(error?.localizedDescription ?? "no error")")
+            XCTAssertNotNil(balance, "Balance not available: \(error?.localizedDescription ?? "no error")")
             expectation.fulfill()
         })
         
@@ -40,7 +40,7 @@ class EthereumClientTests: XCTestCase {
         let expectation = XCTestExpectation(description: "get remote balance incorrect")
         
         client?.eth_getBalance(address: "0xnig42niog2", block: .Latest, completion: { (error, balance) in
-            XCTAssert(error != nil, "Balance error not available")
+            XCTAssertNotNil(error, "Balance error not available")
             expectation.fulfill()
         })
         
@@ -50,7 +50,7 @@ class EthereumClientTests: XCTestCase {
     func testNetVersion() {
         let expectation = XCTestExpectation(description: "get net version")
         client?.net_version(completion: { (error, network) in
-            XCTAssert(network! == EthereumNetwork.Ropsten, "Network incorrect: \(error?.localizedDescription ?? "no error")")
+            XCTAssertEqual(network, EthereumNetwork.Ropsten, "Network incorrect: \(error?.localizedDescription ?? "no error")")
             expectation.fulfill()
         })
         
@@ -60,7 +60,7 @@ class EthereumClientTests: XCTestCase {
     func testEthGasPrice() {
         let expectation = XCTestExpectation(description: "get gas price")
         client?.eth_gasPrice(completion: { (error, gas) in
-            XCTAssert(gas != nil, "Gas not available: \(error?.localizedDescription ?? "no error")")
+            XCTAssertNotNil(gas, "Gas not available: \(error?.localizedDescription ?? "no error")")
             expectation.fulfill()
         })
         
@@ -70,7 +70,7 @@ class EthereumClientTests: XCTestCase {
     func testEthBlockNumber() {
         let expectation = XCTestExpectation(description: "get current block number")
         client?.eth_blockNumber(completion: { (error, block) in
-            XCTAssert(block != nil, "Block not available: \(error?.localizedDescription ?? "no error")")
+            XCTAssertNotNil(block, "Block not available: \(error?.localizedDescription ?? "no error")")
             expectation.fulfill()
         })
         
@@ -80,7 +80,7 @@ class EthereumClientTests: XCTestCase {
     func testEthGetCode() {
         let expectation = XCTestExpectation(description: "get contract code")
         client?.eth_getCode(address: "0x112234455c3a32fd11230c42e7bccd4a84e02010", completion: { (error, code) in
-            XCTAssert(code != nil, "Contract code not available: \(error?.localizedDescription ?? "no error")")
+            XCTAssertNotNil(code, "Contract code not available: \(error?.localizedDescription ?? "no error")")
             expectation.fulfill()
         })
         
@@ -93,7 +93,7 @@ class EthereumClientTests: XCTestCase {
         let tx = EthereumTransaction(from: nil, to: "0x3c1bd6b420448cf16a389c8b0115ccb3660bb854", value: BigUInt(1600000), data: nil, nonce: 2, gasPrice: BigUInt(4000000), gasLimit: BigUInt(50000), chainId: EthereumNetwork.Ropsten.intValue)
         
         self.client?.eth_sendRawTransaction(tx, withAccount: self.account!, completion: { (error, txHash) in
-            XCTAssert(txHash != nil, "Transaction hash not available: \(error?.localizedDescription ?? "no error")")
+            XCTAssertNotNil(txHash, "Transaction hash not available: \(error?.localizedDescription ?? "no error")")
             expectation.fulfill()
         })
     
@@ -104,7 +104,7 @@ class EthereumClientTests: XCTestCase {
         let expectation = XCTestExpectation(description: "get transaction receipt")
         
         client?.eth_getTransactionCount(address: account!.address, block: .Latest, completion: { (error, count) in
-            XCTAssert(count != nil, "Transaction count not available: \(error?.localizedDescription ?? "no error")")
+            XCTAssertNotNil(count, "Transaction count not available: \(error?.localizedDescription ?? "no error")")
             expectation.fulfill()
         })
         
@@ -115,7 +115,7 @@ class EthereumClientTests: XCTestCase {
         let expectation = XCTestExpectation(description: "get transaction receipt")
         
         client?.eth_getTransactionCount(address: account!.address, block: .Pending, completion: { (error, count) in
-            XCTAssert(count != nil, "Transaction count not available: \(error?.localizedDescription ?? "no error")")
+            XCTAssertNotNil(count, "Transaction count not available: \(error?.localizedDescription ?? "no error")")
             expectation.fulfill()
         })
         
@@ -127,7 +127,7 @@ class EthereumClientTests: XCTestCase {
        
         let txHash = "0xc51002441dc669ad03697fd500a7096c054b1eb2ce094821e68831a3666fc878"
         client?.eth_getTransactionReceipt(txHash: txHash, completion: { (error, receipt) in
-            XCTAssert(receipt != nil, "Transaction receipt not available: \(error?.localizedDescription ?? "no error")")
+            XCTAssertNotNil(receipt, "Transaction receipt not available: \(error?.localizedDescription ?? "no error")")
             expectation.fulfill()
         })
         
@@ -139,7 +139,7 @@ class EthereumClientTests: XCTestCase {
         
         let tx = EthereumTransaction(from: nil, to: "0x3c1bd6b420448cf16a389c8b0115ccb3660bb854", value: BigUInt(1800000), data: nil, nonce: 2, gasPrice: BigUInt(400000), gasLimit: BigUInt(50000), chainId: EthereumNetwork.Ropsten.intValue)
         client?.eth_call(tx, block: .Latest, completion: { (error, txHash) in
-            XCTAssert(txHash != nil, "Transaction hash not available: \(error?.localizedDescription ?? "no error")")
+            XCTAssertNotNil(txHash, "Transaction hash not available: \(error?.localizedDescription ?? "no error")")
             expectation.fulfill()
         })
         
@@ -150,7 +150,7 @@ class EthereumClientTests: XCTestCase {
         let expectation = XCTestExpectation(description: "send raw transaction")
         
         client?.eth_getLogs(addresses: ["0x23d0a442580c01e420270fba6ca836a8b2353acb"], topics: nil, fromBlock: EthereumBlock.Number(0), toBlock: .Latest, completion: { (error, logs) in
-            XCTAssert(logs != nil, "Logs not available \(error?.localizedDescription ?? "no error")")
+            XCTAssertNotNil(logs, "Logs not available \(error?.localizedDescription ?? "no error")")
             expectation.fulfill()
         })
         

--- a/web3sTests/Contract/ABIDecoderTests.swift
+++ b/web3sTests/Contract/ABIDecoderTests.swift
@@ -23,7 +23,7 @@ class ABIDecoderTests: XCTestCase {
     func testDecodeUint32() {
         do {
             let decoded = try ABIDecoder.decodeData("0x000000000000000000000000000000000000000000000000000000000000002a", types: ["uint32"]) as! [String]
-            XCTAssert(BigInt(hex: decoded[0]) == 42)
+            XCTAssertEqual(BigInt(hex: decoded[0]), 42)
         } catch let error {
             print(error.localizedDescription)
             XCTFail()
@@ -36,7 +36,7 @@ class ABIDecoderTests: XCTestCase {
             let result = decoded[0].map {
                 return BigInt(hex: $0)!
             }
-            XCTAssert(result == [BigInt(1), BigInt(2), BigInt(3)])
+            XCTAssertEqual(result, [BigInt(1), BigInt(2), BigInt(3)])
         } catch let error {
             print(error.localizedDescription)
             XCTFail()
@@ -46,7 +46,7 @@ class ABIDecoderTests: XCTestCase {
     func testDecodeAddress() {
         do {
             let decoded = try ABIDecoder.decodeData("0x00000000000000000000000021397c1a1f4acd9132fe36df011610564b87e24b", types: ["address"]) as! [String]
-            XCTAssert(decoded[0] == "0x21397c1a1f4acd9132fe36df011610564b87e24b")
+            XCTAssertEqual(decoded[0], "0x21397c1a1f4acd9132fe36df011610564b87e24b")
         } catch let error {
             print(error.localizedDescription)
             XCTFail()
@@ -57,7 +57,7 @@ class ABIDecoderTests: XCTestCase {
     func testDecodeString() {
         do {
             let decoded = try ABIDecoder.decodeData("0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000147665726f6e696b612e617267656e742e74657374000000000000000000000000", types: ["string"]) as! [String]
-            XCTAssert(decoded[0].stringValue == "veronika.argent.test")
+            XCTAssertEqual(decoded[0].stringValue, "veronika.argent.test")
         } catch let error {
             print(error.localizedDescription)
             XCTFail()
@@ -68,7 +68,7 @@ class ABIDecoderTests: XCTestCase {
     func testDecodeAddressArray() {
         do {
             let decoded = try ABIDecoder.decodeData("0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a77b0f3aae325cb2ec1bdb4a3548d816a83b8ca3", types: ["address[]"]) as! [[String]]
-            XCTAssert(decoded[0] == ["0x0000000000000000000000000000000000000000", "0xa77b0f3aae325cb2ec1bdb4a3548d816a83b8ca3"])
+            XCTAssertEqual(decoded[0], ["0x0000000000000000000000000000000000000000", "0xa77b0f3aae325cb2ec1bdb4a3548d816a83b8ca3"])
         } catch let error {
             print(error.localizedDescription)
             XCTFail()

--- a/web3sTests/Contract/ABIEncoderTests.swift
+++ b/web3sTests/Contract/ABIEncoderTests.swift
@@ -24,9 +24,9 @@ class ABIEncoderTests: XCTestCase {
         var encoded: [UInt8]
         do {
             encoded = try ABIEncoder.encode("10000", forType: ABIRawType.FixedInt(32))
-            XCTAssert(String(hexFromBytes: encoded) == "0x0000000000000000000000000000000000000000000000000000000000002710")
+            XCTAssertEqual(String(hexFromBytes: encoded), "0x0000000000000000000000000000000000000000000000000000000000002710")
             encoded = try ABIEncoder.encode("25639", forType: ABIRawType.FixedInt(32))
-            XCTAssert(String(hexFromBytes: encoded) == "0x0000000000000000000000000000000000000000000000000000000000006427")
+            XCTAssertEqual(String(hexFromBytes: encoded), "0x0000000000000000000000000000000000000000000000000000000000006427")
         } catch let error {
             print(error.localizedDescription)    
             XCTFail()
@@ -37,7 +37,7 @@ class ABIEncoderTests: XCTestCase {
         
         do {
             let encoded = try ABIEncoder.encode("-25896", forType: ABIRawType.FixedInt(32))
-            XCTAssert(String(hexFromBytes: encoded) == "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff9ad8")
+            XCTAssertEqual(String(hexFromBytes: encoded), "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff9ad8")
         } catch let error {
             print(error.localizedDescription)
             XCTFail()
@@ -48,7 +48,7 @@ class ABIEncoderTests: XCTestCase {
         
         do {
             let encoded = try ABIEncoder.encode("a response string (unsupported)", forType: ABIRawType.DynamicString)
-            XCTAssert(String(hexFromBytes: encoded) == "0x000000000000000000000000000000000000000000000000000000000000001f6120726573706f6e736520737472696e672028756e737570706f727465642900")
+            XCTAssertEqual(String(hexFromBytes: encoded), "0x000000000000000000000000000000000000000000000000000000000000001f6120726573706f6e736520737472696e672028756e737570706f727465642900")
         } catch let error {
             print(error.localizedDescription)
             XCTFail()
@@ -59,7 +59,7 @@ class ABIEncoderTests: XCTestCase {
         
         do {
             let encoded = try ABIEncoder.encode(" hello world hello world hello world hello world  hello world hello world hello world hello world  hello world hello world hello world hello world hello world hello world hello world hello world", forType: ABIRawType.DynamicString)
-            XCTAssert(String(hexFromBytes: encoded) == "0x00000000000000000000000000000000000000000000000000000000000000c22068656c6c6f20776f726c642068656c6c6f20776f726c642068656c6c6f20776f726c642068656c6c6f20776f726c64202068656c6c6f20776f726c642068656c6c6f20776f726c642068656c6c6f20776f726c642068656c6c6f20776f726c64202068656c6c6f20776f726c642068656c6c6f20776f726c642068656c6c6f20776f726c642068656c6c6f20776f726c642068656c6c6f20776f726c642068656c6c6f20776f726c642068656c6c6f20776f726c642068656c6c6f20776f726c64000000000000000000000000000000000000000000000000000000000000")
+            XCTAssertEqual(String(hexFromBytes: encoded), "0x00000000000000000000000000000000000000000000000000000000000000c22068656c6c6f20776f726c642068656c6c6f20776f726c642068656c6c6f20776f726c642068656c6c6f20776f726c64202068656c6c6f20776f726c642068656c6c6f20776f726c642068656c6c6f20776f726c642068656c6c6f20776f726c64202068656c6c6f20776f726c642068656c6c6f20776f726c642068656c6c6f20776f726c642068656c6c6f20776f726c642068656c6c6f20776f726c642068656c6c6f20776f726c642068656c6c6f20776f726c642068656c6c6f20776f726c64000000000000000000000000000000000000000000000000000000000000")
         } catch let error {
             print(error.localizedDescription)
             XCTFail()
@@ -70,7 +70,7 @@ class ABIEncoderTests: XCTestCase {
         
         do {
             let encoded = try ABIEncoder.encode("0x407d73d8a49eeb85d32cf465507dd71d507100c1", forType: ABIRawType.FixedAddress)
-            XCTAssert(String(hexFromBytes: encoded) == "0x000000000000000000000000407d73d8a49eeb85d32cf465507dd71d507100c1")
+            XCTAssertEqual(String(hexFromBytes: encoded), "0x000000000000000000000000407d73d8a49eeb85d32cf465507dd71d507100c1")
         } catch let error {
             print(error.localizedDescription)
             XCTFail()

--- a/web3sTests/ENS/ENSTests.swift
+++ b/web3sTests/ENS/ENSTests.swift
@@ -25,7 +25,7 @@ class ENSTests: XCTestCase {
     func testNameHash() {
         let name = "argent.test"
         let nameHash = EthereumNameService.nameHash(name: name)
-        XCTAssert(nameHash == "0x3e58ef7a2e196baf0b9d36a65cc590ac9edafb3395b7cdeb8f39206049b4534c")
+        XCTAssertEqual(nameHash, "0x3e58ef7a2e196baf0b9d36a65cc590ac9edafb3395b7cdeb8f39206049b4534c")
     }
     
     func testOwner() {
@@ -54,7 +54,7 @@ class ENSTests: XCTestCase {
         
         let nameService = EthereumNameService(client: client!)
         nameService.resolve(address: EthereumAddress("0xb0b874220ff95d62a676f58d186c832b3e6529c8"), completion: { (error, ens) in
-            XCTAssert("julien.argent.test" == ens)
+            XCTAssertEqual("julien.argent.test", ens)
             expect.fulfill()
         })
         
@@ -66,7 +66,7 @@ class ENSTests: XCTestCase {
         
         let nameService = EthereumNameService(client: client!)
         nameService.resolve(ens: "julien.argent.test", completion: { (error, ens) in
-            XCTAssert("0xb0b874220ff95d62a676f58d186c832b3e6529c8" == ens)
+            XCTAssertEqual("0xb0b874220ff95d62a676f58d186c832b3e6529c8", ens)
             expect.fulfill()
         })
         

--- a/web3sTests/ERC20/ERC20Tests.swift
+++ b/web3sTests/ERC20/ERC20Tests.swift
@@ -29,7 +29,7 @@ class ERC20Tests: XCTestCase {
         let expect = expectation(description: "Get token name")
         erc20?.name(tokenContract: self.testContractAddress, completion: { (error, name) in
             XCTAssertNil(error)
-            XCTAssert(name == "BokkyPooBah Test Token")
+            XCTAssertEqual(name, "BokkyPooBah Test Token")
             expect.fulfill()
         })
         waitForExpectations(timeout: 10)
@@ -39,7 +39,7 @@ class ERC20Tests: XCTestCase {
         let expect = expectation(description: "Get token decimals")
         erc20?.decimals(tokenContract: self.testContractAddress, completion: { (error, decimals) in
             XCTAssertNil(error)
-            XCTAssert(decimals == BigUInt(18))
+            XCTAssertEqual(decimals, BigUInt(18))
             expect.fulfill()
         })
         waitForExpectations(timeout: 10)
@@ -49,7 +49,7 @@ class ERC20Tests: XCTestCase {
         let expect = expectation(description: "Get token symbol")
         erc20?.symbol(tokenContract: self.testContractAddress, completion: { (error, symbol) in
             XCTAssertNil(error)
-            XCTAssert(symbol == "BOKKY")
+            XCTAssertEqual(symbol, "BOKKY")
             expect.fulfill()
         })
         waitForExpectations(timeout: 10)

--- a/web3sTests/Extensions/ByteExtensionsTests.swift
+++ b/web3sTests/Extensions/ByteExtensionsTests.swift
@@ -21,9 +21,9 @@ class ByteExtensionsTests: XCTestCase {
     }
     
     func testBytesFromBigInt() {
-        XCTAssert(BigInt(3251).bytes == [12, 179])
-        XCTAssert(BigInt(434350411044).bytes == [101, 33, 77, 77, 36])
-        XCTAssert(BigInt(-404).bytes == [254, 108])
+        XCTAssertEqual(BigInt(3251).bytes, [12, 179])
+        XCTAssertEqual(BigInt(434350411044).bytes, [101, 33, 77, 77, 36])
+        XCTAssertEqual(BigInt(-404).bytes, [254, 108])
     }
     
     func testBigIntFromTwosComplement() {
@@ -31,13 +31,13 @@ class ByteExtensionsTests: XCTestCase {
         let data = Data(bytes)
         let bint = BigInt(twosComplement: data)
         
-        XCTAssert(bint == 12886506605)
+        XCTAssertEqual(bint, 12886506605)
     }
     
     func testBytesFromData() {
         let bytes: [UInt8] = [255, 0, 123, 64]
         let data = Data(bytes: bytes)
-        XCTAssert(data.bytes == bytes)
+        XCTAssertEqual(data.bytes, bytes)
     }
     
     func testStrippingZeroesFromBytes() {
@@ -45,7 +45,7 @@ class ByteExtensionsTests: XCTestCase {
         let data = Data(bytes)
         
         let stripped = data.strippingZeroesFromBytes
-        XCTAssert([24, 124, 109] == stripped.bytes)
+        XCTAssertEqual([24, 124, 109], stripped.bytes)
     }
     
     func testStrippingZeroesFromBytesNone() {
@@ -53,23 +53,23 @@ class ByteExtensionsTests: XCTestCase {
         let data = Data(bytes)
         
         let stripped = data.strippingZeroesFromBytes
-        XCTAssert([3, 0, 24, 124, 109] == stripped.bytes)
+        XCTAssertEqual([3, 0, 24, 124, 109], stripped.bytes)
     }
     
     func testBytesFromString() {
         let str = "hello world"
-        XCTAssert(str.bytes == [104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100])
+        XCTAssertEqual(str.bytes, [104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100])
     }
     
     func testBytesFromHex() {
         let hex = "0x68656c6c6f20776f726c64"
-        XCTAssert(hex.bytesFromHex! == [104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100])
+        XCTAssertEqual(hex.bytesFromHex!, [104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100])
     }
     
     func testHexFromBytes() {
         let bytes: [UInt8] = [104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100]
         let str = String(hexFromBytes: bytes)
-        XCTAssert(str == "0x68656c6c6f20776f726c64")
+        XCTAssertEqual(str, "0x68656c6c6f20776f726c64")
     }
     
 }

--- a/web3sTests/Extensions/Data+RandomTests.swift
+++ b/web3sTests/Extensions/Data+RandomTests.swift
@@ -21,12 +21,12 @@ class Data_RandomTests: XCTestCase {
     
     func testRandomData16() {
         let data = Data.randomOfLength(16)!
-        XCTAssert(data.count == 16)
+        XCTAssertEqual(data.count, 16)
     }
     
     func testRandomData32() {
         let data = Data.randomOfLength(32)!
-        XCTAssert(data.count == 32)
+        XCTAssertEqual(data.count, 32)
     }
     
 }

--- a/web3sTests/Extensions/HexExtensionsTests.swift
+++ b/web3sTests/Extensions/HexExtensionsTests.swift
@@ -21,94 +21,94 @@ class HexExtensionsTests: XCTestCase {
     }
     
     func testIntToHexString() {
-        XCTAssert(0.hexString == "0x0")
-        XCTAssert(8.hexString == "0x8")
-        XCTAssert(453504.hexString == "0x6eb80")
+        XCTAssertEqual(0.hexString, "0x0")
+        XCTAssertEqual(8.hexString, "0x8")
+        XCTAssertEqual(453504.hexString, "0x6eb80")
     }
     
     func testIntFromHexString() {
-        XCTAssert(Int(hex: "") == nil)
-        XCTAssert(Int(hex: "0x0")! == 0)
-        XCTAssert(Int(hex: "0x10")! == 16)
-        XCTAssert(Int(hex: "0x8f9f31")! == 9412401)
+        XCTAssertEqual(Int(hex: ""), nil)
+        XCTAssertEqual(Int(hex: "0x0")!, 0)
+        XCTAssertEqual(Int(hex: "0x10")!, 16)
+        XCTAssertEqual(Int(hex: "0x8f9f31")!, 9412401)
     }
     
     func testBigUIntFromHexStringEmpty() {
-        XCTAssert(BigUInt(hex: "")! == 0)
-        XCTAssert(BigUInt(hex: "0x0")! == 0)
-        XCTAssert(BigUInt(hex: "0x10")! == 16)
-        XCTAssert(BigUInt(hex: "0x8f9f31")! == 9412401)
-        XCTAssert(BigUInt(hex: "0x2A521C551E7F200D")! == 3049531049592692749)
+        XCTAssertEqual(BigUInt(hex: "")!, 0)
+        XCTAssertEqual(BigUInt(hex: "0x0")!, 0)
+        XCTAssertEqual(BigUInt(hex: "0x10")!, 16)
+        XCTAssertEqual(BigUInt(hex: "0x8f9f31")!, 9412401)
+        XCTAssertEqual(BigUInt(hex: "0x2A521C551E7F200D")!, 3049531049592692749)
     }
     
     func testBigIntFromHexString() {
-        XCTAssert(BigInt(hex: "")! == 0)
-        XCTAssert(BigInt(hex: "0x0")! == 0)
-        XCTAssert(BigInt(hex: "0x10")! == 16)
-        XCTAssert(BigInt(hex: "0x8f9f31")! == 9412401)
-        XCTAssert(BigInt(hex: "0x2A521C551E7F200D")! == 3049531049592692749)
+        XCTAssertEqual(BigInt(hex: "")!, 0)
+        XCTAssertEqual(BigInt(hex: "0x0")!, 0)
+        XCTAssertEqual(BigInt(hex: "0x10")!, 16)
+        XCTAssertEqual(BigInt(hex: "0x8f9f31")!, 9412401)
+        XCTAssertEqual(BigInt(hex: "0x2A521C551E7F200D")!, 3049531049592692749)
     }
     
     func testDataToHexString() {
         let string = "0x68656c6c6f20776f726c64"
         let data = string.hexData!
         let dataToHex = data.hexString
-        XCTAssert(dataToHex == string)
+        XCTAssertEqual(dataToHex, string)
     }
     
     func testDataToHexStringFromBytes() {
         let data = Data(bytes: [43, 111])
         let hexString = data.hexString
-        XCTAssert(hexString == "0x2b6f")
+        XCTAssertEqual(hexString, "0x2b6f")
     }
     
     func testDataToHexStringRandom() {
         let data = Data.randomOfLength(8)!
-        XCTAssert(data.hexString.count == 18)
+        XCTAssertEqual(data.hexString.count, 18)
     }
     
     func testDataFromHexString() {
         let string = "0x68656c6c6f20776f726c64"
         let data = Data(hex: string)
-        XCTAssert(data != nil)
+        XCTAssertNotNil(data)
     }
     
     func testDataFromHexStringFail() {
         let string = "random str"
         let data = Data(hex: string)
-        XCTAssert(data == nil)
+        XCTAssertEqual(data, nil)
     }
     
     func testNoHexPrefixWith() {
         let string = "0x427131"
-        XCTAssert(string.noHexPrefix == "427131")
+        XCTAssertEqual(string.noHexPrefix, "427131")
     }
     
     func testNoHexPrefixWithout() {
         let string = "427131"
-        XCTAssert(string.noHexPrefix == string)
+        XCTAssertEqual(string.noHexPrefix, string)
     }
     
     func testHexStringToData() {
         let hexString = "2b6f"
         let data = hexString.hexData
-        XCTAssert(data == Data(bytes: [43, 111]))
+        XCTAssertEqual(data, Data(bytes: [43, 111]))
     }
     
     func testHexStringToDataPrefix() {
         let hexString = "0x2b6f"
         let data = hexString.hexData
-        XCTAssert(data == Data(bytes: [43, 111]))
+        XCTAssertEqual(data, Data(bytes: [43, 111]))
     }
     
     func testHexStringFromBytes() {
         let string = String(bytes: [43, 111])
-        XCTAssert(string == "0x2b6f")
+        XCTAssertEqual(string, "0x2b6f")
     }
     
     func testHexStringToUTF8() {
         let hex = "0x68656c6c6f20776f726c64"
-        XCTAssert(hex.stringValue == "hello world")
+        XCTAssertEqual(hex.stringValue, "hello world")
     }
 }
 

--- a/web3sTests/Extensions/KeccakExtensionsTests.swift
+++ b/web3sTests/Extensions/KeccakExtensionsTests.swift
@@ -23,7 +23,7 @@ class KeccakExtensionsTests: XCTestCase {
         let string = "hello world"
         let hash = string.keccak256
         let hexStringHash = hash.hexString
-        XCTAssert(hexStringHash == "0x47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad")
+        XCTAssertEqual(hexStringHash, "0x47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad")
     }
     
     
@@ -31,7 +31,7 @@ class KeccakExtensionsTests: XCTestCase {
         let string = "0x68656c6c6f20776f726c64"
         let data = Data(hex: string)!
         let keccak = data.keccak256
-        XCTAssert(keccak.hexString == "0x47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad")
+        XCTAssertEqual(keccak.hexString, "0x47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad")
     }
     
     func testDataKeccak256HashStr() {

--- a/web3sTests/Utils/HexUtilTests.swift
+++ b/web3sTests/Utils/HexUtilTests.swift
@@ -21,23 +21,23 @@ class HexUtilTests: XCTestCase {
     
     func testByteArray() {
         guard let array = try? HexUtil.byteArray(fromHex: "") else { return XCTFail() }
-        XCTAssert(array == [])
+        XCTAssertEqual(array, [])
         
         guard let array1 = try? HexUtil.byteArray(fromHex: "00") else { return XCTFail() }
-        XCTAssert(array1 == [0])
+        XCTAssertEqual(array1, [0])
         
         guard let array2 = try? HexUtil.byteArray(fromHex: "B6AB541600") else { return XCTFail() }
-        XCTAssert(array2 == [182, 171, 84, 22, 0])
+        XCTAssertEqual(array2, [182, 171, 84, 22, 0])
         
         guard let array3 = try? HexUtil.byteArray(fromHex: "68656c6c6f20776f726c6421") else { return XCTFail() }
-        XCTAssert(array3 == [104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 33])
+        XCTAssertEqual(array3, [104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 33])
     }
     
     func testByteArrayFail() {
         do {
             let _ = try HexUtil.byteArray(fromHex: "B6AB54160")
         } catch {
-            XCTAssert((error as? HexConversionError) == HexConversionError.stringNotEven)
+            XCTAssertEqual((error as? HexConversionError), HexConversionError.stringNotEven)
         }
     }
     

--- a/web3sTests/Utils/KeyUtilTests.swift
+++ b/web3sTests/Utils/KeyUtilTests.swift
@@ -22,8 +22,6 @@ class KeyUtilTests: XCTestCase {
     func testPrivateKeyGeneration() {
         if let privateKey = KeyUtil.generatePrivateKeyData() {
             XCTAssertEqual(privateKey.count, 32)
-        } else {
-            XCTAssert(true)
         }
     }
     


### PR DESCRIPTION
Just a minor cleanup that I did when reading and running the unit tests

Also the 'account' test failed for me with my private/public key because of case sensitivity