### PR TITLE
[FIX] Return all logs from the starting block to the end block by doing recursive queries when needed

### DIFF
--- a/web3swift.xcodeproj/project.pbxproj
+++ b/web3swift.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		47F2EAAF22848BB2007063C2 /* ERC721Responses.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47F2EAAE22848BB2007063C2 /* ERC721Responses.swift */; };
 		47F2EAB32285BBDF007063C2 /* ERC165Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47F2EAB12285BAB6007063C2 /* ERC165Tests.swift */; };
 		63002262255192D900C97B80 /* ENSMultiResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63002261255192D900C97B80 /* ENSMultiResolver.swift */; };
+		6327068225A48A8A0061388C /* RecursiveLogCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6327068125A48A8A0061388C /* RecursiveLogCollector.swift */; };
 		63C41E6D254C4CFF0055ED7F /* ENSResponses.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63C41E6C254C4CFF0055ED7F /* ENSResponses.swift */; };
 		63DAC6252549D8700059FF9C /* MulticallContract.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DAC6242549D8700059FF9C /* MulticallContract.swift */; };
 		63DAC6292549D9CE0059FF9C /* Multicall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DAC6282549D9CE0059FF9C /* Multicall.swift */; };
@@ -161,6 +162,7 @@
 		595F7375549A81C8950C1F8E /* Pods-web3s.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-web3s.release.xcconfig"; path = "Pods/Target Support Files/Pods-web3s/Pods-web3s.release.xcconfig"; sourceTree = "<group>"; };
 		5E4FAB97C27DB6CBB355E0F1 /* Pods_web3swiftTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_web3swiftTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		63002261255192D900C97B80 /* ENSMultiResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ENSMultiResolver.swift; sourceTree = "<group>"; };
+		6327068125A48A8A0061388C /* RecursiveLogCollector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecursiveLogCollector.swift; sourceTree = "<group>"; };
 		63C41E6C254C4CFF0055ED7F /* ENSResponses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ENSResponses.swift; sourceTree = "<group>"; };
 		63DAC6242549D8700059FF9C /* MulticallContract.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MulticallContract.swift; sourceTree = "<group>"; };
 		63DAC6282549D9CE0059FF9C /* Multicall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Multicall.swift; sourceTree = "<group>"; };
@@ -390,6 +392,7 @@
 			children = (
 				C9236B832052C6AC00CE5557 /* Models */,
 				3CF37CBF2035ABE90030520E /* EthereumClient.swift */,
+				6327068125A48A8A0061388C /* RecursiveLogCollector.swift */,
 				C927FD58204EB1F4005922DC /* JSONRPC.swift */,
 			);
 			path = Client;
@@ -818,6 +821,7 @@
 				C9F836B52078049E004F45A9 /* EthereumAddress.swift in Sources */,
 				C9236B802052C68D00CE5557 /* EthereumLog.swift in Sources */,
 				47F2EAAB22848B9C007063C2 /* ERC721Functions.swift in Sources */,
+				6327068225A48A8A0061388C /* RecursiveLogCollector.swift in Sources */,
 				63DAC6252549D8700059FF9C /* MulticallContract.swift in Sources */,
 				C9236B8B2052E12200CE5557 /* HexExtensions.swift in Sources */,
 				C927FD62204EF4E1005922DC /* EthereumNameService.swift in Sources */,

--- a/web3swift/src/Client/RecursiveLogCollector.swift
+++ b/web3swift/src/Client/RecursiveLogCollector.swift
@@ -1,0 +1,122 @@
+//
+//  RecursiveLogCollector.swift
+//  web3swift
+//
+//  Created by David Rodrigues on 05/01/2021.
+//  Copyright © 2021 Argent Labs Limited. All rights reserved.
+//
+
+import Foundation
+
+enum Topics: Encodable {
+    case plain([String?])
+    case composed([[String]?])
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        switch self {
+        case .plain(let values):
+            try container.encode(contentsOf: values)
+        case .composed(let values):
+            try container.encode(contentsOf: values)
+        }
+    }
+}
+
+struct RecursiveLogCollector {
+    let ethClient: EthereumClient
+
+    func getAllLogs(
+        addresses: [String]?,
+        topics: Topics?,
+        from: EthereumBlock,
+        to: EthereumBlock
+    ) -> Result<[EthereumLog], EthereumClientError> {
+
+        switch getLogs(addresses: addresses, topics: topics, from: from, to: to) {
+        case .success(let logs):
+            return .success(logs)
+        case.failure(.tooManyResults):
+            guard let middleBlock = getMiddleBlock(from: from, to: to)
+                else { return .failure(.unexpectedReturnValue) }
+
+            guard
+                case let .success(lhs) = getAllLogs(
+                    addresses: addresses,
+                    topics: topics,
+                    from: from,
+                    to: middleBlock
+                ),
+                case let .success(rhs) = getAllLogs(
+                    addresses: addresses,
+                    topics: topics,
+                    from: middleBlock,
+                    to: to
+                )
+            else { return .failure(.unexpectedReturnValue) }
+
+            return .success(lhs + rhs)
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+
+    private func getLogs(
+        addresses: [String]?,
+        topics: Topics? = nil,
+        from: EthereumBlock,
+        to: EthereumBlock
+    ) -> Result<[EthereumLog], EthereumClientError> {
+
+        let sem = DispatchSemaphore(value: 0)
+
+        var response: Result<[EthereumLog], EthereumClientError>!
+
+        ethClient.getLogs(addresses: addresses, topics: topics, fromBlock: from, toBlock: to) { result in
+            response = result
+            sem.signal()
+        }
+
+        sem.wait()
+
+        return response
+    }
+
+    private func getMiddleBlock(
+        from: EthereumBlock,
+        to: EthereumBlock
+    ) -> EthereumBlock? {
+
+        func toBlockNumber() -> Int? {
+            if let toBlockNumber = to.intValue {
+                return toBlockNumber
+            } else if case let .success(currentBlock) = getCurrentBlock(), let currentBlockNumber = currentBlock.intValue {
+                return currentBlockNumber
+            } else {
+                return nil
+            }
+        }
+
+        guard
+            let fromBlockNumber = from.intValue,
+            let toBlockNumber = toBlockNumber()
+        else { return nil }
+
+        return EthereumBlock(rawValue: fromBlockNumber + (toBlockNumber - fromBlockNumber) / 2)
+    }
+
+    private func getCurrentBlock() -> Result<EthereumBlock, EthereumClientError> {
+        let sem = DispatchSemaphore(value: 0)
+        var responseValue: EthereumBlock?
+
+        self.ethClient.eth_blockNumber { (error, blockInt) in
+            if let blockInt = blockInt {
+                responseValue = EthereumBlock(rawValue: blockInt)
+            }
+            sem.signal()
+        }
+        sem.wait()
+
+        return responseValue.map(Result.success) ?? .failure(.unexpectedReturnValue)
+    }
+}


### PR DESCRIPTION
Infura doesn't support return more than 10k results per query which can be an issue while getting logs as some of the functions, e.g. ERC20's `transferEventsTo`, have the assumption they can get all the logs from the starting block to the end block in a single call. 

To simplify the consumption of the API without breaking its ergonomics there's a new log collector entity underneath that will split the query in multiple as required to aggregate all the logs between the two blocks provided and return them in a single pass to consumers.

This can be reformed in the next major version by making some breaking changes in the public API.