### PR TITLE
Add support for custom uint/int types, instead of assuming always 256

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,5 @@
 def all_pods
-  pod 'BigInt', '5.0.0'
+  pod 'BigInt', '5.2.0'
   pod 'secp256k1.swift', '~> 0.1'
   pod 'GenericJSON', '~> 2.0'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
-  - BigInt (5.0.0)
+  - BigInt (5.2.0)
   - GenericJSON (2.0.1)
   - secp256k1.swift (0.1.4)
 
 DEPENDENCIES:
-  - BigInt (= 5.0.0)
+  - BigInt (= 5.2.0)
   - GenericJSON (~> 2.0)
   - secp256k1.swift (~> 0.1)
 
@@ -15,10 +15,10 @@ SPEC REPOS:
     - secp256k1.swift
 
 SPEC CHECKSUMS:
-  BigInt: 74b4d88367b0e819d9f77393549226d36faeb0d8
+  BigInt: f668a80089607f521586bbe29513d708491ef2f7
   GenericJSON: a6e74e2c457f8693caab08e0eafde7d97e6666de
   secp256k1.swift: a7e7a214f6db6ce5db32cc6b2b45e5c4dd633634
 
-PODFILE CHECKSUM: 3d84a95ae54221cea1e840cd6b62e55c04ed01a3
+PODFILE CHECKSUM: 3df5c5e61ce857dec84394cba74c01a6b4c15d3a
 
 COCOAPODS: 1.8.4

--- a/Pods/BigInt/README.md
+++ b/Pods/BigInt/README.md
@@ -111,7 +111,7 @@ BigInt deploys to macOS 10.10, iOS 9, watchOS 2 and tvOS 9.
 It has been tested on the latest OS releases only---however, as the module uses very few platform-provided APIs,
 there should be very few issues with earlier versions.
 
-BigInt uses no APIs specific to Apple platforms except for `arc4random_buf` in `BigUInt Random.swift`, so
+BigInt uses no APIs specific to Apple platforms, so
 it should be easy to port it to other operating systems.
 
 Setup instructions:

