### PR TITLE
Change: Extensions namespacing

### DIFF
--- a/web3sTests/ERC20/ERC20Tests.swift
+++ b/web3sTests/ERC20/ERC20Tests.swift
@@ -35,11 +35,21 @@ class ERC20Tests: XCTestCase {
         waitForExpectations(timeout: 10)
     }
     
-    func testDecimals() {
+    func testNonZeroDecimals() {
         let expect = expectation(description: "Get token decimals")
         erc20?.decimals(tokenContract: self.testContractAddress, completion: { (error, decimals) in
             XCTAssertNil(error)
             XCTAssertEqual(decimals, BigUInt(18))
+            expect.fulfill()
+        })
+        waitForExpectations(timeout: 10)
+    }
+    
+    func testZeroDecimals() {
+        let expect = expectation(description: "Get token decimals (0)")
+        erc20?.decimals(tokenContract: EthereumAddress("0x40dd3ac2481960cf34d96e647dd0bc52a1f03f52"), completion: { (error, decimals) in
+            XCTAssertNil(error)
+            XCTAssertEqual(decimals, BigUInt(0))
             expect.fulfill()
         })
         waitForExpectations(timeout: 10)

--- a/web3sTests/Extensions/KeccakExtensionsTests.swift
+++ b/web3sTests/Extensions/KeccakExtensionsTests.swift
@@ -21,7 +21,7 @@ class KeccakExtensionsTests: XCTestCase {
     
     func testKeccak256Hash() {
         let string = "hello world"
-        let hash = string.keccak256
+        let hash = string.web3.keccak256
         let hexStringHash = hash.hexString
         XCTAssertEqual(hexStringHash, "0x47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad")
     }
@@ -30,14 +30,14 @@ class KeccakExtensionsTests: XCTestCase {
     func testDataKeccak256HashHex() {
         let string = "0x68656c6c6f20776f726c64"
         let data = Data(hex: string)!
-        let keccak = data.keccak256
+        let keccak = data.web3.keccak256
         XCTAssertEqual(keccak.hexString, "0x47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad")
     }
     
     func testDataKeccak256HashStr() {
         let string = "hello world"
         let data = string.data(using: .utf8)!
-        let keccak = data.keccak256
+        let keccak = data.web3.keccak256
         XCTAssertEqual(keccak.hexString, "0x47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad")
     }
     

--- a/web3sTests/Extensions/String+NumericTests.swift
+++ b/web3sTests/Extensions/String+NumericTests.swift
@@ -20,16 +20,16 @@ class String_NumericTests: XCTestCase {
     }
     
     func testStringNumeric() {
-        XCTAssertTrue("493043".isNumeric)
-        XCTAssertTrue("12".isNumeric)
-        XCTAssertTrue("0".isNumeric)
-        XCTAssertTrue("98420342842".isNumeric)
-        XCTAssertTrue("493204385594385034583409583490583".isNumeric)
+        XCTAssertTrue("493043".web3.isNumeric)
+        XCTAssertTrue("12".web3.isNumeric)
+        XCTAssertTrue("0".web3.isNumeric)
+        XCTAssertTrue("98420342842".web3.isNumeric)
+        XCTAssertTrue("493204385594385034583409583490583".web3.isNumeric)
         
-        XCTAssertFalse("0x00".isNumeric)
-        XCTAssertFalse("hello world".isNumeric)
-        XCTAssertFalse("!9043".isNumeric)
-        XCTAssertFalse("#42044".isNumeric)
+        XCTAssertFalse("0x00".web3.isNumeric)
+        XCTAssertFalse("hello world".web3.isNumeric)
+        XCTAssertFalse("!9043".web3.isNumeric)
+        XCTAssertFalse("#42044".web3.isNumeric)
     }
     
 }

--- a/web3swift.xcodeproj/project.pbxproj
+++ b/web3swift.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		3CF37CF7203744400030520E /* KeystoreUtilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF37CF6203744400030520E /* KeystoreUtilTests.swift */; };
 		473D9B8A20F629C500FD04BB /* TransactionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 473D9B8820F6297D00FD04BB /* TransactionTests.swift */; };
 		473E682F20CE7F80006D11AF /* EthereumBlockInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 473E682E20CE7F80006D11AF /* EthereumBlockInfo.swift */; };
