### PR TITLE
Make sign(_ transaction: EthereumTransaction) publicly available

### DIFF
--- a/web3sTests/Account/EthereumAccount+SignTransactionTests.swift
+++ b/web3sTests/Account/EthereumAccount+SignTransactionTests.swift
@@ -33,7 +33,7 @@ class EthereumAccount_SignTransactionTests: XCTestCase {
         let tx = EthereumTransaction(from: nil, to: to, value: value, data: nil, nonce: nonce, gasPrice: gasPrice, gasLimit: gasLimit, chainId: chainID)
         
         let account = try! EthereumAccount.init(keyStorage: TestEthereumKeyStorage(privateKey: "0x4646464646464646464646464646464646464646464646464646464646464646"))
-        let signed = try! account.sign(tx)
+        let signed = try! account.sign(transaction: tx)
         
         let v = signed.v.web3.hexString
         let r = signed.r.web3.hexString

--- a/web3swift/src/Account/EthereumAccount+SignTransaction.swift
+++ b/web3swift/src/Account/EthereumAccount+SignTransaction.swift
@@ -16,14 +16,14 @@ enum EthereumSignerError: Error {
 public extension EthereumAccount {
     
     func signRaw(_ transaction: EthereumTransaction) throws -> Data {
-        let signed: SignedTransaction = try sign(transaction)
+        let signed: SignedTransaction = try sign(transaction: transaction)
         guard let raw = signed.raw else {
             throw EthereumSignerError.unknownError
         }
         return raw
     }
     
-    internal func sign(_ transaction: EthereumTransaction) throws -> SignedTransaction {
+    internal func sign(transaction: EthereumTransaction) throws -> SignedTransaction {
         
         guard let raw = transaction.raw else {
             throw EthereumSignerError.emptyRawTransaction

--- a/web3swift/src/Account/EthereumAccount.swift
+++ b/web3swift/src/Account/EthereumAccount.swift
@@ -23,7 +23,7 @@ protocol EthereumAccountProtocol {
     func sign(hex: String) throws -> Data
     func sign(message: Data) throws -> Data
     func sign(message: String) throws -> Data
-    func sign(_ transaction: EthereumTransaction) throws -> SignedTransaction
+    func sign(transaction: EthereumTransaction) throws -> SignedTransaction
 }
 
 public enum EthereumAccountError: Error {

--- a/web3swift/src/Client/EthereumClient.swift
+++ b/web3swift/src/Client/EthereumClient.swift
@@ -246,7 +246,7 @@ public class EthereumClient: EthereumClientProtocol {
                     transaction.chainId = network.intValue
                 }
                 
-                guard let _ = transaction.chainId, let signedTx = (try? account.sign(transaction)), let transactionHex = signedTx.raw?.web3.hexString else {
+                guard let _ = transaction.chainId, let signedTx = (try? account.sign(transaction: transaction)), let transactionHex = signedTx.raw?.web3.hexString else {
                     group.leave()
                     return completion(EthereumClientError.encodeIssue, nil)
                 }

--- a/web3swift/src/Client/Models/EthereumTransaction.swift
+++ b/web3swift/src/Client/Models/EthereumTransaction.swift
@@ -133,7 +133,7 @@ public struct EthereumTransaction: EthereumTransactionProtocol, Equatable, Codab
 }
 
 public struct SignedTransaction {
-    let transaction: EthereumTransaction
+    public let transaction: EthereumTransaction
     let v: Int
     let r: Data
     let s: Data
@@ -151,7 +151,7 @@ public struct SignedTransaction {
         return RLP.encode(txArray)
     }
     
-    var hash: Data? {
+    public var hash: Data? {
         return raw?.web3.keccak256
     }
 }

--- a/web3swift/src/Client/Models/EthereumTransaction.swift
+++ b/web3swift/src/Client/Models/EthereumTransaction.swift
@@ -132,7 +132,7 @@ public struct EthereumTransaction: EthereumTransactionProtocol, Equatable, Codab
     }
 }
 
-struct SignedTransaction {
+public struct SignedTransaction {
     let transaction: EthereumTransaction
     let v: Int
     let r: Data
@@ -145,7 +145,7 @@ struct SignedTransaction {
         self.s = s.web3.strippingZeroesFromBytes
     }
     
-    var raw: Data? {
+    public var raw: Data? {
         let txArray: [Any?] = [transaction.nonce, transaction.gasPrice, transaction.gasLimit, transaction.to.value.web3.noHexPrefix, transaction.value, transaction.data, self.v, self.r, self.s]
 
         return RLP.encode(txArray)


### PR DESCRIPTION
In solving my own issue #141 I thought I'd offer my solution as a PR. 
If I have missed any crucial issues with this feel free to let me know and/or ignore.

**Problem**
Obtaining a signed transaction for later submission is not possible as sign(_ transaction: EthereumTransaction) is not publicly available

**Solution**
Make the function publicly available, including dependent private variables

