### PR TITLE
Feature: Support 'getBlockByNumber'

### DIFF
--- a/web3sTests/Client/EthereumClientTests.swift
+++ b/web3sTests/Client/EthereumClientTests.swift
@@ -163,7 +163,7 @@ class EthereumClientTests: XCTestCase {
         client?.eth_getBlockByNumber(.Number(0)) { error, block in
             XCTAssertNil(error)
             
-            XCTAssertEqual(block?.timestamp, 0)
+            XCTAssertEqual(block?.timestamp.timeIntervalSince1970, 0)
             XCTAssertEqual(block?.transactions.count, 0)
             expectation.fulfill()
         }
@@ -190,7 +190,7 @@ class EthereumClientTests: XCTestCase {
         client?.eth_getBlockByNumber(.Number(3415757)) { error, block in
             XCTAssertNil(error)
             
-            XCTAssertEqual(block?.timestamp, 1528711895)
+            XCTAssertEqual(block?.timestamp.timeIntervalSince1970, 1528711895)
             XCTAssertEqual(block?.transactions.count, 40)
             XCTAssertEqual(block?.transactions.first, "0x387867d052b3f89fb87937572891118aa704c1ba604c157bbd9c5a07f3a7e5cd")
             expectation.fulfill()

--- a/web3sTests/Client/EthereumClientTests.swift
+++ b/web3sTests/Client/EthereumClientTests.swift
@@ -157,4 +157,57 @@ class EthereumClientTests: XCTestCase {
         wait(for: [expectation], timeout: timeout)
     }
     
+    func testGivenGenesisBlock_ReturnsByNumber() {
+        let expectation = XCTestExpectation(description: "get block by number")
+        
+        client?.eth_getBlockByNumber(.Number(0)) { error, block in
+            XCTAssertNil(error)
+            
+            XCTAssertEqual(block?.timestamp, 0)
+            XCTAssertEqual(block?.transactions.count, 0)
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: timeout)
+    }
+
+    func testGivenLatestBlock_ReturnsByNumber() {
+        let expectation = XCTestExpectation(description: "get block by number")
+        
+        client?.eth_getBlockByNumber(.Latest) { error, block in
+            XCTAssertNil(error)
+            
+            XCTAssert((block?.transactions.count ?? 0) > 0);
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: timeout)
+    }
+    
+    func testGivenExistingBlock_getsBlockByNumber() {
+        let expectation = XCTestExpectation(description: "get block by number")
+        
+        client?.eth_getBlockByNumber(.Number(3415757)) { error, block in
+            XCTAssertNil(error)
+            
+            XCTAssertEqual(block?.timestamp, 1528711895)
+            XCTAssertEqual(block?.transactions.count, 40)
+            XCTAssertEqual(block?.transactions.first, "0x387867d052b3f89fb87937572891118aa704c1ba604c157bbd9c5a07f3a7e5cd")
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: timeout)
+    }
+    
+    func testGivenUnexistingBlockNumber_getBlockByNumberReturnsError() {
+        let expectation = XCTestExpectation(description: "get block by number")
+        
+        client?.eth_getBlockByNumber(.Number(Int.max)) { error, block in
+            XCTAssertNotNil(error)
+            XCTAssertNil(block)
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: timeout)
+    }
 }

--- a/web3sTests/Client/EthereumClientTests.swift
+++ b/web3sTests/Client/EthereumClientTests.swift
@@ -165,6 +165,7 @@ class EthereumClientTests: XCTestCase {
             
             XCTAssertEqual(block?.timestamp.timeIntervalSince1970, 0)
             XCTAssertEqual(block?.transactions.count, 0)
+            XCTAssertEqual(block?.number, .Number(0))
             expectation.fulfill()
         }
         
@@ -190,6 +191,7 @@ class EthereumClientTests: XCTestCase {
         client?.eth_getBlockByNumber(.Number(3415757)) { error, block in
             XCTAssertNil(error)
             
+            XCTAssertEqual(block?.number, .Number(3415757))
             XCTAssertEqual(block?.timestamp.timeIntervalSince1970, 1528711895)
             XCTAssertEqual(block?.transactions.count, 40)
             XCTAssertEqual(block?.transactions.first, "0x387867d052b3f89fb87937572891118aa704c1ba604c157bbd9c5a07f3a7e5cd")

--- a/web3swift.xcodeproj/project.pbxproj
+++ b/web3swift.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		3CF37CEB20372CA10030520E /* KeyDerivationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF37CEA20372CA10030520E /* KeyDerivationTests.swift */; };
 		3CF37CF520373E320030520E /* Data+RandomTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF37CF420373E320030520E /* Data+RandomTests.swift */; };
 		3CF37CF7203744400030520E /* KeystoreUtilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF37CF6203744400030520E /* KeystoreUtilTests.swift */; };
+		473E682F20CE7F80006D11AF /* EthereumBlockInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 473E682E20CE7F80006D11AF /* EthereumBlockInfo.swift */; };
 		6C4ABDDAA3313A1B32EAB620 /* Pods_web3swiftTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E4FAB97C27DB6CBB355E0F1 /* Pods_web3swiftTests.framework */; };
 		9164E8EEDA7FB33A6638D561 /* Pods_web3swift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BD54E6F686FEE6C1126AB6A0 /* Pods_web3swift.framework */; };
 		C91A7E80205C1F120074D3B4 /* ABIEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C91A7E7F205C1F120074D3B4 /* ABIEncoder.swift */; };