+		475E53E92344A4110071BF8B /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 475E53E82344A4110071BF8B /* Extensions.swift */; };
 		47ADCD9221AE9CA3006DE71F /* ABIFunctionEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47ADCD9021AE9B8E006DE71F /* ABIFunctionEncoderTests.swift */; };
 		47F2EA9B2284896A007063C2 /* ERC721Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47F2EA992284894A007063C2 /* ERC721Tests.swift */; };
 		47F2EAA622848B5D007063C2 /* ERC721.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47F2EAA522848B5D007063C2 /* ERC721.swift */; };
@@ -200,6 +201,7 @@
 		45FF08D408285DBA7FF4564A /* Pods-web3sTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-web3sTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-web3sTests/Pods-web3sTests.release.xcconfig"; sourceTree = "<group>"; };
 		473D9B8820F6297D00FD04BB /* TransactionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionTests.swift; sourceTree = "<group>"; };
 		473E682E20CE7F80006D11AF /* EthereumBlockInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EthereumBlockInfo.swift; sourceTree = "<group>"; };
+		475E53E82344A4110071BF8B /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		47ADCD9021AE9B8E006DE71F /* ABIFunctionEncoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABIFunctionEncoderTests.swift; sourceTree = "<group>"; };
 		47F2EA992284894A007063C2 /* ERC721Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ERC721Tests.swift; sourceTree = "<group>"; };
 		47F2EAA522848B5D007063C2 /* ERC721.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ERC721.swift; sourceTree = "<group>"; };
@@ -669,6 +671,7 @@
 				C9A78E66205878AE00CF8316 /* KeccakExtensions.swift */,
 				C9A78E68205878B900CF8316 /* Data+Random.swift */,
 				C9A78E58205851D700CF8316 /* String+Numeric.swift */,
+				475E53E82344A4110071BF8B /* Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -954,6 +957,7 @@
 				C927FD57204EAD6E005922DC /* EthereumKeyStorage.swift in Sources */,
 				C9D43D25207CED1D00685FB6 /* ABIDecoder+Static.swift in Sources */,
 				C9A78E5F2058735500CF8316 /* EthereumJSONContract.swift in Sources */,
+				475E53E92344A4110071BF8B /* Extensions.swift in Sources */,
 				C9F836C1207B932E004F45A9 /* ABIFunction.swift in Sources */,
 				C91A7E82205C1F1B0074D3B4 /* ABIDecoder.swift in Sources */,
 				3CF37CC22036CF6C0030520E /* KeystoreUtil.swift in Sources */,

--- a/web3swift/src/Client/Models/EthereumTransaction.swift
+++ b/web3swift/src/Client/Models/EthereumTransaction.swift
@@ -31,7 +31,7 @@ public struct EthereumTransaction: EthereumTransactionProtocol, Codable {
     public private(set) var hash: Data?
     var chainId: Int? {
         didSet {
-            self.hash = self.raw?.keccak256
+            self.hash = self.raw?.web3.keccak256
         }
     }
     
@@ -152,6 +152,6 @@ struct SignedTransaction {
     }
     
     var hash: Data? {
-        return raw?.keccak256
+        return raw?.web3.keccak256
     }
 }

