### PR TITLE
Handle responses as per old geth version

### DIFF
--- a/web3sTests/Client/EthereumClientTests.swift
+++ b/web3sTests/Client/EthereumClientTests.swift
@@ -378,7 +378,7 @@ class EthereumClientTests: XCTestCase {
     
     func test_GivenValidTransaction_ThenEstimatesGas() {
         let expect = expectation(description: "estimateOK")
-        let function = TransferToken(wallet: EthereumAddress("0xd5b919520259e1174274420E3291ab77215C3D13"),
+        let function = TransferToken(wallet: EthereumAddress("0xD18dE36e6FB4a5A069f673723Fab71cc00C6CE5F"),
                                      token: EthereumAddress("0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
                                      to: EthereumAddress("0x2A6295C34b4136F2C3c1445c6A0338D784fe0ddd"),
                                      amount: 1,

--- a/web3sTests/Client/EthereumClientTests.swift
+++ b/web3sTests/Client/EthereumClientTests.swift
@@ -34,12 +34,14 @@ struct TransferMatchingSignatureEvent: ABIEvent {
 
 class EthereumClientTests: XCTestCase {
     var client: EthereumClient?
+    var mainnetClient: EthereumClient?
     var account: EthereumAccount?
     let timeout = 10.0
     
     override func setUp() {
         super.setUp()
         self.client = EthereumClient(url: URL(string: TestConfig.clientUrl)!)
+        self.mainnetClient = EthereumClient(url: URL(string: TestConfig.mainnetClientUrl)!)
         self.account = try? EthereumAccount(keyStorage: TestEthereumKeyStorage(privateKey: TestConfig.privateKey))
         print("Public address: \(self.account?.address ?? "NONE")")
     }
@@ -376,6 +378,28 @@ class EthereumClientTests: XCTestCase {
         waitForExpectations(timeout: 10)
     }
     
+    // This is how geth used to work up until a recent version
+    // see https://github.com/ethereum/go-ethereum/pull/21083/
+    // Used to return '0x' in response, and would fail decoding
+    // We'll continue to support this as user of library (and Argent in our case)
+    // works with this assumption.
+    // NOTE: This behaviour will be removed at a later time to fail as expected
+    // NOTE: At the time of writing, this test succeeds as-is in ropsten as nodes behaviour is different. That's why we use a mainnet check here
+    func test_GivenUnimplementedMethod_WhenCallingContract_ThenFailsWith0x() {
+        let expect = expectation(description: "graceful_failure")
+        
+        let function = InvalidMethod(param: .zero)
+        
+        function.call(withClient: self.mainnetClient!,
+                      responseType: InvalidMethod.BoolResponse.self) { (error, response) in
+                        XCTAssertEqual(error, .decodeIssue)
+                        XCTAssertNil(response)
+                        expect.fulfill()
+        }
+        
+        waitForExpectations(timeout: 10)
+    }
+    
     func test_GivenValidTransaction_ThenEstimatesGas() {
         let expect = expectation(description: "estimateOK")
         let function = TransferToken(wallet: EthereumAddress("0xD18dE36e6FB4a5A069f673723Fab71cc00C6CE5F"),
@@ -443,3 +467,24 @@ struct TransferToken: ABIFunction {
     }
 }
 
+struct InvalidMethod: ABIFunction {
+    static let name = "invalidMethodCallBoolResponse"
+    let contract = EthereumAddress("0xed0439eacf4c4965ae4613d77a5c2efe10e5f183")
+    let from: EthereumAddress? = EthereumAddress("0xed0439eacf4c4965ae4613d77a5c2efe10e5f183")
+    let gasPrice: BigUInt? = nil
+    let gasLimit: BigUInt? = nil
+    
+    let param: EthereumAddress
+    
+    struct BoolResponse: ABIResponse {
+        static var types: [ABIType.Type] = [Bool.self]
+        let value: Bool
+
+        init?(values: [ABIDecoder.DecodedValue]) throws {
+            self.value = try values[0].decoded()
+        }
+    }
+
+    func encode(to encoder: ABIFunctionEncoder) throws {
+    }
+}

--- a/web3sTests/TestConfig.swift
+++ b/web3sTests/TestConfig.swift
@@ -12,6 +12,9 @@ struct TestConfig {
     // This is the proxy URL for connecting to the Blockchain. For testing we usually use the Ropsten network on Infura. Using free tier, so might hit rate limits
     static let clientUrl = "https://ropsten.infura.io/v3/b2f4b3f635d8425c96854c3d28ba6bb0"
     
+    // Same for mainnet
+    static let mainnetClientUrl = "https://mainnet.infura.io/v3/b2f4b3f635d8425c96854c3d28ba6bb0"
+    
     // An EOA with some Ether, so that we can test sending transactions (pay for gas)
     static let privateKey = "0xef4e182ae2cf32192d2a62c1159c8c4f7f2d658c303d0dfca5791a205456a132"
     

--- a/web3swift/src/Client/EthereumClient.swift
+++ b/web3swift/src/Client/EthereumClient.swift
@@ -325,7 +325,12 @@ public class EthereumClient: EthereumClientProtocol {
         let params = CallParams(from: transaction.from?.value, to: transaction.to.value, data: transactionData.web3.hexString, block: block.stringValue)
         EthereumRPC.execute(session: session, url: url, method: "eth_call", params: params, receive: String.self) { (error, response) in
             if let resDataString = response as? String {
-                completion(nil, resDataString)
+                completion(nil, resDataString) 
+            } else if
+                let error = error,
+                case let JSONRPCError.executionError(result) = error,
+                result.error.code == JSONRPCErrorCode.executionReverted {
+                completion(nil, "0x")
             } else {
                 completion(EthereumClientError.unexpectedReturnValue, nil)
             }

--- a/web3swift/src/Client/JSONRPC.swift
+++ b/web3swift/src/Client/JSONRPC.swift
@@ -34,6 +34,7 @@ struct JSONRPCErrorResult: Decodable {
 
 enum JSONRPCErrorCode {
     static var tooManyResults = -32005
+    static var executionReverted = -32000
 }
 
 enum JSONRPCError: Error {


### PR DESCRIPTION
Temporary change to allow clients of the library to adapt later if '0x' was returned.
We'll add later a proper error enum to notify caller that execution reverted instead.