@@ -190,6 +191,7 @@
 		3CF37CF420373E320030520E /* Data+RandomTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+RandomTests.swift"; sourceTree = "<group>"; };
 		3CF37CF6203744400030520E /* KeystoreUtilTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeystoreUtilTests.swift; sourceTree = "<group>"; };
 		45FF08D408285DBA7FF4564A /* Pods-web3sTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-web3sTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-web3sTests/Pods-web3sTests.release.xcconfig"; sourceTree = "<group>"; };
+		473E682E20CE7F80006D11AF /* EthereumBlockInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EthereumBlockInfo.swift; sourceTree = "<group>"; };
 		52B3D38DF87EAFCBBD99CCF1 /* Pods-web3swiftTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-web3swiftTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-web3swiftTests/Pods-web3swiftTests.debug.xcconfig"; sourceTree = "<group>"; };
 		595F7375549A81C8950C1F8E /* Pods-web3s.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-web3s.release.xcconfig"; path = "Pods/Target Support Files/Pods-web3s/Pods-web3s.release.xcconfig"; sourceTree = "<group>"; };
 		5E4FAB97C27DB6CBB355E0F1 /* Pods_web3swiftTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_web3swiftTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -539,6 +541,7 @@
 				C9236B842052CBFC00CE5557 /* EthereumNetwork.swift */,
 				C9236B7F2052C68D00CE5557 /* EthereumLog.swift */,
 				C9236B812052C69B00CE5557 /* EthereumTransactionReceipt.swift */,
+				473E682E20CE7F80006D11AF /* EthereumBlockInfo.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -929,6 +932,7 @@
 				C9236B8D2052E51100CE5557 /* EthereumAccount+SignTransaction.swift in Sources */,
 				3CF37C5F20343BA60030520E /* keccak-tiny.c in Sources */,
 				C967AAA92080BF7900A24D15 /* ERC20Responses.swift in Sources */,
+				473E682F20CE7F80006D11AF /* EthereumBlockInfo.swift in Sources */,
 				C94C2BD02090C70D00F024EE /* ERC20Events.swift in Sources */,
 				C91A7E84205C1F260074D3B4 /* ABIRawType.swift in Sources */,
 				3C8D94FE20402D8400D0D5D7 /* EthereumTransaction.swift in Sources */,

--- a/web3swift/src/Client/Models/EthereumBlockInfo.swift
+++ b/web3swift/src/Client/Models/EthereumBlockInfo.swift
@@ -1,0 +1,45 @@
+//
+//  EthereumBlockData.swift
+//  web3swift
+//
+//  Created by Miguel on 11/06/2018.
+//  Copyright © 2018 Argent Labs Limited. All rights reserved.
+//
+
+import Foundation
+
+public struct EthereumBlockInfo {
+    public var number: Int
+    public var timestamp: TimeInterval
+    public var transactions: [String]
+}
+
+extension EthereumBlockInfo: Decodable {
+    enum CodingKeys: CodingKey {
+        case number
+        case timestamp
+        case transactions
+    }
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        guard let numberRaw = try? container.decode(String.self, forKey: .number),
+            let number = Int(hex: numberRaw) else {
+            throw JSONRPCError.decodingError
+        }
+        
+        guard let timestampRaw = try? container.decode(String.self, forKey: .timestamp),
+            let timestamp = TimeInterval(timestampRaw) else {
+                throw JSONRPCError.decodingError
+        }
+        
+        guard let transactions = try? container.decode([String].self, forKey: .transactions) else {
+            throw JSONRPCError.decodingError
+        }
+        
+        self.number = number
+        self.timestamp = timestamp
+        self.transactions = transactions
+    }
+}
+

--- a/web3swift/src/Client/Models/EthereumBlockInfo.swift
+++ b/web3swift/src/Client/Models/EthereumBlockInfo.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public struct EthereumBlockInfo {
-    public var number: Int
+    public var number: EthereumBlock
     public var timestamp: Date
     public var transactions: [String]
 }
@@ -23,8 +23,7 @@ extension EthereumBlockInfo: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         
-        guard let numberRaw = try? container.decode(String.self, forKey: .number),
-            let number = Int(hex: numberRaw) else {
+        guard let number = try? container.decode(EthereumBlock.self, forKey: .number) else {
             throw JSONRPCError.decodingError
         }
         

--- a/web3swift/src/Client/Models/EthereumBlockInfo.swift
+++ b/web3swift/src/Client/Models/EthereumBlockInfo.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public struct EthereumBlockInfo {
     public var number: Int
-    public var timestamp: TimeInterval
+    public var timestamp: Date
     public var transactions: [String]
 }
 
@@ -38,7 +38,7 @@ extension EthereumBlockInfo: Decodable {
         }
         
         self.number = number
-        self.timestamp = timestamp
+        self.timestamp = Date(timeIntervalSince1970: timestamp)
         self.transactions = transactions
     }
 }


### PR DESCRIPTION
We add simple support for `getBlockByNumber`:

- Always returning transaction hashes
- Only exposing in the block info this data: the number, transaction hashes, timestamp