--- a/Pods/BigInt/Sources/Data Conversion.swift
+++ b/Pods/BigInt/Sources/Data Conversion.swift
@@ -11,6 +11,7 @@ import Foundation
 extension BigUInt {
     //MARK: NSData Conversion
 
+    /// Initialize a BigInt from bytes accessed from an UnsafeRawBufferPointer
     public init(_ buffer: UnsafeRawBufferPointer) {
         // This assumes Word is binary.
         precondition(Word.bitWidth % 8 == 0)
@@ -108,3 +109,71 @@ extension BigUInt {
     }
 }
 
+extension BigInt {
+    
+    /// Initialize a BigInt from bytes accessed from an UnsafeRawBufferPointer,
+    /// where the first byte indicates sign (0 for positive, 1 for negative)
+    public init(_ buffer: UnsafeRawBufferPointer) {
+        // This assumes Word is binary.
+        precondition(Word.bitWidth % 8 == 0)
+        
+        self.init()
+        
+        let length = buffer.count
+        
+        // Serialized data for a BigInt should contain at least 2 bytes: one representing
+        // the sign, and another for the non-zero magnitude. Zero is represented by an
+        // empty Data struct, and negative zero is not supported.
+        guard length > 1, let firstByte = buffer.first else { return }
+
+        // The first byte gives the sign
+        // This byte is compared to a bitmask to allow additional functionality to be added
+        // to this byte in the future.
+        self.sign = firstByte & 0b1 == 0 ? .plus : .minus
+
+        self.magnitude = BigUInt(UnsafeRawBufferPointer(rebasing: buffer.dropFirst(1)))
+    }
+    
+    /// Initializes an integer from the bits stored inside a piece of `Data`.
+    /// The data is assumed to be in network (big-endian) byte order with a first
+    /// byte to represent the sign (0 for positive, 1 for negative)
+    public init(_ data: Data) {
+        // This assumes Word is binary.
+        // This is the same assumption made when initializing BigUInt from Data
+        precondition(Word.bitWidth % 8 == 0)
+
+        self.init()
+        
+        // Serialized data for a BigInt should contain at least 2 bytes: one representing
+        // the sign, and another for the non-zero magnitude. Zero is represented by an
+        // empty Data struct, and negative zero is not supported.
+        guard data.count > 1, let firstByte = data.first else { return }
+        
+        // The first byte gives the sign
+        // This byte is compared to a bitmask to allow additional functionality to be added
+        // to this byte in the future.
+        self.sign = firstByte & 0b1 == 0 ? .plus : .minus
+        
+        // The remaining bytes are read and stored as the magnitude
+        self.magnitude = BigUInt(data.dropFirst(1))
+    }
+    
+    /// Return a `Data` value that contains the base-256 representation of this integer, in network (big-endian) byte order and a prepended byte to indicate the sign (0 for positive, 1 for negative)
+    public func serialize() -> Data {
+        // Create a data object for the magnitude portion of the BigInt
+        let magnitudeData = self.magnitude.serialize()
+        
+        // Similar to BigUInt, a value of 0 should return an initialized, empty Data struct
+        guard magnitudeData.count > 0 else { return magnitudeData }
+        
+        // Create a new Data struct for the signed BigInt value
+        var data = Data(capacity: magnitudeData.count + 1)
+        
+        // The first byte should be 0 for a positive value, or 1 for a negative value
+        // i.e., the sign bit is the LSB
+        data.append(self.sign == .plus ? 0 : 1)
+        
+        data.append(magnitudeData)
+        return data
+    }
+}

--- a/Pods/BigInt/Sources/Random.swift
+++ b/Pods/BigInt/Sources/Random.swift
@@ -6,66 +6,96 @@
 //  Copyright © 2016-2017 Károly Lőrentey.
 //
 
-import Foundation
-#if os(Linux) || os(FreeBSD)
-  import Glibc
-#endif
-
-
 extension BigUInt {
-    //MARK: Random Integers
-
-    /// Create a big integer consisting of `width` uniformly distributed random bits.
+    /// Create a big unsigned integer consisting of `width` uniformly distributed random bits.
     ///
-    /// - Returns: A big integer less than `1 << width`.
-    /// - Note: This function uses `arc4random_buf` to generate random bits.
-    public static func randomInteger(withMaximumWidth width: Int) -> BigUInt {
-        guard width > 0 else { return 0 }
-
-        let byteCount = (width + 7) / 8
-        assert(byteCount > 0)
-
-        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: byteCount)
-      #if os(Linux) || os(FreeBSD)
-        let fd = open("/dev/urandom", O_RDONLY)
-        defer {
-            close(fd)
+    /// - Parameter width: The maximum number of one bits in the result.
+    /// - Parameter generator: The source of randomness.
+    /// - Returns: A big unsigned integer less than `1 << width`.
+    public static func randomInteger<RNG: RandomNumberGenerator>(withMaximumWidth width: Int, using generator: inout RNG) -> BigUInt {
+        var result = BigUInt.zero
+        var bitsLeft = width
+        var i = 0
+        let wordsNeeded = (width + Word.bitWidth - 1) / Word.bitWidth
+        if wordsNeeded > 2 {
+            result.reserveCapacity(wordsNeeded)
         }
-        let _ = read(fd, buffer, MemoryLayout<UInt8>.size * byteCount)
-      #else
-        arc4random_buf(buffer, byteCount)
-      #endif
-        if width % 8 != 0 {
-            buffer[0] &= UInt8(1 << (width % 8) - 1)
+        while bitsLeft >= Word.bitWidth {
+            result[i] = generator.next()
+            i += 1
+            bitsLeft -= Word.bitWidth
         }
-        defer {
-            buffer.deinitialize(count: byteCount)
-            buffer.deallocate()
+        if bitsLeft > 0 {
+            let mask: Word = (1 << bitsLeft) - 1
+            result[i] = (generator.next() as Word) & mask
         }
-        return BigUInt(Data(bytesNoCopy: buffer, count: byteCount, deallocator: .none))
+        return result
     }
 
-    /// Create a big integer consisting of `width-1` uniformly distributed random bits followed by a one bit.
+    /// Create a big unsigned integer consisting of `width` uniformly distributed random bits.
     ///
-    /// - Returns: A random big integer whose width is `width`.
-    /// - Note: This function uses `arc4random_buf` to generate random bits.
-    public static func randomInteger(withExactWidth width: Int) -> BigUInt {
+    /// - Note: I use a `SystemRandomGeneratorGenerator` as the source of randomness.
+    ///
+    /// - Parameter width: The maximum number of one bits in the result.
+    /// - Returns: A big unsigned integer less than `1 << width`.
+    public static func randomInteger(withMaximumWidth width: Int) -> BigUInt {
+        var rng = SystemRandomNumberGenerator()
+        return randomInteger(withMaximumWidth: width, using: &rng)
+    }
+
+    /// Create a big unsigned integer consisting of `width-1` uniformly distributed random bits followed by a one bit.
+    ///
+    /// - Note: If `width` is zero, the result is zero.
+    ///
+    /// - Parameter width: The number of bits required to represent the answer.
+    /// - Parameter generator: The source of randomness.
+    /// - Returns: A random big unsigned integer whose width is `width`.
+    public static func randomInteger<RNG: RandomNumberGenerator>(withExactWidth width: Int, using generator: inout RNG) -> BigUInt {
+        // width == 0 -> return 0 because there is no room for a one bit.
+        // width == 1 -> return 1 because there is no room for any random bits.
         guard width > 1 else { return BigUInt(width) }
-        var result = randomInteger(withMaximumWidth: width - 1)
+        var result = randomInteger(withMaximumWidth: width - 1, using: &generator)
         result[(width - 1) / Word.bitWidth] |= 1 << Word((width - 1) % Word.bitWidth)
         return result
     }
 
-    /// Create a uniformly distributed random integer that's less than the specified limit.
+    /// Create a big unsigned integer consisting of `width-1` uniformly distributed random bits followed by a one bit.
     ///
-    /// - Returns: A random big integer that is less than `limit`.
-    /// - Note: This function uses `arc4random_buf` to generate random bits.
-    public static func randomInteger(lessThan limit: BigUInt) -> BigUInt {
+    /// - Note: If `width` is zero, the result is zero.
+    /// - Note: I use a `SystemRandomGeneratorGenerator` as the source of randomness.
+    ///
+    /// - Returns: A random big unsigned integer whose width is `width`.
+    public static func randomInteger(withExactWidth width: Int) -> BigUInt {
+        var rng = SystemRandomNumberGenerator()
+        return randomInteger(withExactWidth: width, using: &rng)
+    }
+
+    /// Create a uniformly distributed random unsigned integer that's less than the specified limit.
+    ///
+    /// - Precondition: `limit > 0`.
+    ///
+    /// - Parameter limit: The upper bound on the result.
+    /// - Parameter generator: The source of randomness.
+    /// - Returns: A random big unsigned integer that is less than `limit`.
+    public static func randomInteger<RNG: RandomNumberGenerator>(lessThan limit: BigUInt, using generator: inout RNG) -> BigUInt {
+        precondition(limit > 0, "\(#function): 0 is not a valid limit")
         let width = limit.bitWidth
-        var random = randomInteger(withMaximumWidth: width)
+        var random = randomInteger(withMaximumWidth: width, using: &generator)
         while random >= limit {
-            random = randomInteger(withMaximumWidth: width)
+            random = randomInteger(withMaximumWidth: width, using: &generator)
         }
         return random
+    }
+
+    /// Create a uniformly distributed random unsigned integer that's less than the specified limit.
+    ///
+    /// - Precondition: `limit > 0`.
+    /// - Note: I use a `SystemRandomGeneratorGenerator` as the source of randomness.
+    ///
+    /// - Parameter limit: The upper bound on the result.
+    /// - Returns: A random big unsigned integer that is less than `limit`.
+    public static func randomInteger(lessThan limit: BigUInt) -> BigUInt {
+        var rng = SystemRandomNumberGenerator()
+        return randomInteger(lessThan: limit, using: &rng)
     }
 }

--- a/Pods/Manifest.lock
+++ b/Pods/Manifest.lock
@@ -1,10 +1,10 @@
 PODS:
-  - BigInt (5.0.0)
+  - BigInt (5.2.0)
   - GenericJSON (2.0.1)
   - secp256k1.swift (0.1.4)
 
 DEPENDENCIES:
-  - BigInt (= 5.0.0)
+  - BigInt (= 5.2.0)
   - GenericJSON (~> 2.0)
   - secp256k1.swift (~> 0.1)
 
@@ -15,10 +15,10 @@ SPEC REPOS:
     - secp256k1.swift
 
 SPEC CHECKSUMS:
-  BigInt: 74b4d88367b0e819d9f77393549226d36faeb0d8
+  BigInt: f668a80089607f521586bbe29513d708491ef2f7
   GenericJSON: a6e74e2c457f8693caab08e0eafde7d97e6666de
   secp256k1.swift: a7e7a214f6db6ce5db32cc6b2b45e5c4dd633634
 
-PODFILE CHECKSUM: 3d84a95ae54221cea1e840cd6b62e55c04ed01a3
+PODFILE CHECKSUM: 3df5c5e61ce857dec84394cba74c01a6b4c15d3a
 
 COCOAPODS: 1.8.4

--- a/Pods/Target Support Files/BigInt/BigInt-Info.plist
+++ b/Pods/Target Support Files/BigInt/BigInt-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>5.0.0</string>
+  <string>5.2.0</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/web3sTests/Contract/ABIFunctionEncoderTests.swift
+++ b/web3sTests/Contract/ABIFunctionEncoderTests.swift
@@ -15,41 +15,88 @@ class ABIFunctionEncoderTests: XCTestCase {
     
     override func setUp() {
         encoder = ABIFunctionEncoder("test")
-
     }
     
     func testGivenEmptyString_ThenEncodesCorrectly() {
-        try! encoder.encode("")
+        XCTAssertNoThrow(try encoder.encode(""))
         let encoded = try! encoder.encoded()
         XCTAssertEqual(String(hexFromBytes: encoded.web3.bytes), "0xf9fbd554000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")
     }
     
     func testGivenNonEmptyString_ThenEncodesCorrectly() {
-        try! encoder.encode("hi")
+        XCTAssertNoThrow(try encoder.encode("hi"))
         let encoded = try! encoder.encoded()
         XCTAssertEqual(String(hexFromBytes: encoded.web3.bytes), "0xf9fbd554000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000026869000000000000000000000000000000000000000000000000000000000000")
     }
+    
+    func testGivenUInt_WhenNoExplicitSize_ThenEncodesAs256() {
+        XCTAssertNoThrow(try encoder.encode(BigUInt(100)))
+        let encoded = try! encoder.encoded()
+        XCTAssertEqual(String(hexFromBytes: encoded.web3.bytes), "0x29e99f070000000000000000000000000000000000000000000000000000000000000064")
+    }
+    
+    func testGivenUInt_WhenExplicitSize256_ThenEncodesAs256() {
+        XCTAssertNoThrow(try encoder.encode(BigUInt(100), staticSize: 256))
+        let encoded = try! encoder.encoded()
+        XCTAssertEqual(String(hexFromBytes: encoded.web3.bytes), "0x29e99f070000000000000000000000000000000000000000000000000000000000000064")
+    }
+    
+    func testGivenUInt_WhenValidExplicitSize100_ThenEncodesAs100() {
+        XCTAssertNoThrow(try encoder.encode(BigUInt(100), staticSize: 100))
+        let encoded = try! encoder.encoded()
+        XCTAssertEqual(String(hexFromBytes: encoded.web3.bytes), "0xbc39e7b50000000000000000000000000000000000000000000000000000000000000064")
+    }
+    
+    func testGivenUInt_WhenInvalidSizeBiggerThan256_ThenFailsEncoding() {
+        XCTAssertThrowsError(try encoder.encode(BigUInt(100), staticSize: 257))
+    }
+    
+    func testGivenPositiveInt_WhenNoExplicitSize_ThenEncodesAs256() {
+        XCTAssertNoThrow(try encoder.encode(BigInt(100)))
+        let encoded = try! encoder.encoded()
+        XCTAssertEqual(String(hexFromBytes: encoded.web3.bytes), "0x9b22c05d0000000000000000000000000000000000000000000000000000000000000064")
+    }
+    
+    func testGivenPositiveInt_WhenValidSize256_ThenEncodesAs256() {
+        XCTAssertNoThrow(try encoder.encode(BigInt(100), staticSize: 256))
+        let encoded = try! encoder.encoded()
+        XCTAssertEqual(String(hexFromBytes: encoded.web3.bytes), "0x9b22c05d0000000000000000000000000000000000000000000000000000000000000064")
+    }
+    
+    func testGivenPositiveInt_WhenValidExplicitSize100_ThenEncodesAs100() {
+        XCTAssertNoThrow(try encoder.encode(BigInt(100), staticSize: 100))
+        let encoded = try! encoder.encoded()
+        XCTAssertEqual(String(hexFromBytes: encoded.web3.bytes), "0x868147590000000000000000000000000000000000000000000000000000000000000064")
+    }
+    
+    func testGivenPositiveInt_WhenInvalidSizeBiggerThan256_ThenFailsEncoding() {
+        XCTAssertThrowsError(try encoder.encode(BigInt(100), staticSize: 257))
+    }
 
     func testGivenEmptyData_ThenEncodesCorrectly() {
-        try! encoder.encode(Data())
+        XCTAssertNoThrow(try encoder.encode(Data()))
         let encoded = try! encoder.encoded()
         XCTAssertEqual(String(hexFromBytes: encoded.web3.bytes), "0x2f570a2300000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000")
     }
     
     func testGivenNonEmptyData_ThenEncodesCorrectly() {
-        try! encoder.encode(Data("hi".web3.bytes))
+        XCTAssertNoThrow(try encoder.encode(Data("hi".web3.bytes)))
         let encoded = try! encoder.encoded()
         XCTAssertEqual(String(hexFromBytes: encoded.web3.bytes), "0x2f570a23000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000026869000000000000000000000000000000000000000000000000000000000000")
     }
     
     func testGivenStaticSizeData4_ThenEncodesCorrectly() {
-        try! encoder.encode(Data(hex: "0xffffffff")!, staticSize: 4)
+        XCTAssertNoThrow(try encoder.encode(Data(hex: "0xffffffff")!, staticSize: 4))
         let encoded = try! encoder.encoded()
         XCTAssertEqual(String(hexFromBytes: encoded.web3.bytes), "0xda67eb8affffffff00000000000000000000000000000000000000000000000000000000")
     }
     
+    func testGivenStaticSizeDataBiggerThan32_ThenFailsEncoding() {
+        XCTAssertThrowsError(try encoder.encode(Data(hex: "0xffffffff")!, staticSize: 33))
+    }
+    
     func testGivenEmptyArrayOfAddressses_ThenEncodesCorrectly() {
-        try! encoder.encode([EthereumAddress]())
+        XCTAssertNoThrow(try encoder.encode([EthereumAddress]()))
         let encoded = try! encoder.encoded()
         XCTAssertEqual(String(hexFromBytes: encoded.web3.bytes), "0xd57498ea00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000")
     }
@@ -62,7 +109,7 @@ class ABIFunctionEncoderTests: XCTestCase {
                          "0x8c2dc702371d73febc50c6e6ced100bf9dbcb029",
                          "0x007eedb5044ed5512ed7b9f8b42fe3113452491e"].map(EthereumAddress.init)
 
-        try! encoder.encode(addresses)
+        XCTAssertNoThrow(try encoder.encode(addresses))
         let encoded = try! encoder.encoded()
         XCTAssertEqual(String(hexFromBytes: encoded.web3.bytes), "0xd57498ea0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000500000000000000000000000026fc876db425b44bf6c377a7beef65e9ebad0ec300000000000000000000000025a01a05c188dacbcf1d61af55d4a5b4021f7eed000000000000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee0000000000000000000000008c2dc702371d73febc50c6e6ced100bf9dbcb029000000000000000000000000007eedb5044ed5512ed7b9f8b42fe3113452491e")
     }
@@ -81,7 +128,7 @@ class ABIFunctionEncoderTests: XCTestCase {
     func testGivenArrayOfBigUInt_ThenEncodesCorrectly() {
         let values = [BigUInt(1),BigUInt(2),BigUInt(3)]
 
-        try! encoder.encode(values)
+        XCTAssertNoThrow(try encoder.encode(values))
         let encoded = try! encoder.encoded()
         XCTAssertEqual(String(hexFromBytes: encoded.web3.bytes), "0xca16068400000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003")
     }

--- a/web3swift/src/Contract/Statically Typed/ABIFunctionEncoder.swift
+++ b/web3swift/src/Contract/Statically Typed/ABIFunctionEncoder.swift
@@ -44,7 +44,20 @@ public class ABIFunctionEncoder {
         encodedValues.append(encoded)
         switch (staticSize, rawType) {
         case (let size?, .DynamicBytes):
+            guard size <= 32 else {
+                throw ABIError.invalidType
+            }
             types.append(.FixedBytes(size))
+        case (let size?, .FixedUInt):
+            guard size <= 256 else {
+                throw ABIError.invalidType
+            }
+            types.append(.FixedUInt(size))
+        case (let size?, .FixedInt):
+            guard size <= 256 else {
+                throw ABIError.invalidType
+            }
+            types.append(.FixedInt(size))
         default:
             types.append(rawType)
         }

--- a/web3swift/src/ERC721/ERC721.swift
+++ b/web3swift/src/ERC721/ERC721.swift
@@ -141,7 +141,7 @@ public class ERC721Metadata: ERC721 {
         let function = ERC721MetadataFunctions.tokenURI(contract: contract,
                                                         tokenID: tokenID)
         function.call(withClient: client, responseType: ERC721MetadataResponses.tokenURIResponse.self) { error, response in
-            return completion(error, response?.uri)
+            return completion(error, response?.value)
         }
     }
     


### PR DESCRIPTION
The API uses 'container' types `BigInt`, `BigUInt` and `Data`, but in Solidity those can have specific size (`Data` is also dynamic unless specifically known size).

If a specific size should be used to encode, a `staticSize` parameter should be passed when using `BigInt`, `BigUInt` or `Data`. Currently that size was ignored for Ints.