### PR TITLE
[UPDATE] BigInt library

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    atomos (0.1.2)
+    atomos (0.1.3)
     claide (1.0.2)
     cocoapods (1.5.3)
       activesupport (>= 4.0.2, < 5)
@@ -33,12 +33,12 @@ GEM
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
     cocoapods-deintegrate (1.0.2)
-    cocoapods-downloader (1.2.1)
+    cocoapods-downloader (1.2.2)
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-search (1.0.0)
     cocoapods-stats (1.0.0)
-    cocoapods-trunk (1.3.0)
+    cocoapods-trunk (1.3.1)
       nap (>= 0.8, < 2.0)
       netrc (~> 0.11)
     cocoapods-try (1.1.0)
@@ -51,20 +51,20 @@ GEM
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     minitest (5.11.3)
-    molinillo (0.6.5)
-    nanaimo (0.2.5)
+    molinillo (0.6.6)
+    nanaimo (0.2.6)
     nap (1.1.0)
     netrc (0.11.0)
-    ruby-macho (1.2.0)
+    ruby-macho (1.3.1)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    xcodeproj (1.5.9)
+    xcodeproj (1.7.0)
       CFPropertyList (>= 2.3.3, < 4.0)
-      atomos (~> 0.1.2)
+      atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
-      nanaimo (~> 0.2.5)
+      nanaimo (~> 0.2.6)
 
 PLATFORMS
   ruby
@@ -73,4 +73,4 @@ DEPENDENCIES
   cocoapods
 
 BUNDLED WITH
-   1.16.1
+   1.16.6

--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,5 @@
 def all_pods
-  pod 'BigInt', '~> 3.0.1'
+  pod 'BigInt', '3.1.0'
 end
 
 target 'web3swift' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
-  - BigInt (3.0.1):
+  - BigInt (3.1.0):
     - SipHash (~> 1.2)
-  - SipHash (1.2.0)
+  - SipHash (1.2.2)
 
 DEPENDENCIES:
-  - BigInt (~> 3.0.1)
+  - BigInt (= 3.1.0)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -12,9 +12,9 @@ SPEC REPOS:
     - SipHash
 
 SPEC CHECKSUMS:
-  BigInt: 8e8a52161c745cd3ab78e3dc346a9fbee51e6cf6
-  SipHash: c6e9e43e9c531b5bc6602545130c26194a6d31ce
+  BigInt: 76b5dfdfa3e2e478d4ffdf161aeede5502e2742f
+  SipHash: fad90a4683e420c52ef28063063dbbce248ea6d4
 
-PODFILE CHECKSUM: 67f19944c0b15799d71ad44aab63ca30fcbd5189
+PODFILE CHECKSUM: 7d6817b2b66ca961a4ac6f21b073018916aa7067
 
-COCOAPODS: 1.5.2
+COCOAPODS: 1.5.3


### PR DESCRIPTION
Changelog:

3.1.0

    Swift 4.1 compatibility for Linux and macOS
    Fix warnings for Swift 4.1

There were no functional changes.

3.0.2

    Fixed product definitions in Package.swift not to create a duplicate library. (Issue #37)

There were no functional changes.