--- a/web3swift/src/Contract/ABIEncoder.swift
+++ b/web3swift/src/Contract/ABIEncoder.swift
@@ -19,7 +19,7 @@ public class ABIEncoder {
         
         switch type {
         case .FixedUInt(_):
-            guard value.isNumeric, let int = BigInt(value) else {
+            guard value.web3.isNumeric, let int = BigInt(value) else {
                 throw ABIError.invalidType
             }
             let bytes = int.bytes // should be <= 32 bytes
@@ -123,7 +123,7 @@ public class ABIEncoder {
         let typeNames = types.map { $0.rawValue }
         let signature = name + "(" + typeNames.joined(separator: ",") + ")"
         guard let data = signature.data(using: .utf8) else { throw ABIError.invalidSignature }
-        return data.keccak256.bytes
+        return data.web3.keccak256.bytes
     }
 }
 

--- a/web3swift/src/ENS/EthereumNameService.swift
+++ b/web3swift/src/ENS/EthereumNameService.swift
@@ -118,8 +118,8 @@ public class EthereumNameService: EthereumNameServiceProtocol {
         var node = Data.init(count: 32)
         let labels = name.components(separatedBy: ".")
         for label in labels.reversed() {
-            node.append(label.keccak256)
-            node = node.keccak256
+            node.append(label.web3.keccak256)
+            node = node.web3.keccak256
         }
         return node.hexString
     }

--- a/web3swift/src/ERC165/ERC165.swift
+++ b/web3swift/src/ERC165/ERC165.swift
@@ -29,7 +29,7 @@ public class ERC165 {
 
 public enum ERC165Functions {
     public static var interfaceId: Data {
-        return "supportsInterface(bytes4)".keccak256.bytes4
+        return "supportsInterface(bytes4)".web3.keccak256.bytes4
     }
     
     struct supportsInterface: ABIFunction {

--- a/web3swift/src/ERC721/ERC721Functions.swift
+++ b/web3swift/src/ERC721/ERC721Functions.swift
@@ -43,9 +43,9 @@ public enum ERC721Functions {
 
 public enum ERC721MetadataFunctions {
     public static var interfaceId: Data {
-        return "name()".keccak256.bytes4 ^
-            "symbol()".keccak256.bytes4 ^
-            "tokenURI(uint256)".keccak256.bytes4
+        return "name()".web3.keccak256.bytes4 ^
+            "symbol()".web3.keccak256.bytes4 ^
+            "tokenURI(uint256)".web3.keccak256.bytes4
     }
     
     struct name: ABIFunction {
@@ -85,9 +85,9 @@ public enum ERC721MetadataFunctions {
 
 public enum ERC721EnumerableFunctions {
     public static var interfaceId: Data {
-        return "totalSupply()".keccak256.bytes4 ^
-            "tokenByIndex(uint256)".keccak256.bytes4 ^
-            "tokenOfOwnerByIndex(address,uint256)".keccak256.bytes4
+        return "totalSupply()".web3.keccak256.bytes4 ^
+            "tokenByIndex(uint256)".web3.keccak256.bytes4 ^
+            "tokenOfOwnerByIndex(address,uint256)".web3.keccak256.bytes4
     }
 
     struct totalSupply: ABIFunction {

--- a/web3swift/src/Extensions/Extensions.swift
+++ b/web3swift/src/Extensions/Extensions.swift
@@ -1,0 +1,30 @@
+//
+//  Extensions.swift
+//  web3swift
+//
+//  Created by Miguel on 02/10/2019.
+//  Copyright © 2019 Argent Labs Limited. All rights reserved.
+//
+
+import Foundation
+
+public protocol Web3Extendable {
+    associatedtype T
+    var web3: T { get }
+}
+
+public extension Web3Extendable {
+    var web3: Web3Extensions<Self> {
+        return Web3Extensions(self)
+    }
+}
+
+public struct Web3Extensions<Base> {
+    let base: Base
+    init(_ base: Base) {
+        self.base = base
+    }
+}
+
+extension Data: Web3Extendable {}
+extension String: Web3Extendable {}

--- a/web3swift/src/Extensions/KeccakExtensions.swift
+++ b/web3swift/src/Extensions/KeccakExtensions.swift
@@ -9,24 +9,24 @@
 import Foundation
 import keccaktiny
 
-public extension Data {
+public extension Web3Extensions where Base == Data {
     var keccak256: Data {
-        let nsData = self as NSData
-        let input = nsData.bytes.bindMemory(to: UInt8.self, capacity: self.count)
+        let nsData = self.base as NSData
+        let input = nsData.bytes.bindMemory(to: UInt8.self, capacity: self.base.count)
         let result = UnsafeMutablePointer<UInt8>.allocate(capacity: 32)
-        keccak_256(result, 32, input, self.count)
+        keccak_256(result, 32, input, self.base.count)
         return Data(bytes: result, count: 32)
     }
 }
 
-public extension String {
+public extension Web3Extensions where Base == String {
     var keccak256: Data {
-        let data = self.data(using: .utf8) ?? Data()
-        return data.keccak256
+        let data = self.base.data(using: .utf8) ?? Data()
+        return data.web3.keccak256
     }
     
     var keccak256fromHex: Data {
-        let data = self.hexData!
-        return data.keccak256
+        let data = self.base.hexData!
+        return data.web3.keccak256
     }
 }

--- a/web3swift/src/Extensions/String+Numeric.swift
+++ b/web3swift/src/Extensions/String+Numeric.swift
@@ -8,8 +8,8 @@
 
 import Foundation
 
-extension String {
+extension Web3Extensions where Base == String {
     var isNumeric: Bool {
-        return !self.isEmpty && self.rangeOfCharacter(from: CharacterSet.decimalDigits.inverted) == nil
+        return !self.base.isEmpty && self.base.rangeOfCharacter(from: CharacterSet.decimalDigits.inverted) == nil
     }
 }

--- a/web3swift/src/Utils/KeyUtil.swift
+++ b/web3swift/src/Utils/KeyUtil.swift
@@ -50,7 +50,7 @@ class KeyUtil {
     }
     
     static func generateAddress(from publicKey: Data) -> String {
-        let hash = publicKey.keccak256
+        let hash = publicKey.web3.keccak256
         let address = hash.subdata(in: 12..<hash.count)
         return address.hexString
     }
@@ -61,7 +61,7 @@ class KeyUtil {
             throw KeyUtilError.invalidContext
         }
 
-        let msg = ((hashing ? message.keccak256 : message) as NSData).bytes.assumingMemoryBound(to: UInt8.self)
+        let msg = ((hashing ? message.web3.keccak256 : message) as NSData).bytes.assumingMemoryBound(to: UInt8.self)
         let privateKeyPtr = (privateKey as NSData).bytes.assumingMemoryBound(to: UInt8.self)
         let signaturePtr = UnsafeMutablePointer<secp256k1_ecdsa_recoverable_signature>.allocate(capacity: 1)
         guard secp256k1_ecdsa_sign_recoverable(ctx, signaturePtr, msg, privateKeyPtr, nil, nil) == 1 else {

--- a/web3swift/src/Utils/KeystoreUtil.swift
+++ b/web3swift/src/Utils/KeystoreUtil.swift
@@ -56,7 +56,7 @@ class KeystoreUtil: KeystoreUtilProtocol {
         // compute mac
         let macKey = derivedKey.subdata(in: 16..<32)
         let concat = macKey + ciphertext
-        let mac = concat.keccak256
+        let mac = concat.web3.keccak256
         
         // create keystore
         let crypto = KeystoreFileCrypto(
@@ -101,7 +101,7 @@ class KeystoreUtil: KeystoreUtilProtocol {
         // verify mac
         let macKey = derivedKey.subdata(in: 16..<32)
         let concat = macKey + ciphertext
-        let mac = concat.keccak256
+        let mac = concat.web3.keccak256
         guard mac.hexString.noHexPrefix == keystore.crypto.mac else {
             throw KeystoreUtilError.corruptedKeystore
         }


### PR DESCRIPTION
Given extensions can conflict with other libraries, and technically, ObjC object extensions should be prefixed with module name.

Here taken approach of removing extension from ObjC Foundation object, and instead using Swift mechanism to namespace.