### PR TITLE
Async await

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,12 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 import PackageDescription
 
 let package = Package(
     name: "web3.swift",
     platforms: [
-        .iOS(SupportedPlatform.IOSVersion.v11)
+        .iOS(.v15),
+        .macOS(.v12),
+        .tvOS(.v15)
     ],
     products: [
         .library(name: "web3.swift", targets: ["web3"]),

--- a/web3sTests/Client/EthereumClientAsyncTests.swift
+++ b/web3sTests/Client/EthereumClientAsyncTests.swift
@@ -29,15 +29,7 @@ class EthereumClientAsyncTests: XCTestCase {
         super.tearDown()
     }
     
-//    func testEthGetBalance() {
-//        let expectation = XCTestExpectation(description: "get remote balance")
-//        client?.eth_getBalance(address: account?.address ?? .zero, block: .Latest, completion: { (error, balance) in
-//            XCTAssertNotNil(balance, "Balance not available: \(error?.localizedDescription ?? "no error")")
-//            expectation.fulfill()
-//        })
-//        
-//        wait(for: [expectation], timeout: timeout)
-//    }
+
 //    
 //    func testEthGetBalanceIncorrectAddress() {
 //        let expectation = XCTestExpectation(description: "get remote balance incorrect")
@@ -76,344 +68,360 @@ class EthereumClientAsyncTests: XCTestCase {
         wait(for: [expectation], timeout: timeout)
     }
     
-    func testEthBlockNumber() {
+    func testEthBlockNumber() async {
         let expectation = XCTestExpectation(description: "get current block number")
-        client?.eth_blockNumber(completion: { (error, block) in
-            XCTAssertNotNil(block, "Block not available: \(error?.localizedDescription ?? "no error")")
+        do {
+            let block = try await client!.eth_blockNumber()
+            XCTAssertGreaterThan(block, 1)
             expectation.fulfill()
-        })
-        
-        wait(for: [expectation], timeout: timeout)
-    }
-    
-    func testEthGetCode() {
-        let expectation = XCTestExpectation(description: "get contract code")
-        client?.eth_getCode(address: EthereumAddress("0x112234455c3a32fd11230c42e7bccd4a84e02010"), completion: { (error, code) in
-            XCTAssertNotNil(code, "Contract code not available: \(error?.localizedDescription ?? "no error")")
-            expectation.fulfill()
-        })
-        
-        wait(for: [expectation], timeout: timeout)
-    }
-    
-    func testEthSendRawTransaction() {
-        let expectation = XCTestExpectation(description: "send raw transaction")
-            
-        let tx = EthereumTransaction(from: nil, to: EthereumAddress("0x3c1bd6b420448cf16a389c8b0115ccb3660bb854"), value: BigUInt(1600000), data: nil, nonce: 2, gasPrice: BigUInt(4000000), gasLimit: BigUInt(50000), chainId: EthereumNetwork.Ropsten.intValue)
-        
-        self.client?.eth_sendRawTransaction(tx, withAccount: self.account!, completion: { (error, txHash) in
-            XCTAssertNotNil(txHash, "No tx hash, ensure key is valid in TestConfig.swift")
-            expectation.fulfill()
-        })
-    
-        wait(for: [expectation], timeout: timeout)
-    }
-    
-    func testEthGetTransactionCount() {
-        let expectation = XCTestExpectation(description: "get transaction receipt")
-        
-        client?.eth_getTransactionCount(address: account!.address, block: .Latest, completion: { (error, count) in
-            XCTAssertNotNil(count, "Transaction count not available: \(error?.localizedDescription ?? "no error")")
-            expectation.fulfill()
-        })
-        
-        wait(for: [expectation], timeout: timeout)
-    }
-    
-    func testEthGetTransactionCountPending() {
-        let expectation = XCTestExpectation(description: "get transaction receipt")
-        
-        client?.eth_getTransactionCount(address: account!.address, block: .Pending, completion: { (error, count) in
-            XCTAssertNotNil(count, "Transaction count not available: \(error?.localizedDescription ?? "no error")")
-            expectation.fulfill()
-        })
-        
-        wait(for: [expectation], timeout: timeout)
-    }
-    
-    func testEthGetTransactionReceipt() {
-        let expectation = XCTestExpectation(description: "get transaction receipt")
-       
-        let txHash = "0xc51002441dc669ad03697fd500a7096c054b1eb2ce094821e68831a3666fc878"
-        client?.eth_getTransactionReceipt(txHash: txHash, completion: { (error, receipt) in
-            XCTAssertNotNil(receipt, "Transaction receipt not available: \(error?.localizedDescription ?? "no error")")
-            expectation.fulfill()
-        })
-        
-        wait(for: [expectation], timeout: timeout)
-    }
-    
-    func testEthCall() {
-        let expectation = XCTestExpectation(description: "send raw transaction")
-        
-        let tx = EthereumTransaction(from: nil, to: EthereumAddress("0x3c1bd6b420448cf16a389c8b0115ccb3660bb854"), value: BigUInt(1800000), data: nil, nonce: 2, gasPrice: BigUInt(400000), gasLimit: BigUInt(50000), chainId: EthereumNetwork.Ropsten.intValue)
-        client?.eth_call(tx, block: .Latest, completion: { (error, txHash) in
-            XCTAssertNotNil(txHash, "Transaction hash not available: \(error?.localizedDescription ?? "no error")")
-            expectation.fulfill()
-        })
-        
-        wait(for: [expectation], timeout: timeout)
-    }
-    
-    func testSimpleEthGetLogs() {
-        let expectation = XCTestExpectation(description: "get logs")
-        
-        client?.eth_getLogs(addresses: [EthereumAddress("0x23d0a442580c01e420270fba6ca836a8b2353acb")], topics: nil, fromBlock: .Earliest, toBlock: .Latest, completion: { (error, logs) in
-            XCTAssertNotNil(logs, "Logs not available \(error?.localizedDescription ?? "no error")")
-            expectation.fulfill()
-        })
-        
-        wait(for: [expectation], timeout: timeout)
-    }
-    
-    func testOrTopicsEthGetLogs() {
-        let expectation = XCTestExpectation(description: "get logs")
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
 
-        // Deposit/Withdrawal event to specific address
-        client?.eth_getLogs(addresses: nil, orTopics: [["0xe1fffcc4923d04b559f4d29a8bfc6cda04eb5b0d3c460751c2402c5c5cc9109c", "0x7fcf532c15f0a6db0bd6d0e038bea71d30d808c7d98cb3bf7268a95bf5081b65"], ["0x000000000000000000000000655ef694b98e55977a93259cb3b708560869a8f3"]], fromBlock: .Number(6540313), toBlock: .Number(6540397), completion: { (error, logs) in
-            XCTAssertEqual(logs?.count, 2)
-            XCTAssertNotNil(logs, "Logs not available \(error?.localizedDescription ?? "no error")")
+        wait(for: [expectation], timeout: timeout)
+    }
+    
+    func testEthGetBalance() async {
+        let expectation = XCTestExpectation(description: "get remote balance")
+        do {
+            let balance = try await client!.eth_getBalance(address: account?.address ?? .zero, block: .latest)
+            XCTAssertGreaterThan(balance, 0)
             expectation.fulfill()
-        })
-        
-        wait(for: [expectation], timeout: timeout)
-    }
-    
-    func testGivenGenesisBlock_ThenReturnsByNumber() {
-        let expectation = XCTestExpectation(description: "get block by number")
-        
-        client?.eth_getBlockByNumber(.Number(0)) { error, block in
-            XCTAssertNil(error)
-            
-            XCTAssertEqual(block?.timestamp.timeIntervalSince1970, 0)
-            XCTAssertEqual(block?.transactions.count, 0)
-            XCTAssertEqual(block?.number, .Number(0))
-            expectation.fulfill()
-        }
-        
-        wait(for: [expectation], timeout: timeout)
-    }
-
-    func testGivenLatestBlock_ThenReturnsByNumber() {
-        let expectation = XCTestExpectation(description: "get block by number")
-        
-        client?.eth_getBlockByNumber(.Latest) { error, block in
-            XCTAssertNil(error)
-            XCTAssertNotNil(block?.number.intValue)
-            expectation.fulfill()
+        } catch {
+            XCTFail(error.localizedDescription)
         }
         
         wait(for: [expectation], timeout: timeout)
     }
     
-    func testGivenExistingBlock_ThenGetsBlockByNumber() {
-        let expectation = XCTestExpectation(description: "get block by number")
-        
-        client?.eth_getBlockByNumber(.Number(3415757)) { error, block in
-            XCTAssertNil(error)
-            
-            XCTAssertEqual(block?.number, .Number(3415757))
-            XCTAssertEqual(block?.timestamp.timeIntervalSince1970, 1528711895)
-            XCTAssertEqual(block?.transactions.count, 40)
-            XCTAssertEqual(block?.transactions.first, "0x387867d052b3f89fb87937572891118aa704c1ba604c157bbd9c5a07f3a7e5cd")
-            expectation.fulfill()
-        }
-        
-        wait(for: [expectation], timeout: timeout)
-    }
-    
-    func testGivenUnexistingBlockNumber_ThenGetBlockByNumberReturnsError() {
-        let expectation = XCTestExpectation(description: "get block by number")
-        
-        client?.eth_getBlockByNumber(.Number(Int.max)) { error, block in
-            XCTAssertNotNil(error)
-            XCTAssertNil(block)
-            expectation.fulfill()
-        }
-        
-        wait(for: [expectation], timeout: timeout)
-    }
-    
-    func testGivenMinedTransactionHash_ThenGetsTransactionByHash() {
-        let expectation = XCTestExpectation(description: "get transaction by hash")
-        
-        client?.eth_getTransaction(byHash: "0x014726c783ab2fd6828a9ca556850bccfc66f70926f411274eaf886385c704af") { error, transaction in
-            XCTAssertNil(error)
-            XCTAssertEqual(transaction?.from?.value, "0xbbf5029fd710d227630c8b7d338051b8e76d50b3")
-            XCTAssertEqual(transaction?.to.value, "0x37f13b5ffcc285d2452c0556724afb22e58b6bbe")
-            XCTAssertEqual(transaction?.gas, "30400")
-            XCTAssertEqual(transaction?.gasPrice, BigUInt(hex: "0x9184e72a000"))
-            XCTAssertEqual(transaction?.nonce, 973253)
-            XCTAssertEqual(transaction?.value, BigUInt(hex: "0x56bc75e2d63100000"))
-            XCTAssertEqual(transaction?.blockNumber, EthereumBlock.Number(3439303))
-            XCTAssertEqual(transaction?.hash?.web3.hexString, "0x014726c783ab2fd6828a9ca556850bccfc66f70926f411274eaf886385c704af")
-            
-            expectation.fulfill()
-        }
-        
-        wait(for: [expectation], timeout: timeout)
-    }
-    
-    func testGivenUnexistingTransactionHash_ThenErrorsGetTransactionByHash() {
-        let expectation = XCTestExpectation(description: "get transaction by hash")
-        
-        client?.eth_getTransaction(byHash: "0x01234") { error, transaction in
-            XCTAssertNotNil(error)
-            XCTAssertNil(transaction)
-            expectation.fulfill()
-        }
-        
-        wait(for: [expectation], timeout: timeout)
-    }
-    
-    func testGivenNoFilters_WhenMatchingSingleTransferEvents_AllEventsReturned() {
-        let expectation = XCTestExpectation(description: "get events")
-        
-        let to = try! ABIEncoder.encode(EthereumAddress("0x3C1Bd6B420448Cf16A389C8b0115CCB3660bB854"))
-            
-        client?.getEvents(addresses: nil,
-                          topics: [try! ERC20Events.Transfer.signature(), nil, to.hexString, nil],
-                          fromBlock: .Earliest,
-                          toBlock: .Latest,
-                          eventTypes: [ERC20Events.Transfer.self]) { (error, events, logs) in
-            XCTAssertNil(error)
-            XCTAssertEqual(events.count, 2)
-            XCTAssertEqual(logs.count, 0)
-            expectation.fulfill()
-        }
-        
-        wait(for: [expectation], timeout: timeout)
-    }
-    
-    func testGivenNoFilters_WhenMatchingMultipleTransferEvents_BothEventsReturned() {
-        let expectation = XCTestExpectation(description: "get events")
-        
-        let to = try! ABIEncoder.encode(EthereumAddress("0x3C1Bd6B420448Cf16A389C8b0115CCB3660bB854"))
-        
-        client?.getEvents(addresses: nil,
-                          topics: [try! ERC20Events.Transfer.signature(), nil, to.hexString, nil],
-                          fromBlock: .Earliest,
-                          toBlock: .Latest,
-                          eventTypes: [ERC20Events.Transfer.self, TransferMatchingSignatureEvent.self]) { (error, events, logs) in
-                            XCTAssertNil(error)
-                            XCTAssertEqual(events.count, 4)
-                            XCTAssertEqual(logs.count, 0)
-                            expectation.fulfill()
-        }
-        
-        wait(for: [expectation], timeout: timeout)
-    }
-    
-    func testGivenContractFilter_WhenMatchingSingleTransferEvents_OnlyMatchingSourceEventReturned() {
-        let expectation = XCTestExpectation(description: "get events")
-        
-        let to = try! ABIEncoder.encodeRaw("0x3C1Bd6B420448Cf16A389C8b0115CCB3660bB854", forType: ABIRawType.FixedAddress)
-        let filters = [
-            EventFilter(type: ERC20Events.Transfer.self, allowedSenders: [EthereumAddress("0xdb0040451f373949a4be60dcd7b6b8d6e42658b6")])
-        ]
-        
-        client?.getEvents(addresses: nil,
-                          topics: [try! ERC20Events.Transfer.signature(), nil, to.hexString, nil],
-                          fromBlock: .Earliest,
-                          toBlock: .Latest,
-                          matching: filters) { (error, events, logs) in
-                            XCTAssertNil(error)
-                            XCTAssertEqual(events.count, 1)
-                            XCTAssertEqual(logs.count, 1)
-                            expectation.fulfill()
-        }
-        
-        wait(for: [expectation], timeout: timeout)
-    }
-    
-    func testGivenContractFilter_WhenMatchingMultipleTransferEvents_OnlyMatchingSourceEventsReturned() {
-        let expectation = XCTestExpectation(description: "get events")
-        
-        let to = try! ABIEncoder.encode(EthereumAddress("0x3C1Bd6B420448Cf16A389C8b0115CCB3660bB854"))
-        let filters = [
-            EventFilter(type: ERC20Events.Transfer.self, allowedSenders: [EthereumAddress("0xdb0040451f373949a4be60dcd7b6b8d6e42658b6")]),
-            EventFilter(type: TransferMatchingSignatureEvent.self, allowedSenders: [EthereumAddress("0xdb0040451f373949a4be60dcd7b6b8d6e42658b6")])
-        ]
-        
-        client?.getEvents(addresses: nil,
-                          topics: [try! ERC20Events.Transfer.signature(), nil, to.hexString, nil],
-                          fromBlock: .Earliest,
-                          toBlock: .Latest,
-                          matching: filters) { (error, events, logs) in
-                            XCTAssertNil(error)
-                            XCTAssertEqual(events.count, 2)
-                            XCTAssertEqual(logs.count, 2)
-                            expectation.fulfill()
-        }
-        
-        wait(for: [expectation], timeout: timeout)
-    }
-    
-    func test_GivenDynamicArrayResponse_ThenCallReceivesData() {
-        let expect = expectation(description: "call")
-        
-        let function = GetGuardians(wallet: EthereumAddress("0x2A6295C34b4136F2C3c1445c6A0338D784fe0ddd"))
-        function.call(withClient: self.client!,
-                      responseType: GetGuardians.Response.self) { (error, response) in
-                        XCTAssertNil(error)
-                        XCTAssertEqual(response?.guardians, [EthereumAddress("0x44fe11c90d2bcbc8267a0e56d55235ddc2b96c4f")])
-                        expect.fulfill()
-        }
-        
-        waitForExpectations(timeout: 10)
-    }
-    
-    // This is how geth used to work up until a recent version
-    // see https://github.com/ethereum/go-ethereum/pull/21083/
-    // Used to return '0x' in response, and would fail decoding
-    // We'll continue to support this as user of library (and Argent in our case)
-    // works with this assumption.
-    // NOTE: This behaviour will be removed at a later time to fail as expected
-    // NOTE: At the time of writing, this test succeeds as-is in ropsten as nodes behaviour is different. That's why we use a mainnet check here
-    func test_GivenUnimplementedMethod_WhenCallingContract_ThenFailsWith0x() {
-        let expect = expectation(description: "graceful_failure")
-        
-        let function = InvalidMethodA(param: .zero)
-        
-        function.call(withClient: self.mainnetClient!,
-                      responseType: InvalidMethodA.BoolResponse.self) { (error, response) in
-                        XCTAssertEqual(error, .decodeIssue)
-                        XCTAssertNil(response)
-                        expect.fulfill()
-        }
-        
-        waitForExpectations(timeout: 10)
-    }
-    func test_GivenFailingCallMethod_WhenCallingContract_ThenFailsWith0x() {
-        let expect = expectation(description: "graceful_failure")
-        
-        let function = InvalidMethodB(param: .zero)
-        
-        function.call(withClient: self.mainnetClient!,
-                      responseType: InvalidMethodB.BoolResponse.self) { (error, response) in
-                        XCTAssertEqual(error, .decodeIssue)
-                        XCTAssertNil(response)
-                        expect.fulfill()
-        }
-        
-        waitForExpectations(timeout: 10)
-    }
-    
-    func test_GivenValidTransaction_ThenEstimatesGas() {
-        let expect = expectation(description: "estimateOK")
-        let function = TransferToken(wallet: EthereumAddress("0xD18dE36e6FB4a5A069f673723Fab71cc00C6CE5F"),
-                                     token: EthereumAddress("0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
-                                     to: EthereumAddress("0x2A6295C34b4136F2C3c1445c6A0338D784fe0ddd"),
-                                     amount: 1,
-                                     data: Data(),
-                                     gasPrice: 0,
-                                     gasLimit: 0)
-        client!.eth_estimateGas(try! function.transaction(), withAccount: account!) { (error, value) in
-            XCTAssertNil(error)
-            XCTAssert(value != 0)
-            expect.fulfill()
-        }
-        
-        waitForExpectations(timeout: 10)
-    }
+//    func testEthGetCode() {
+//        let expectation = XCTestExpectation(description: "get contract code")
+//        client?.eth_getCode(address: EthereumAddress("0x112234455c3a32fd11230c42e7bccd4a84e02010"), completion: { (error, code) in
+//            XCTAssertNotNil(code, "Contract code not available: \(error?.localizedDescription ?? "no error")")
+//            expectation.fulfill()
+//        })
+//
+//        wait(for: [expectation], timeout: timeout)
+//    }
+//
+//    func testEthSendRawTransaction() {
+//        let expectation = XCTestExpectation(description: "send raw transaction")
+//
+//        let tx = EthereumTransaction(from: nil, to: EthereumAddress("0x3c1bd6b420448cf16a389c8b0115ccb3660bb854"), value: BigUInt(1600000), data: nil, nonce: 2, gasPrice: BigUInt(4000000), gasLimit: BigUInt(50000), chainId: EthereumNetwork.Ropsten.intValue)
+//
+//        self.client?.eth_sendRawTransaction(tx, withAccount: self.account!, completion: { (error, txHash) in
+//            XCTAssertNotNil(txHash, "No tx hash, ensure key is valid in TestConfig.swift")
+//            expectation.fulfill()
+//        })
+//
+//        wait(for: [expectation], timeout: timeout)
+//    }
+//
+//    func testEthGetTransactionCount() {
+//        let expectation = XCTestExpectation(description: "get transaction receipt")
+//
+//        client?.eth_getTransactionCount(address: account!.address, block: .Latest, completion: { (error, count) in
+//            XCTAssertNotNil(count, "Transaction count not available: \(error?.localizedDescription ?? "no error")")
+//            expectation.fulfill()
+//        })
+//
+//        wait(for: [expectation], timeout: timeout)
+//    }
+//
+//    func testEthGetTransactionCountPending() {
+//        let expectation = XCTestExpectation(description: "get transaction receipt")
+//
+//        client?.eth_getTransactionCount(address: account!.address, block: .Pending, completion: { (error, count) in
+//            XCTAssertNotNil(count, "Transaction count not available: \(error?.localizedDescription ?? "no error")")
+//            expectation.fulfill()
+//        })
+//
+//        wait(for: [expectation], timeout: timeout)
+//    }
+//
+//    func testEthGetTransactionReceipt() {
+//        let expectation = XCTestExpectation(description: "get transaction receipt")
+//
+//        let txHash = "0xc51002441dc669ad03697fd500a7096c054b1eb2ce094821e68831a3666fc878"
+//        client?.eth_getTransactionReceipt(txHash: txHash, completion: { (error, receipt) in
+//            XCTAssertNotNil(receipt, "Transaction receipt not available: \(error?.localizedDescription ?? "no error")")
+//            expectation.fulfill()
+//        })
+//
+//        wait(for: [expectation], timeout: timeout)
+//    }
+//
+//    func testEthCall() {
+//        let expectation = XCTestExpectation(description: "send raw transaction")
+//
+//        let tx = EthereumTransaction(from: nil, to: EthereumAddress("0x3c1bd6b420448cf16a389c8b0115ccb3660bb854"), value: BigUInt(1800000), data: nil, nonce: 2, gasPrice: BigUInt(400000), gasLimit: BigUInt(50000), chainId: EthereumNetwork.Ropsten.intValue)
+//        client?.eth_call(tx, block: .Latest, completion: { (error, txHash) in
+//            XCTAssertNotNil(txHash, "Transaction hash not available: \(error?.localizedDescription ?? "no error")")
+//            expectation.fulfill()
+//        })
+//
+//        wait(for: [expectation], timeout: timeout)
+//    }
+//
+//    func testSimpleEthGetLogs() {
+//        let expectation = XCTestExpectation(description: "get logs")
+//
+//        client?.eth_getLogs(addresses: [EthereumAddress("0x23d0a442580c01e420270fba6ca836a8b2353acb")], topics: nil, fromBlock: .Earliest, toBlock: .Latest, completion: { (error, logs) in
+//            XCTAssertNotNil(logs, "Logs not available \(error?.localizedDescription ?? "no error")")
+//            expectation.fulfill()
+//        })
+//
+//        wait(for: [expectation], timeout: timeout)
+//    }
+//
+//    func testOrTopicsEthGetLogs() {
+//        let expectation = XCTestExpectation(description: "get logs")
+//
+//        // Deposit/Withdrawal event to specific address
+//        client?.eth_getLogs(addresses: nil, orTopics: [["0xe1fffcc4923d04b559f4d29a8bfc6cda04eb5b0d3c460751c2402c5c5cc9109c", "0x7fcf532c15f0a6db0bd6d0e038bea71d30d808c7d98cb3bf7268a95bf5081b65"], ["0x000000000000000000000000655ef694b98e55977a93259cb3b708560869a8f3"]], fromBlock: .Number(6540313), toBlock: .Number(6540397), completion: { (error, logs) in
+//            XCTAssertEqual(logs?.count, 2)
+//            XCTAssertNotNil(logs, "Logs not available \(error?.localizedDescription ?? "no error")")
+//            expectation.fulfill()
+//        })
+//
+//        wait(for: [expectation], timeout: timeout)
+//    }
+//
+//    func testGivenGenesisBlock_ThenReturnsByNumber() {
+//        let expectation = XCTestExpectation(description: "get block by number")
+//
+//        client?.eth_getBlockByNumber(.Number(0)) { error, block in
+//            XCTAssertNil(error)
+//
+//            XCTAssertEqual(block?.timestamp.timeIntervalSince1970, 0)
+//            XCTAssertEqual(block?.transactions.count, 0)
+//            XCTAssertEqual(block?.number, .Number(0))
+//            expectation.fulfill()
+//        }
+//
+//        wait(for: [expectation], timeout: timeout)
+//    }
+//
+//    func testGivenLatestBlock_ThenReturnsByNumber() {
+//        let expectation = XCTestExpectation(description: "get block by number")
+//
+//        client?.eth_getBlockByNumber(.Latest) { error, block in
+//            XCTAssertNil(error)
+//            XCTAssertNotNil(block?.number.intValue)
+//            expectation.fulfill()
+//        }
+//
+//        wait(for: [expectation], timeout: timeout)
+//    }
+//
+//    func testGivenExistingBlock_ThenGetsBlockByNumber() {
+//        let expectation = XCTestExpectation(description: "get block by number")
+//
+//        client?.eth_getBlockByNumber(.Number(3415757)) { error, block in
+//            XCTAssertNil(error)
+//
+//            XCTAssertEqual(block?.number, .Number(3415757))
+//            XCTAssertEqual(block?.timestamp.timeIntervalSince1970, 1528711895)
+//            XCTAssertEqual(block?.transactions.count, 40)
+//            XCTAssertEqual(block?.transactions.first, "0x387867d052b3f89fb87937572891118aa704c1ba604c157bbd9c5a07f3a7e5cd")
+//            expectation.fulfill()
+//        }
+//
+//        wait(for: [expectation], timeout: timeout)
+//    }
+//
+//    func testGivenUnexistingBlockNumber_ThenGetBlockByNumberReturnsError() {
+//        let expectation = XCTestExpectation(description: "get block by number")
+//
+//        client?.eth_getBlockByNumber(.Number(Int.max)) { error, block in
+//            XCTAssertNotNil(error)
+//            XCTAssertNil(block)
+//            expectation.fulfill()
+//        }
+//
+//        wait(for: [expectation], timeout: timeout)
+//    }
+//
+//    func testGivenMinedTransactionHash_ThenGetsTransactionByHash() {
+//        let expectation = XCTestExpectation(description: "get transaction by hash")
+//
+//        client?.eth_getTransaction(byHash: "0x014726c783ab2fd6828a9ca556850bccfc66f70926f411274eaf886385c704af") { error, transaction in
+//            XCTAssertNil(error)
+//            XCTAssertEqual(transaction?.from?.value, "0xbbf5029fd710d227630c8b7d338051b8e76d50b3")
+//            XCTAssertEqual(transaction?.to.value, "0x37f13b5ffcc285d2452c0556724afb22e58b6bbe")
+//            XCTAssertEqual(transaction?.gas, "30400")
+//            XCTAssertEqual(transaction?.gasPrice, BigUInt(hex: "0x9184e72a000"))
+//            XCTAssertEqual(transaction?.nonce, 973253)
+//            XCTAssertEqual(transaction?.value, BigUInt(hex: "0x56bc75e2d63100000"))
+//            XCTAssertEqual(transaction?.blockNumber, EthereumBlock.Number(3439303))
+//            XCTAssertEqual(transaction?.hash?.web3.hexString, "0x014726c783ab2fd6828a9ca556850bccfc66f70926f411274eaf886385c704af")
+//
+//            expectation.fulfill()
+//        }
+//
+//        wait(for: [expectation], timeout: timeout)
+//    }
+//
+//    func testGivenUnexistingTransactionHash_ThenErrorsGetTransactionByHash() {
+//        let expectation = XCTestExpectation(description: "get transaction by hash")
+//
+//        client?.eth_getTransaction(byHash: "0x01234") { error, transaction in
+//            XCTAssertNotNil(error)
+//            XCTAssertNil(transaction)
+//            expectation.fulfill()
+//        }
+//
+//        wait(for: [expectation], timeout: timeout)
+//    }
+//
+//    func testGivenNoFilters_WhenMatchingSingleTransferEvents_AllEventsReturned() {
+//        let expectation = XCTestExpectation(description: "get events")
+//
+//        let to = try! ABIEncoder.encode(EthereumAddress("0x3C1Bd6B420448Cf16A389C8b0115CCB3660bB854"))
+//
+//        client?.getEvents(addresses: nil,
+//                          topics: [try! ERC20Events.Transfer.signature(), nil, to.hexString, nil],
+//                          fromBlock: .Earliest,
+//                          toBlock: .Latest,
+//                          eventTypes: [ERC20Events.Transfer.self]) { (error, events, logs) in
+//            XCTAssertNil(error)
+//            XCTAssertEqual(events.count, 2)
+//            XCTAssertEqual(logs.count, 0)
+//            expectation.fulfill()
+//        }
+//
+//        wait(for: [expectation], timeout: timeout)
+//    }
+//
+//    func testGivenNoFilters_WhenMatchingMultipleTransferEvents_BothEventsReturned() {
+//        let expectation = XCTestExpectation(description: "get events")
+//
+//        let to = try! ABIEncoder.encode(EthereumAddress("0x3C1Bd6B420448Cf16A389C8b0115CCB3660bB854"))
+//
+//        client?.getEvents(addresses: nil,
+//                          topics: [try! ERC20Events.Transfer.signature(), nil, to.hexString, nil],
+//                          fromBlock: .Earliest,
+//                          toBlock: .Latest,
+//                          eventTypes: [ERC20Events.Transfer.self, TransferMatchingSignatureEvent.self]) { (error, events, logs) in
+//                            XCTAssertNil(error)
+//                            XCTAssertEqual(events.count, 4)
+//                            XCTAssertEqual(logs.count, 0)
+//                            expectation.fulfill()
+//        }
+//
+//        wait(for: [expectation], timeout: timeout)
+//    }
+//
+//    func testGivenContractFilter_WhenMatchingSingleTransferEvents_OnlyMatchingSourceEventReturned() {
+//        let expectation = XCTestExpectation(description: "get events")
+//
+//        let to = try! ABIEncoder.encodeRaw("0x3C1Bd6B420448Cf16A389C8b0115CCB3660bB854", forType: ABIRawType.FixedAddress)
+//        let filters = [
+//            EventFilter(type: ERC20Events.Transfer.self, allowedSenders: [EthereumAddress("0xdb0040451f373949a4be60dcd7b6b8d6e42658b6")])
+//        ]
+//
+//        client?.getEvents(addresses: nil,
+//                          topics: [try! ERC20Events.Transfer.signature(), nil, to.hexString, nil],
+//                          fromBlock: .Earliest,
+//                          toBlock: .Latest,
+//                          matching: filters) { (error, events, logs) in
+//                            XCTAssertNil(error)
+//                            XCTAssertEqual(events.count, 1)
+//                            XCTAssertEqual(logs.count, 1)
+//                            expectation.fulfill()
+//        }
+//
+//        wait(for: [expectation], timeout: timeout)
+//    }
+//
+//    func testGivenContractFilter_WhenMatchingMultipleTransferEvents_OnlyMatchingSourceEventsReturned() {
+//        let expectation = XCTestExpectation(description: "get events")
+//
+//        let to = try! ABIEncoder.encode(EthereumAddress("0x3C1Bd6B420448Cf16A389C8b0115CCB3660bB854"))
+//        let filters = [
+//            EventFilter(type: ERC20Events.Transfer.self, allowedSenders: [EthereumAddress("0xdb0040451f373949a4be60dcd7b6b8d6e42658b6")]),
+//            EventFilter(type: TransferMatchingSignatureEvent.self, allowedSenders: [EthereumAddress("0xdb0040451f373949a4be60dcd7b6b8d6e42658b6")])
+//        ]
+//
+//        client?.getEvents(addresses: nil,
+//                          topics: [try! ERC20Events.Transfer.signature(), nil, to.hexString, nil],
+//                          fromBlock: .Earliest,
+//                          toBlock: .Latest,
+//                          matching: filters) { (error, events, logs) in
+//                            XCTAssertNil(error)
+//                            XCTAssertEqual(events.count, 2)
+//                            XCTAssertEqual(logs.count, 2)
+//                            expectation.fulfill()
+//        }
+//
+//        wait(for: [expectation], timeout: timeout)
+//    }
+//
+//    func test_GivenDynamicArrayResponse_ThenCallReceivesData() {
+//        let expect = expectation(description: "call")
+//
+//        let function = GetGuardians(wallet: EthereumAddress("0x2A6295C34b4136F2C3c1445c6A0338D784fe0ddd"))
+//        function.call(withClient: self.client!,
+//                      responseType: GetGuardians.Response.self) { (error, response) in
+//                        XCTAssertNil(error)
+//                        XCTAssertEqual(response?.guardians, [EthereumAddress("0x44fe11c90d2bcbc8267a0e56d55235ddc2b96c4f")])
+//                        expect.fulfill()
+//        }
+//
+//        waitForExpectations(timeout: 10)
+//    }
+//
+//    // This is how geth used to work up until a recent version
+//    // see https://github.com/ethereum/go-ethereum/pull/21083/
+//    // Used to return '0x' in response, and would fail decoding
+//    // We'll continue to support this as user of library (and Argent in our case)
+//    // works with this assumption.
+//    // NOTE: This behaviour will be removed at a later time to fail as expected
+//    // NOTE: At the time of writing, this test succeeds as-is in ropsten as nodes behaviour is different. That's why we use a mainnet check here
+//    func test_GivenUnimplementedMethod_WhenCallingContract_ThenFailsWith0x() {
+//        let expect = expectation(description: "graceful_failure")
+//
+//        let function = InvalidMethodA(param: .zero)
+//
+//        function.call(withClient: self.mainnetClient!,
+//                      responseType: InvalidMethodA.BoolResponse.self) { (error, response) in
+//                        XCTAssertEqual(error, .decodeIssue)
+//                        XCTAssertNil(response)
+//                        expect.fulfill()
+//        }
+//
+//        waitForExpectations(timeout: 10)
+//    }
+//    func test_GivenFailingCallMethod_WhenCallingContract_ThenFailsWith0x() {
+//        let expect = expectation(description: "graceful_failure")
+//
+//        let function = InvalidMethodB(param: .zero)
+//
+//        function.call(withClient: self.mainnetClient!,
+//                      responseType: InvalidMethodB.BoolResponse.self) { (error, response) in
+//                        XCTAssertEqual(error, .decodeIssue)
+//                        XCTAssertNil(response)
+//                        expect.fulfill()
+//        }
+//
+//        waitForExpectations(timeout: 10)
+//    }
+//
+//    func test_GivenValidTransaction_ThenEstimatesGas() {
+//        let expect = expectation(description: "estimateOK")
+//        let function = TransferToken(wallet: EthereumAddress("0xD18dE36e6FB4a5A069f673723Fab71cc00C6CE5F"),
+//                                     token: EthereumAddress("0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
+//                                     to: EthereumAddress("0x2A6295C34b4136F2C3c1445c6A0338D784fe0ddd"),
+//                                     amount: 1,
+//                                     data: Data(),
+//                                     gasPrice: 0,
+//                                     gasLimit: 0)
+//        client!.eth_estimateGas(try! function.transaction(), withAccount: account!) { (error, value) in
+//            XCTAssertNil(error)
+//            XCTAssert(value != 0)
+//            expect.fulfill()
+//        }
+//
+//        waitForExpectations(timeout: 10)
+//    }
 }

--- a/web3sTests/Client/EthereumClientAsyncTests.swift
+++ b/web3sTests/Client/EthereumClientAsyncTests.swift
@@ -442,55 +442,57 @@ class EthereumClientAsyncTests: XCTestCase {
         wait(for: [expectation], timeout: timeout)
     }
 
-//    func test_GivenDynamicArrayResponse_ThenCallReceivesData() async {
-//        let expect = expectation(description: "call")
-//
-//        let function = GetGuardians(wallet: EthereumAddress("0x2A6295C34b4136F2C3c1445c6A0338D784fe0ddd"))
-//        function.call(withClient: self.client!,
-//                      responseType: GetGuardians.Response.self) { (error, response) in
-//                        XCTAssertNil(error)
-//                        XCTAssertEqual(response?.guardians, [EthereumAddress("0x44fe11c90d2bcbc8267a0e56d55235ddc2b96c4f")])
-//                        expect.fulfill()
-//        }
-//
-//        waitForExpectations(timeout: 10)
-//    }
-//
-//    // This is how geth used to work up until a recent version
-//    // see https://github.com/ethereum/go-ethereum/pull/21083/
-//    // Used to return '0x' in response, and would fail decoding
-//    // We'll continue to support this as user of library (and Argent in our case)
-//    // works with this assumption.
-//    // NOTE: This behaviour will be removed at a later time to fail as expected
-//    // NOTE: At the time of writing, this test succeeds as-is in ropsten as nodes behaviour is different. That's why we use a mainnet check here
-//    func test_GivenUnimplementedMethod_WhenCallingContract_ThenFailsWith0x() {
-//        let expect = expectation(description: "graceful_failure")
-//
-//        let function = InvalidMethodA(param: .zero)
-//
-//        function.call(withClient: self.mainnetClient!,
-//                      responseType: InvalidMethodA.BoolResponse.self) { (error, response) in
-//                        XCTAssertEqual(error, .decodeIssue)
-//                        XCTAssertNil(response)
-//                        expect.fulfill()
-//        }
-//
-//        waitForExpectations(timeout: 10)
-//    }
-//    func test_GivenFailingCallMethod_WhenCallingContract_ThenFailsWith0x() {
-//        let expect = expectation(description: "graceful_failure")
-//
-//        let function = InvalidMethodB(param: .zero)
-//
-//        function.call(withClient: self.mainnetClient!,
-//                      responseType: InvalidMethodB.BoolResponse.self) { (error, response) in
-//                        XCTAssertEqual(error, .decodeIssue)
-//                        XCTAssertNil(response)
-//                        expect.fulfill()
-//        }
-//
-//        waitForExpectations(timeout: 10)
-//    }
-//
+    func test_GivenDynamicArrayResponse_ThenCallReceivesData() async {
+        let expectation = expectation(description: "call")
+
+        let function = GetGuardians(wallet: EthereumAddress("0x2A6295C34b4136F2C3c1445c6A0338D784fe0ddd"))
+        do {
+            let response = try await function.call(withClient: self.client!, responseType: GetGuardians.Response.self)
+            XCTAssertEqual(response.guardians, [EthereumAddress("0x44fe11c90d2bcbc8267a0e56d55235ddc2b96c4f")])
+            expectation.fulfill()
+        } catch {
+            XCTFail("fail: \(error)")
+        }
+
+        wait(for: [expectation], timeout: timeout)
+    }
+
+    // This is how geth used to work up until a recent version
+    // see https://github.com/ethereum/go-ethereum/pull/21083/
+    // Used to return '0x' in response, and would fail decoding
+    // We'll continue to support this as user of library (and Argent in our case)
+    // works with this assumption.
+    // NOTE: This behaviour will be removed at a later time to fail as expected
+    // NOTE: At the time of writing, this test succeeds as-is in ropsten as nodes behaviour is different. That's why we use a mainnet check here
+    func test_GivenUnimplementedMethod_WhenCallingContract_ThenFailsWith0x() async {
+        let expectation = expectation(description: "graceful_failure")
+
+        let function = InvalidMethodA(param: .zero)
+
+        do {
+            _ = try await function.call(withClient: self.mainnetClient!, responseType: InvalidMethodA.BoolResponse.self)
+            XCTFail("this call should fail")
+        } catch {
+            XCTAssertEqual(error as? EthereumClientError, EthereumClientError.decodeIssue )
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: timeout)
+    }
+    func test_GivenFailingCallMethod_WhenCallingContract_ThenFailsWith0x() async {
+        let expectation = expectation(description: "graceful_failure")
+
+        let function = InvalidMethodB(param: .zero)
+
+        do {
+            _ = try await function.call(withClient: self.mainnetClient!, responseType: InvalidMethodB.BoolResponse.self)
+            XCTFail("this call should fail")
+        } catch {
+            XCTAssertEqual(error as? EthereumClientError, EthereumClientError.decodeIssue )
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: timeout)
+    }
 
 }

--- a/web3sTests/Client/EthereumClientAsyncTests.swift
+++ b/web3sTests/Client/EthereumClientAsyncTests.swift
@@ -442,17 +442,13 @@ class EthereumClientAsyncTests: XCTestCase {
         wait(for: [expectation], timeout: timeout)
     }
 
-    func test_GivenDynamicArrayResponse_ThenCallReceivesData() async {
+    func test_GivenDynamicArrayResponse_ThenCallReceivesData() async throws {
         let expectation = expectation(description: "call")
 
         let function = GetGuardians(wallet: EthereumAddress("0x2A6295C34b4136F2C3c1445c6A0338D784fe0ddd"))
-        do {
-            let response = try await function.call(withClient: self.client!, responseType: GetGuardians.Response.self)
-            XCTAssertEqual(response.guardians, [EthereumAddress("0x44fe11c90d2bcbc8267a0e56d55235ddc2b96c4f")])
-            expectation.fulfill()
-        } catch {
-            XCTFail("fail: \(error)")
-        }
+        let response = try await function.call(withClient: self.client!, responseType: GetGuardians.Response.self)
+        XCTAssertEqual(response.guardians, [EthereumAddress("0x44fe11c90d2bcbc8267a0e56d55235ddc2b96c4f")])
+        expectation.fulfill()
 
         wait(for: [expectation], timeout: timeout)
     }

--- a/web3sTests/Client/EthereumClientAsyncTests.swift
+++ b/web3sTests/Client/EthereumClientAsyncTests.swift
@@ -28,87 +28,42 @@ class EthereumClientAsyncTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
     }
-    
-
-//    
-//    func testEthGetBalanceIncorrectAddress() {
-//        let expectation = XCTestExpectation(description: "get remote balance incorrect")
-//        
-//        client?.eth_getBalance(address: EthereumAddress("0xnig42niog2"), block: .Latest, completion: { (error, balance) in
-//            XCTAssertNotNil(error, "Balance error not available")
-//            expectation.fulfill()
-//        })
-//        
-//        wait(for: [expectation], timeout: timeout)
-//    }
-    
-    func testNetVersion() async {
-        let expectation = XCTestExpectation(description: "get net version")
+  
+    func testEthGetBalanceIncorrectAddress() async throws {
         do {
-            let network = try await client!.net_version()
-            XCTAssertEqual(network, EthereumNetwork.Ropsten)
-            expectation.fulfill()
+            _ = try await client!.eth_getBalance(address: EthereumAddress("0xnig42niog2"), block: .latest)
+            XCTFail("balance should fail")
         } catch {
-            XCTFail(error.localizedDescription)
+            XCTAssertNotNil(error, "Balance error not available")
         }
-      
-        wait(for: [expectation], timeout: timeout)
     }
     
-    func testEthGasPrice() async {
-        let expectation = XCTestExpectation(description: "get gas price")
-        do {
-            let gasPrice = try await client!.eth_gasPrice()
-            XCTAssertGreaterThan(gasPrice, 0)
-            expectation.fulfill()
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
-        
-        wait(for: [expectation], timeout: timeout)
+    func testNetVersion() async throws {
+        let network = try await client!.net_version()
+        XCTAssertEqual(network, EthereumNetwork.Ropsten)
     }
     
-    func testEthBlockNumber() async {
-        let expectation = XCTestExpectation(description: "get current block number")
-        do {
-            let block = try await client!.eth_blockNumber()
-            XCTAssertGreaterThan(block, 1)
-            expectation.fulfill()
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
-
-        wait(for: [expectation], timeout: timeout)
+    func testEthGasPrice() async throws {
+        let gasPrice = try await client!.eth_gasPrice()
+        XCTAssertGreaterThan(gasPrice, 0)
     }
     
-    func testEthGetBalance() async {
-        let expectation = XCTestExpectation(description: "get remote balance")
-        do {
-            let balance = try await client!.eth_getBalance(address: account?.address ?? .zero, block: .latest)
-            XCTAssertGreaterThan(balance, 0)
-            expectation.fulfill()
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
-        
-        wait(for: [expectation], timeout: timeout)
+    func testEthBlockNumber() async throws {
+        let block = try await client!.eth_blockNumber()
+        XCTAssertGreaterThan(block, 1)
     }
     
-    func testEthGetCode() async {
-        let expectation = XCTestExpectation(description: "get contract code")
-        do {
-            let code = try await client!.eth_getCode(address: EthereumAddress("0x112234455c3a32fd11230c42e7bccd4a84e02010"))
-            XCTAssertGreaterThan(code.count, 1)
-            expectation.fulfill()
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
-
-        wait(for: [expectation], timeout: timeout)
+    func testEthGetBalance() async throws {
+        let balance = try await client!.eth_getBalance(address: account?.address ?? .zero, block: .latest)
+        XCTAssertGreaterThan(balance, 0)
     }
     
-    func test_GivenValidTransaction_ThenEstimatesGas() async {
-        let expect = expectation(description: "estimateOK")
+    func testEthGetCode() async throws {
+        let code = try await client!.eth_getCode(address: EthereumAddress("0x112234455c3a32fd11230c42e7bccd4a84e02010"))
+        XCTAssertGreaterThan(code.count, 1)
+    }
+    
+    func test_GivenValidTransaction_ThenEstimatesGas() async throws {
         let function = TransferToken(wallet: EthereumAddress("0xD18dE36e6FB4a5A069f673723Fab71cc00C6CE5F"),
                                      token: EthereumAddress("0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
                                      to: EthereumAddress("0x2A6295C34b4136F2C3c1445c6A0338D784fe0ddd"),
@@ -116,74 +71,30 @@ class EthereumClientAsyncTests: XCTestCase {
                                      data: Data(),
                                      gasPrice: 0,
                                      gasLimit: 0)
-        do {
-            let gas = try await client!.eth_estimateGas(try! function.transaction(), withAccount: account!)
-            XCTAssert(gas > 0)
-            expect.fulfill()
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
-
-        wait(for: [expect], timeout: 10)    
+        let gas = try await client!.eth_estimateGas(try! function.transaction(), withAccount: account!)
+        XCTAssert(gas > 0)
     }
 
-    func testEthSendRawTransaction() async {
-        let expectation = XCTestExpectation(description: "send raw transaction")
-
+    func testEthSendRawTransaction() async throws {
         let tx = EthereumTransaction(from: nil, to: EthereumAddress("0x3c1bd6b420448cf16a389c8b0115ccb3660bb854"), value: BigUInt(1600000), data: nil, nonce: 2, gasPrice: BigUInt(4000000), gasLimit: BigUInt(50000), chainId: EthereumNetwork.Ropsten.intValue)
-
-        do {
-            let txHash = try await self.client!.eth_sendRawTransaction(tx, withAccount: self.account!)
-            XCTAssert(txHash.count > 0)
-            expectation.fulfill()
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
-                                            
-        wait(for: [expectation], timeout: timeout)
+        let txHash = try await self.client!.eth_sendRawTransaction(tx, withAccount: self.account!)
+        XCTAssert(txHash.count > 0)
     }
 
-    func testEthGetTransactionCount() async {
-        let expectation = XCTestExpectation(description: "get transaction receipt")
-
-        do {
-            let count = try await client!.eth_getTransactionCount(address: account!.address, block: .latest)
-            XCTAssert(count > 0)
-            expectation.fulfill()
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
-
-        wait(for: [expectation], timeout: timeout)
+    func testEthGetTransactionCount() async throws {
+        let count = try await client!.eth_getTransactionCount(address: account!.address, block: .latest)
+        XCTAssert(count > 0)
     }
     
-    func testEthGetTransactionCountPending() async {
-        let expectation = XCTestExpectation(description: "get transaction receipt")
-        
-        do {
-            _ = try await client!.eth_getTransactionCount(address: account!.address, block: .pending)
-            expectation.fulfill()
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
-
-        wait(for: [expectation], timeout: timeout)
+    func testEthGetTransactionCountPending() async throws {
+        _ = try await client!.eth_getTransactionCount(address: account!.address, block: .pending)
     }
     
-    func testEthGetTransactionReceipt() async {
-        let expectation = XCTestExpectation(description: "get transaction receipt")
-
-        do {
-            let txHash = "0x9d7282cc7140ac23c709e07cf717bad25605dbc454f6ac22245989afd711e5ec"
-            let receipt = try await client!.eth_getTransactionReceipt(txHash: txHash)
-            XCTAssertEqual(receipt.transactionHash, "0x9d7282cc7140ac23c709e07cf717bad25605dbc454f6ac22245989afd711e5ec")
-            XCTAssertEqual(receipt.blockNumber, BigUInt(10797945))
-            expectation.fulfill()
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
-
-        wait(for: [expectation], timeout: timeout)
+    func testEthGetTransactionReceipt() async throws {
+        let txHash = "0x9d7282cc7140ac23c709e07cf717bad25605dbc454f6ac22245989afd711e5ec"
+        let receipt = try await client!.eth_getTransactionReceipt(txHash: txHash)
+        XCTAssertEqual(receipt.transactionHash, "0x9d7282cc7140ac23c709e07cf717bad25605dbc454f6ac22245989afd711e5ec")
+        XCTAssertEqual(receipt.blockNumber, BigUInt(10797945))
     }
     
     func testEthGetInvalidTransactionReceipt() async {
@@ -207,27 +118,17 @@ class EthereumClientAsyncTests: XCTestCase {
         wait(for: [expectation], timeout: timeout)
     }
 
-    func testGivenMinedTransactionHash_ThenGetsTransactionByHash() async {
-        let expectation = XCTestExpectation(description: "get transaction by hash")
-
-        do {
-            let transaction = try await client!.eth_getTransaction(byHash: "0x014726c783ab2fd6828a9ca556850bccfc66f70926f411274eaf886385c704af")
-            
-            XCTAssertEqual(transaction.from?.value, "0xbbf5029fd710d227630c8b7d338051b8e76d50b3")
-            XCTAssertEqual(transaction.to.value, "0x37f13b5ffcc285d2452c0556724afb22e58b6bbe")
-            XCTAssertEqual(transaction.gas, "30400")
-            XCTAssertEqual(transaction.gasPrice, BigUInt(hex: "0x9184e72a000"))
-            XCTAssertEqual(transaction.nonce, 973253)
-            XCTAssertEqual(transaction.value, BigUInt(hex: "0x56bc75e2d63100000"))
-            XCTAssertEqual(transaction.blockNumber, EthereumBlock.number(3439303))
-            XCTAssertEqual(transaction.hash?.web3.hexString, "0x014726c783ab2fd6828a9ca556850bccfc66f70926f411274eaf886385c704af")
-
-            expectation.fulfill()
-        } catch {
-            XCTFail("fail: \(error)")
-        }
-
-        wait(for: [expectation], timeout: timeout)
+    func testGivenMinedTransactionHash_ThenGetsTransactionByHash() async throws {
+        let transaction = try await client!.eth_getTransaction(byHash: "0x014726c783ab2fd6828a9ca556850bccfc66f70926f411274eaf886385c704af")
+        
+        XCTAssertEqual(transaction.from?.value, "0xbbf5029fd710d227630c8b7d338051b8e76d50b3")
+        XCTAssertEqual(transaction.to.value, "0x37f13b5ffcc285d2452c0556724afb22e58b6bbe")
+        XCTAssertEqual(transaction.gas, "30400")
+        XCTAssertEqual(transaction.gasPrice, BigUInt(hex: "0x9184e72a000"))
+        XCTAssertEqual(transaction.nonce, 973253)
+        XCTAssertEqual(transaction.value, BigUInt(hex: "0x56bc75e2d63100000"))
+        XCTAssertEqual(transaction.blockNumber, EthereumBlock.number(3439303))
+        XCTAssertEqual(transaction.hash?.web3.hexString, "0x014726c783ab2fd6828a9ca556850bccfc66f70926f411274eaf886385c704af")
     }
 
     func testGivenUnexistingTransactionHash_ThenErrorsGetTransactionByHash() async {
@@ -243,95 +144,39 @@ class EthereumClientAsyncTests: XCTestCase {
         wait(for: [expectation], timeout: timeout)
     }
 
-    func testEthCall() async {
-        let expectation = XCTestExpectation(description: "send raw transaction")
-
-        do {
-            let tx = EthereumTransaction(from: nil, to: EthereumAddress("0x3c1bd6b420448cf16a389c8b0115ccb3660bb854"), value: BigUInt(1800000), data: nil, nonce: 2, gasPrice: BigUInt(400000), gasLimit: BigUInt(50000), chainId: EthereumNetwork.Ropsten.intValue)
-            let txHash = try await client!.eth_call(tx, block: .latest)
-            XCTAssertNotNil(txHash)
-            expectation.fulfill()
-        } catch {
-            XCTFail("fail: \(error)")
-        }
-
-        wait(for: [expectation], timeout: timeout)
+    func testEthCall() async throws {
+        let tx = EthereumTransaction(from: nil, to: EthereumAddress("0x3c1bd6b420448cf16a389c8b0115ccb3660bb854"), value: BigUInt(1800000), data: nil, nonce: 2, gasPrice: BigUInt(400000), gasLimit: BigUInt(50000), chainId: EthereumNetwork.Ropsten.intValue)
+        let txHash = try await client!.eth_call(tx, block: .latest)
+        XCTAssertNotNil(txHash)
     }
 
-    func testSimpleEthGetLogs() async {
-        let expectation = XCTestExpectation(description: "get logs")
-
-        do {
-            _ = try await client!.eth_getLogs(addresses: [EthereumAddress("0x23d0a442580c01e420270fba6ca836a8b2353acb")], topics: nil, fromBlock: .earliest, toBlock: .latest)
-            expectation.fulfill()
-        } catch {
-            XCTFail("fail: \(error)")
-        }
-
-        wait(for: [expectation], timeout: timeout)
+    func testSimpleEthGetLogs() async throws {
+        _ = try await client!.eth_getLogs(addresses: [EthereumAddress("0x23d0a442580c01e420270fba6ca836a8b2353acb")], topics: nil, fromBlock: .earliest, toBlock: .latest)
     }
 
-    func testOrTopicsEthGetLogs() async {
-        let expectation = XCTestExpectation(description: "get logs")
-
-        do {
-        // Deposit/Withdrawal event to specific address
-            let logs = try await client!.eth_getLogs(addresses: nil, orTopics: [["0xe1fffcc4923d04b559f4d29a8bfc6cda04eb5b0d3c460751c2402c5c5cc9109c", "0x7fcf532c15f0a6db0bd6d0e038bea71d30d808c7d98cb3bf7268a95bf5081b65"], ["0x000000000000000000000000655ef694b98e55977a93259cb3b708560869a8f3"]], fromBlock: .number(6540313), toBlock: .number(6540397))
-            XCTAssertEqual(logs.count, 2)
-            expectation.fulfill()
-        
-        } catch {
-            XCTFail("fail: \(error)")
-        }
-
-        wait(for: [expectation], timeout: timeout)
+    func testOrTopicsEthGetLogs() async throws {
+        let logs = try await client!.eth_getLogs(addresses: nil, orTopics: [["0xe1fffcc4923d04b559f4d29a8bfc6cda04eb5b0d3c460751c2402c5c5cc9109c", "0x7fcf532c15f0a6db0bd6d0e038bea71d30d808c7d98cb3bf7268a95bf5081b65"], ["0x000000000000000000000000655ef694b98e55977a93259cb3b708560869a8f3"]], fromBlock: .number(6540313), toBlock: .number(6540397))
+        XCTAssertEqual(logs.count, 2)
     }
 
-    func testGivenGenesisBlock_ThenReturnsByNumber() async {
-        let expectation = XCTestExpectation(description: "get block by number")
-
-        do {
-            let block = try await client!.eth_getBlockByNumber(.number(0))
-            XCTAssertEqual(block.timestamp.timeIntervalSince1970, 0)
-            XCTAssertEqual(block.transactions.count, 0)
-            XCTAssertEqual(block.number, .number(0))
-            expectation.fulfill()
-        } catch {
-            XCTFail("fail: \(error)")
-        }
-        
-        wait(for: [expectation], timeout: timeout)
+    func testGivenGenesisBlock_ThenReturnsByNumber() async throws {
+        let block = try await client!.eth_getBlockByNumber(.number(0))
+        XCTAssertEqual(block.timestamp.timeIntervalSince1970, 0)
+        XCTAssertEqual(block.transactions.count, 0)
+        XCTAssertEqual(block.number, .number(0))
     }
 
-    func testGivenLatestBlock_ThenReturnsByNumber() async {
-        let expectation = XCTestExpectation(description: "get block by number")
-
-        do {
-            let block = try await client!.eth_getBlockByNumber(.latest)
-            XCTAssert(block.number.intValue ?? 0 > 1)
-            expectation.fulfill()
-        } catch {
-            XCTFail("fail: \(error)")
-        }
-        
-        wait(for: [expectation], timeout: timeout)
+    func testGivenLatestBlock_ThenReturnsByNumber() async throws {
+        let block = try await client!.eth_getBlockByNumber(.latest)
+        XCTAssert(block.number.intValue ?? 0 > 1)
     }
 
-    func testGivenExistingBlock_ThenGetsBlockByNumber() async {
-        let expectation = XCTestExpectation(description: "get block by number")
-
-        do {
-            let block = try await client!.eth_getBlockByNumber(.number(3415757))
-            XCTAssertEqual(block.number, .number(3415757))
-            XCTAssertEqual(block.timestamp.timeIntervalSince1970, 1528711895)
-            XCTAssertEqual(block.transactions.count, 40)
-            XCTAssertEqual(block.transactions.first, "0x387867d052b3f89fb87937572891118aa704c1ba604c157bbd9c5a07f3a7e5cd")
-            expectation.fulfill()
-        } catch {
-            XCTFail("fail: \(error)")
-        }
-
-        wait(for: [expectation], timeout: timeout)
+    func testGivenExistingBlock_ThenGetsBlockByNumber() async throws {
+        let block = try await client!.eth_getBlockByNumber(.number(3415757))
+        XCTAssertEqual(block.number, .number(3415757))
+        XCTAssertEqual(block.timestamp.timeIntervalSince1970, 1528711895)
+        XCTAssertEqual(block.transactions.count, 40)
+        XCTAssertEqual(block.transactions.first, "0x387867d052b3f89fb87937572891118aa704c1ba604c157bbd9c5a07f3a7e5cd")
     }
 
     func testGivenUnexistingBlockNumber_ThenGetBlockByNumberReturnsError() async {
@@ -347,110 +192,65 @@ class EthereumClientAsyncTests: XCTestCase {
         wait(for: [expectation], timeout: timeout)
     }
 
-    func testGivenNoFilters_WhenMatchingSingleTransferEvents_AllEventsReturned() async {
-        let expectation = XCTestExpectation(description: "get events")
-
-        do {
-            let to = try! ABIEncoder.encode(EthereumAddress("0x3C1Bd6B420448Cf16A389C8b0115CCB3660bB854"))
-            let (events, logs) = try await client!.getEvents(
-                addresses: nil,
-                topics: [try! ERC20Events.Transfer.signature(), nil, to.hexString, nil],
-                fromBlock: .earliest,
-                toBlock: .latest,
-                eventTypes: [ERC20Events.Transfer.self])
-            
-            XCTAssertEqual(events.count, 2)
-            XCTAssertEqual(logs.count, 0)
-            expectation.fulfill()
-        } catch {
-            XCTFail("fail: \(error)")
-        }
-        
-        wait(for: [expectation], timeout: timeout)
-    }
-
-    func testGivenNoFilters_WhenMatchingMultipleTransferEvents_BothEventsReturned() async {
-        let expectation = XCTestExpectation(description: "get events")
-
+    func testGivenNoFilters_WhenMatchingSingleTransferEvents_AllEventsReturned() async throws {
         let to = try! ABIEncoder.encode(EthereumAddress("0x3C1Bd6B420448Cf16A389C8b0115CCB3660bB854"))
-
-        do {
-            let (events, logs) = try await client!.getEvents(addresses: nil,
-                          topics: [try! ERC20Events.Transfer.signature(), nil, to.hexString, nil],
-                          fromBlock: .earliest,
-                          toBlock: .latest,
-                          eventTypes: [ERC20Events.Transfer.self, TransferMatchingSignatureEvent.self])
+        let (events, logs) = try await client!.getEvents(
+            addresses: nil,
+            topics: [try! ERC20Events.Transfer.signature(), nil, to.hexString, nil],
+            fromBlock: .earliest,
+            toBlock: .latest,
+            eventTypes: [ERC20Events.Transfer.self])
         
-            XCTAssertEqual(events.count, 4)
-            XCTAssertEqual(logs.count, 0)
-            expectation.fulfill()
-            
-        } catch {
-            XCTFail("fail: \(error)")
-        }
-
-        wait(for: [expectation], timeout: timeout)
+        XCTAssertEqual(events.count, 2)
+        XCTAssertEqual(logs.count, 0)
     }
 
-    func testGivenContractFilter_WhenMatchingSingleTransferEvents_OnlyMatchingSourceEventReturned() async {
-        let expectation = XCTestExpectation(description: "get events")
+    func testGivenNoFilters_WhenMatchingMultipleTransferEvents_BothEventsReturned() async throws {
+        let to = try! ABIEncoder.encode(EthereumAddress("0x3C1Bd6B420448Cf16A389C8b0115CCB3660bB854"))
+        let (events, logs) = try await client!.getEvents(addresses: nil,
+                      topics: [try! ERC20Events.Transfer.signature(), nil, to.hexString, nil],
+                      fromBlock: .earliest,
+                      toBlock: .latest,
+                      eventTypes: [ERC20Events.Transfer.self, TransferMatchingSignatureEvent.self])
+    
+        XCTAssertEqual(events.count, 4)
+        XCTAssertEqual(logs.count, 0)
+    }
 
+    func testGivenContractFilter_WhenMatchingSingleTransferEvents_OnlyMatchingSourceEventReturned() async throws {
         let to = try! ABIEncoder.encodeRaw("0x3C1Bd6B420448Cf16A389C8b0115CCB3660bB854", forType: ABIRawType.FixedAddress)
         let filters = [
             EventFilter(type: ERC20Events.Transfer.self, allowedSenders: [EthereumAddress("0xdb0040451f373949a4be60dcd7b6b8d6e42658b6")])
         ]
+        let (events, logs) = try await client!.getEvents(addresses: nil,
+                          topics: [try! ERC20Events.Transfer.signature(), nil, to.hexString, nil],
+                          fromBlock: .earliest,
+                          toBlock: .latest,
+                          matching: filters)
         
-        do {
-            let (events, logs) = try await client!.getEvents(addresses: nil,
-                              topics: [try! ERC20Events.Transfer.signature(), nil, to.hexString, nil],
-                              fromBlock: .earliest,
-                              toBlock: .latest,
-                              matching: filters)
-            
-            XCTAssertEqual(events.count, 1)
-            XCTAssertEqual(logs.count, 1)
-            expectation.fulfill()
-        } catch {
-            XCTFail("fail: \(error)")
-        }
-
-        wait(for: [expectation], timeout: timeout)
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(logs.count, 1)
     }
 
-    func testGivenContractFilter_WhenMatchingMultipleTransferEvents_OnlyMatchingSourceEventsReturned() async {
-        let expectation = XCTestExpectation(description: "get events")
-
+    func testGivenContractFilter_WhenMatchingMultipleTransferEvents_OnlyMatchingSourceEventsReturned() async throws {
         let to = try! ABIEncoder.encode(EthereumAddress("0x3C1Bd6B420448Cf16A389C8b0115CCB3660bB854"))
         let filters = [
             EventFilter(type: ERC20Events.Transfer.self, allowedSenders: [EthereumAddress("0xdb0040451f373949a4be60dcd7b6b8d6e42658b6")]),
             EventFilter(type: TransferMatchingSignatureEvent.self, allowedSenders: [EthereumAddress("0xdb0040451f373949a4be60dcd7b6b8d6e42658b6")])
         ]
-
-        do {
-            let (events, logs) = try await client!.getEvents(addresses: nil,
-                                                             topics: [try! ERC20Events.Transfer.signature(), nil, to.hexString, nil],
-                                                             fromBlock: .earliest,
-                                                             toBlock: .latest,
-                                                             matching: filters)
-           XCTAssertEqual(events.count, 2)
-           XCTAssertEqual(logs.count, 2)
-           expectation.fulfill()
-        } catch {
-            XCTFail("fail: \(error)")
-        }
-
-        wait(for: [expectation], timeout: timeout)
+        let (events, logs) = try await client!.getEvents(addresses: nil,
+                                                         topics: [try! ERC20Events.Transfer.signature(), nil, to.hexString, nil],
+                                                         fromBlock: .earliest,
+                                                         toBlock: .latest,
+                                                         matching: filters)
+       XCTAssertEqual(events.count, 2)
+       XCTAssertEqual(logs.count, 2)
     }
 
     func test_GivenDynamicArrayResponse_ThenCallReceivesData() async throws {
-        let expectation = expectation(description: "call")
-
         let function = GetGuardians(wallet: EthereumAddress("0x2A6295C34b4136F2C3c1445c6A0338D784fe0ddd"))
         let response = try await function.call(withClient: self.client!, responseType: GetGuardians.Response.self)
         XCTAssertEqual(response.guardians, [EthereumAddress("0x44fe11c90d2bcbc8267a0e56d55235ddc2b96c4f")])
-        expectation.fulfill()
-
-        wait(for: [expectation], timeout: timeout)
     }
 
     // This is how geth used to work up until a recent version
@@ -475,6 +275,7 @@ class EthereumClientAsyncTests: XCTestCase {
 
         wait(for: [expectation], timeout: timeout)
     }
+    
     func test_GivenFailingCallMethod_WhenCallingContract_ThenFailsWith0x() async {
         let expectation = expectation(description: "graceful_failure")
 

--- a/web3sTests/Client/EthereumClientAsyncTests.swift
+++ b/web3sTests/Client/EthereumClientAsyncTests.swift
@@ -257,30 +257,35 @@ class EthereumClientAsyncTests: XCTestCase {
 
         wait(for: [expectation], timeout: timeout)
     }
-//
-//    func testSimpleEthGetLogs() {
-//        let expectation = XCTestExpectation(description: "get logs")
-//
-//        client?.eth_getLogs(addresses: [EthereumAddress("0x23d0a442580c01e420270fba6ca836a8b2353acb")], topics: nil, fromBlock: .Earliest, toBlock: .Latest, completion: { (error, logs) in
-//            XCTAssertNotNil(logs, "Logs not available \(error?.localizedDescription ?? "no error")")
-//            expectation.fulfill()
-//        })
-//
-//        wait(for: [expectation], timeout: timeout)
-//    }
-//
-//    func testOrTopicsEthGetLogs() {
-//        let expectation = XCTestExpectation(description: "get logs")
-//
-//        // Deposit/Withdrawal event to specific address
-//        client?.eth_getLogs(addresses: nil, orTopics: [["0xe1fffcc4923d04b559f4d29a8bfc6cda04eb5b0d3c460751c2402c5c5cc9109c", "0x7fcf532c15f0a6db0bd6d0e038bea71d30d808c7d98cb3bf7268a95bf5081b65"], ["0x000000000000000000000000655ef694b98e55977a93259cb3b708560869a8f3"]], fromBlock: .Number(6540313), toBlock: .Number(6540397), completion: { (error, logs) in
-//            XCTAssertEqual(logs?.count, 2)
-//            XCTAssertNotNil(logs, "Logs not available \(error?.localizedDescription ?? "no error")")
-//            expectation.fulfill()
-//        })
-//
-//        wait(for: [expectation], timeout: timeout)
-//    }
+
+    func testSimpleEthGetLogs() async {
+        let expectation = XCTestExpectation(description: "get logs")
+
+        do {
+            _ = try await client!.eth_getLogs(addresses: [EthereumAddress("0x23d0a442580c01e420270fba6ca836a8b2353acb")], topics: nil, fromBlock: .earliest, toBlock: .latest)
+            expectation.fulfill()
+        } catch {
+            XCTFail("fail: \(error)")
+        }
+
+        wait(for: [expectation], timeout: timeout)
+    }
+
+    func testOrTopicsEthGetLogs() async {
+        let expectation = XCTestExpectation(description: "get logs")
+
+        do {
+        // Deposit/Withdrawal event to specific address
+            let logs = try await client!.eth_getLogs(addresses: nil, orTopics: [["0xe1fffcc4923d04b559f4d29a8bfc6cda04eb5b0d3c460751c2402c5c5cc9109c", "0x7fcf532c15f0a6db0bd6d0e038bea71d30d808c7d98cb3bf7268a95bf5081b65"], ["0x000000000000000000000000655ef694b98e55977a93259cb3b708560869a8f3"]], fromBlock: .number(6540313), toBlock: .number(6540397))
+            XCTAssertEqual(logs.count, 2)
+            expectation.fulfill()
+        
+        } catch {
+            XCTFail("fail: \(error)")
+        }
+
+        wait(for: [expectation], timeout: timeout)
+    }
 //
 //    func testGivenGenesisBlock_ThenReturnsByNumber() {
 //        let expectation = XCTestExpectation(description: "get block by number")

--- a/web3sTests/Client/EthereumClientAsyncTests.swift
+++ b/web3sTests/Client/EthereumClientAsyncTests.swift
@@ -368,72 +368,81 @@ class EthereumClientAsyncTests: XCTestCase {
         
         wait(for: [expectation], timeout: timeout)
     }
-//
-//    func testGivenNoFilters_WhenMatchingMultipleTransferEvents_BothEventsReturned() {
-//        let expectation = XCTestExpectation(description: "get events")
-//
-//        let to = try! ABIEncoder.encode(EthereumAddress("0x3C1Bd6B420448Cf16A389C8b0115CCB3660bB854"))
-//
-//        client?.getEvents(addresses: nil,
-//                          topics: [try! ERC20Events.Transfer.signature(), nil, to.hexString, nil],
-//                          fromBlock: .Earliest,
-//                          toBlock: .Latest,
-//                          eventTypes: [ERC20Events.Transfer.self, TransferMatchingSignatureEvent.self]) { (error, events, logs) in
-//                            XCTAssertNil(error)
-//                            XCTAssertEqual(events.count, 4)
-//                            XCTAssertEqual(logs.count, 0)
-//                            expectation.fulfill()
-//        }
-//
-//        wait(for: [expectation], timeout: timeout)
-//    }
-//
-//    func testGivenContractFilter_WhenMatchingSingleTransferEvents_OnlyMatchingSourceEventReturned() {
-//        let expectation = XCTestExpectation(description: "get events")
-//
-//        let to = try! ABIEncoder.encodeRaw("0x3C1Bd6B420448Cf16A389C8b0115CCB3660bB854", forType: ABIRawType.FixedAddress)
-//        let filters = [
-//            EventFilter(type: ERC20Events.Transfer.self, allowedSenders: [EthereumAddress("0xdb0040451f373949a4be60dcd7b6b8d6e42658b6")])
-//        ]
-//
-//        client?.getEvents(addresses: nil,
-//                          topics: [try! ERC20Events.Transfer.signature(), nil, to.hexString, nil],
-//                          fromBlock: .Earliest,
-//                          toBlock: .Latest,
-//                          matching: filters) { (error, events, logs) in
-//                            XCTAssertNil(error)
-//                            XCTAssertEqual(events.count, 1)
-//                            XCTAssertEqual(logs.count, 1)
-//                            expectation.fulfill()
-//        }
-//
-//        wait(for: [expectation], timeout: timeout)
-//    }
-//
-//    func testGivenContractFilter_WhenMatchingMultipleTransferEvents_OnlyMatchingSourceEventsReturned() {
-//        let expectation = XCTestExpectation(description: "get events")
-//
-//        let to = try! ABIEncoder.encode(EthereumAddress("0x3C1Bd6B420448Cf16A389C8b0115CCB3660bB854"))
-//        let filters = [
-//            EventFilter(type: ERC20Events.Transfer.self, allowedSenders: [EthereumAddress("0xdb0040451f373949a4be60dcd7b6b8d6e42658b6")]),
-//            EventFilter(type: TransferMatchingSignatureEvent.self, allowedSenders: [EthereumAddress("0xdb0040451f373949a4be60dcd7b6b8d6e42658b6")])
-//        ]
-//
-//        client?.getEvents(addresses: nil,
-//                          topics: [try! ERC20Events.Transfer.signature(), nil, to.hexString, nil],
-//                          fromBlock: .Earliest,
-//                          toBlock: .Latest,
-//                          matching: filters) { (error, events, logs) in
-//                            XCTAssertNil(error)
-//                            XCTAssertEqual(events.count, 2)
-//                            XCTAssertEqual(logs.count, 2)
-//                            expectation.fulfill()
-//        }
-//
-//        wait(for: [expectation], timeout: timeout)
-//    }
-//
-//    func test_GivenDynamicArrayResponse_ThenCallReceivesData() {
+
+    func testGivenNoFilters_WhenMatchingMultipleTransferEvents_BothEventsReturned() async {
+        let expectation = XCTestExpectation(description: "get events")
+
+        let to = try! ABIEncoder.encode(EthereumAddress("0x3C1Bd6B420448Cf16A389C8b0115CCB3660bB854"))
+
+        do {
+            let (events, logs) = try await client!.getEvents(addresses: nil,
+                          topics: [try! ERC20Events.Transfer.signature(), nil, to.hexString, nil],
+                          fromBlock: .earliest,
+                          toBlock: .latest,
+                          eventTypes: [ERC20Events.Transfer.self, TransferMatchingSignatureEvent.self])
+        
+            XCTAssertEqual(events.count, 4)
+            XCTAssertEqual(logs.count, 0)
+            expectation.fulfill()
+            
+        } catch {
+            XCTFail("fail: \(error)")
+        }
+
+        wait(for: [expectation], timeout: timeout)
+    }
+
+    func testGivenContractFilter_WhenMatchingSingleTransferEvents_OnlyMatchingSourceEventReturned() async {
+        let expectation = XCTestExpectation(description: "get events")
+
+        let to = try! ABIEncoder.encodeRaw("0x3C1Bd6B420448Cf16A389C8b0115CCB3660bB854", forType: ABIRawType.FixedAddress)
+        let filters = [
+            EventFilter(type: ERC20Events.Transfer.self, allowedSenders: [EthereumAddress("0xdb0040451f373949a4be60dcd7b6b8d6e42658b6")])
+        ]
+        
+        do {
+            let (events, logs) = try await client!.getEvents(addresses: nil,
+                              topics: [try! ERC20Events.Transfer.signature(), nil, to.hexString, nil],
+                              fromBlock: .earliest,
+                              toBlock: .latest,
+                              matching: filters)
+            
+            XCTAssertEqual(events.count, 1)
+            XCTAssertEqual(logs.count, 1)
+            expectation.fulfill()
+        } catch {
+            XCTFail("fail: \(error)")
+        }
+
+        wait(for: [expectation], timeout: timeout)
+    }
+
+    func testGivenContractFilter_WhenMatchingMultipleTransferEvents_OnlyMatchingSourceEventsReturned() async {
+        let expectation = XCTestExpectation(description: "get events")
+
+        let to = try! ABIEncoder.encode(EthereumAddress("0x3C1Bd6B420448Cf16A389C8b0115CCB3660bB854"))
+        let filters = [
+            EventFilter(type: ERC20Events.Transfer.self, allowedSenders: [EthereumAddress("0xdb0040451f373949a4be60dcd7b6b8d6e42658b6")]),
+            EventFilter(type: TransferMatchingSignatureEvent.self, allowedSenders: [EthereumAddress("0xdb0040451f373949a4be60dcd7b6b8d6e42658b6")])
+        ]
+
+        do {
+            let (events, logs) = try await client!.getEvents(addresses: nil,
+                                                             topics: [try! ERC20Events.Transfer.signature(), nil, to.hexString, nil],
+                                                             fromBlock: .earliest,
+                                                             toBlock: .latest,
+                                                             matching: filters)
+           XCTAssertEqual(events.count, 2)
+           XCTAssertEqual(logs.count, 2)
+           expectation.fulfill()
+        } catch {
+            XCTFail("fail: \(error)")
+        }
+
+        wait(for: [expectation], timeout: timeout)
+    }
+
+//    func test_GivenDynamicArrayResponse_ThenCallReceivesData() async {
 //        let expect = expectation(description: "call")
 //
 //        let function = GetGuardians(wallet: EthereumAddress("0x2A6295C34b4136F2C3c1445c6A0338D784fe0ddd"))

--- a/web3sTests/Client/EthereumClientTests.swift
+++ b/web3sTests/Client/EthereumClientTests.swift
@@ -52,7 +52,7 @@ class EthereumClientTests: XCTestCase {
     
     func testEthGetBalance() {
         let expectation = XCTestExpectation(description: "get remote balance")
-        client?.eth_getBalance(address: account?.address ?? .zero, block: .Latest, completion: { (error, balance) in
+        client?.eth_getBalance(address: account?.address ?? .zero, block: .latest, completion: { (error, balance) in
             XCTAssertNotNil(balance, "Balance not available: \(error?.localizedDescription ?? "no error")")
             expectation.fulfill()
         })
@@ -63,7 +63,7 @@ class EthereumClientTests: XCTestCase {
     func testEthGetBalanceIncorrectAddress() {
         let expectation = XCTestExpectation(description: "get remote balance incorrect")
         
-        client?.eth_getBalance(address: EthereumAddress("0xnig42niog2"), block: .Latest, completion: { (error, balance) in
+        client?.eth_getBalance(address: EthereumAddress("0xnig42niog2"), block: .latest, completion: { (error, balance) in
             XCTAssertNotNil(error, "Balance error not available")
             expectation.fulfill()
         })
@@ -140,7 +140,7 @@ class EthereumClientTests: XCTestCase {
     func testEthGetTransactionCount() {
         let expectation = XCTestExpectation(description: "get transaction receipt")
         
-        client?.eth_getTransactionCount(address: account!.address, block: .Latest, completion: { (error, count) in
+        client?.eth_getTransactionCount(address: account!.address, block: .latest, completion: { (error, count) in
             XCTAssertNotNil(count, "Transaction count not available: \(error?.localizedDescription ?? "no error")")
             expectation.fulfill()
         })
@@ -151,7 +151,7 @@ class EthereumClientTests: XCTestCase {
     func testEthGetTransactionCountPending() {
         let expectation = XCTestExpectation(description: "get transaction receipt")
         
-        client?.eth_getTransactionCount(address: account!.address, block: .Pending, completion: { (error, count) in
+        client?.eth_getTransactionCount(address: account!.address, block: .pending, completion: { (error, count) in
             XCTAssertNotNil(count, "Transaction count not available: \(error?.localizedDescription ?? "no error")")
             expectation.fulfill()
         })
@@ -175,7 +175,7 @@ class EthereumClientTests: XCTestCase {
         let expectation = XCTestExpectation(description: "send raw transaction")
         
         let tx = EthereumTransaction(from: nil, to: EthereumAddress("0x3c1bd6b420448cf16a389c8b0115ccb3660bb854"), value: BigUInt(1800000), data: nil, nonce: 2, gasPrice: BigUInt(400000), gasLimit: BigUInt(50000), chainId: EthereumNetwork.Ropsten.intValue)
-        client?.eth_call(tx, block: .Latest, completion: { (error, txHash) in
+        client?.eth_call(tx, block: .latest, completion: { (error, txHash) in
             XCTAssertNotNil(txHash, "Transaction hash not available: \(error?.localizedDescription ?? "no error")")
             expectation.fulfill()
         })
@@ -186,7 +186,7 @@ class EthereumClientTests: XCTestCase {
     func testSimpleEthGetLogs() {
         let expectation = XCTestExpectation(description: "get logs")
         
-        client?.eth_getLogs(addresses: [EthereumAddress("0x23d0a442580c01e420270fba6ca836a8b2353acb")], topics: nil, fromBlock: .Earliest, toBlock: .Latest, completion: { (error, logs) in
+        client?.eth_getLogs(addresses: [EthereumAddress("0x23d0a442580c01e420270fba6ca836a8b2353acb")], topics: nil, fromBlock: .earliest, toBlock: .latest, completion: { (error, logs) in
             XCTAssertNotNil(logs, "Logs not available \(error?.localizedDescription ?? "no error")")
             expectation.fulfill()
         })
@@ -198,7 +198,7 @@ class EthereumClientTests: XCTestCase {
         let expectation = XCTestExpectation(description: "get logs")
 
         // Deposit/Withdrawal event to specific address
-        client?.eth_getLogs(addresses: nil, orTopics: [["0xe1fffcc4923d04b559f4d29a8bfc6cda04eb5b0d3c460751c2402c5c5cc9109c", "0x7fcf532c15f0a6db0bd6d0e038bea71d30d808c7d98cb3bf7268a95bf5081b65"], ["0x000000000000000000000000655ef694b98e55977a93259cb3b708560869a8f3"]], fromBlock: .Number(6540313), toBlock: .Number(6540397), completion: { (error, logs) in
+        client?.eth_getLogs(addresses: nil, orTopics: [["0xe1fffcc4923d04b559f4d29a8bfc6cda04eb5b0d3c460751c2402c5c5cc9109c", "0x7fcf532c15f0a6db0bd6d0e038bea71d30d808c7d98cb3bf7268a95bf5081b65"], ["0x000000000000000000000000655ef694b98e55977a93259cb3b708560869a8f3"]], fromBlock: .number(6540313), toBlock: .number(6540397), completion: { (error, logs) in
             XCTAssertEqual(logs?.count, 2)
             XCTAssertNotNil(logs, "Logs not available \(error?.localizedDescription ?? "no error")")
             expectation.fulfill()
@@ -210,12 +210,12 @@ class EthereumClientTests: XCTestCase {
     func testGivenGenesisBlock_ThenReturnsByNumber() {
         let expectation = XCTestExpectation(description: "get block by number")
         
-        client?.eth_getBlockByNumber(.Number(0)) { error, block in
+        client?.eth_getBlockByNumber(.number(0)) { error, block in
             XCTAssertNil(error)
             
             XCTAssertEqual(block?.timestamp.timeIntervalSince1970, 0)
             XCTAssertEqual(block?.transactions.count, 0)
-            XCTAssertEqual(block?.number, .Number(0))
+            XCTAssertEqual(block?.number, .number(0))
             expectation.fulfill()
         }
         
@@ -225,7 +225,7 @@ class EthereumClientTests: XCTestCase {
     func testGivenLatestBlock_ThenReturnsByNumber() {
         let expectation = XCTestExpectation(description: "get block by number")
         
-        client?.eth_getBlockByNumber(.Latest) { error, block in
+        client?.eth_getBlockByNumber(.latest) { error, block in
             XCTAssertNil(error)
             XCTAssertNotNil(block?.number.intValue)
             expectation.fulfill()
@@ -237,10 +237,10 @@ class EthereumClientTests: XCTestCase {
     func testGivenExistingBlock_ThenGetsBlockByNumber() {
         let expectation = XCTestExpectation(description: "get block by number")
         
-        client?.eth_getBlockByNumber(.Number(3415757)) { error, block in
+        client?.eth_getBlockByNumber(.number(3415757)) { error, block in
             XCTAssertNil(error)
             
-            XCTAssertEqual(block?.number, .Number(3415757))
+            XCTAssertEqual(block?.number, .number(3415757))
             XCTAssertEqual(block?.timestamp.timeIntervalSince1970, 1528711895)
             XCTAssertEqual(block?.transactions.count, 40)
             XCTAssertEqual(block?.transactions.first, "0x387867d052b3f89fb87937572891118aa704c1ba604c157bbd9c5a07f3a7e5cd")
@@ -253,7 +253,7 @@ class EthereumClientTests: XCTestCase {
     func testGivenUnexistingBlockNumber_ThenGetBlockByNumberReturnsError() {
         let expectation = XCTestExpectation(description: "get block by number")
         
-        client?.eth_getBlockByNumber(.Number(Int.max)) { error, block in
+        client?.eth_getBlockByNumber(.number(Int.max)) { error, block in
             XCTAssertNotNil(error)
             XCTAssertNil(block)
             expectation.fulfill()
@@ -273,7 +273,7 @@ class EthereumClientTests: XCTestCase {
             XCTAssertEqual(transaction?.gasPrice, BigUInt(hex: "0x9184e72a000"))
             XCTAssertEqual(transaction?.nonce, 973253)
             XCTAssertEqual(transaction?.value, BigUInt(hex: "0x56bc75e2d63100000"))
-            XCTAssertEqual(transaction?.blockNumber, EthereumBlock.Number(3439303))
+            XCTAssertEqual(transaction?.blockNumber, EthereumBlock.number(3439303))
             XCTAssertEqual(transaction?.hash?.web3.hexString, "0x014726c783ab2fd6828a9ca556850bccfc66f70926f411274eaf886385c704af")
             
             expectation.fulfill()
@@ -301,8 +301,8 @@ class EthereumClientTests: XCTestCase {
             
         client?.getEvents(addresses: nil,
                           topics: [try! ERC20Events.Transfer.signature(), nil, to.hexString, nil],
-                          fromBlock: .Earliest,
-                          toBlock: .Latest,
+                          fromBlock: .earliest,
+                          toBlock: .latest,
                           eventTypes: [ERC20Events.Transfer.self]) { (error, events, logs) in
             XCTAssertNil(error)
             XCTAssertEqual(events.count, 2)
@@ -320,8 +320,8 @@ class EthereumClientTests: XCTestCase {
         
         client?.getEvents(addresses: nil,
                           topics: [try! ERC20Events.Transfer.signature(), nil, to.hexString, nil],
-                          fromBlock: .Earliest,
-                          toBlock: .Latest,
+                          fromBlock: .earliest,
+                          toBlock: .latest,
                           eventTypes: [ERC20Events.Transfer.self, TransferMatchingSignatureEvent.self]) { (error, events, logs) in
                             XCTAssertNil(error)
                             XCTAssertEqual(events.count, 4)
@@ -342,8 +342,8 @@ class EthereumClientTests: XCTestCase {
         
         client?.getEvents(addresses: nil,
                           topics: [try! ERC20Events.Transfer.signature(), nil, to.hexString, nil],
-                          fromBlock: .Earliest,
-                          toBlock: .Latest,
+                          fromBlock: .earliest,
+                          toBlock: .latest,
                           matching: filters) { (error, events, logs) in
                             XCTAssertNil(error)
                             XCTAssertEqual(events.count, 1)
@@ -365,8 +365,8 @@ class EthereumClientTests: XCTestCase {
         
         client?.getEvents(addresses: nil,
                           topics: [try! ERC20Events.Transfer.signature(), nil, to.hexString, nil],
-                          fromBlock: .Earliest,
-                          toBlock: .Latest,
+                          fromBlock: .earliest,
+                          toBlock: .latest,
                           matching: filters) { (error, events, logs) in
                             XCTAssertNil(error)
                             XCTAssertEqual(events.count, 2)

--- a/web3sTests/Contract/ABIEventTests.swift
+++ b/web3sTests/Contract/ABIEventTests.swift
@@ -24,8 +24,8 @@ class ABIEventTests: XCTestCase {
         
         client.getEvents(addresses: nil,
                          topics: [try? EnabledStaticCall.signature(),  String(hexFromBytes: encodedAddress), nil],
-                         fromBlock: .Number(8386245),
-                         toBlock: .Number(8386245),
+                         fromBlock: .number(8386245),
+                         toBlock: .number(8386245),
                          eventTypes: [EnabledStaticCall.self]) { (error, events, logs) in
                             XCTAssertNil(error)
                             let event = events.first as? EnabledStaticCall
@@ -46,9 +46,9 @@ class ABIEventTests: XCTestCase {
         
         client.getEvents(addresses: nil,
                          topics: [try? UpgraderRegistered.signature()],
-                         fromBlock: .Number(
+                         fromBlock: .number(
                          8110676 ),
-                         toBlock: .Number(
+                         toBlock: .number(
                          8110676 ),
                          eventTypes: [UpgraderRegistered.self]) { (error, events, logs) in
                             XCTAssertNil(error)

--- a/web3sTests/ENS/ENSAsyncTests.swift
+++ b/web3sTests/ENS/ENSAsyncTests.swift
@@ -1,0 +1,153 @@
+//
+//  ENSTests.swift
+//  web3sTests
+//
+//  Created by Matt Marshall on 13/03/2018.
+//  Copyright © 2018 Argent Labs Limited. All rights reserved.
+//
+
+import XCTest
+@testable import web3
+
+class ENSAsyncTests: XCTestCase {
+    var account: EthereumAccount?
+    var client: EthereumClient!
+
+    override func setUp() {
+        super.setUp()
+        self.client = EthereumClient(url: URL(string: TestConfig.clientUrl)!)
+    }
+    
+    func testGivenName_ThenResolvesNameHash() {
+        let name = "argent.test"
+        let nameHash = EthereumNameService.nameHash(name: name)
+        XCTAssertEqual(nameHash, "0x3e58ef7a2e196baf0b9d36a65cc590ac9edafb3395b7cdeb8f39206049b4534c")
+    }
+    
+    func testGivenRopstenRegistry_WhenExistingDomainName_ResolvesOwnerAddressCorrectly() async throws {
+        let function = ENSContracts.ENSRegistryFunctions.owner(contract: ENSContracts.RopstenAddress, _node: EthereumNameService.nameHash(name: "test").web3.hexData ?? Data())
+        let tx = try function.transaction()
+        let dataStr = try await client!.eth_call(tx, block: .latest)
+        let owner = String(dataStr[dataStr.index(dataStr.endIndex, offsetBy: -40)...])
+        XCTAssertEqual(owner.web3.noHexPrefix,"09b5bd82f3351a4c8437fc6d7772a9e6cd5d25a1")
+    }
+    
+    func testGivenRopstenRegistry_WhenExistingAddress_ThenResolvesCorrectly() async throws {
+        let nameService = EthereumNameService(client: client!)
+        let ens = try await nameService.resolve(address: EthereumAddress("0xb0b874220ff95d62a676f58d186c832b3e6529c8"))
+        XCTAssertEqual("julien.argent.test", ens)
+    }
+    
+    func testGivenRopstenRegistry_WhenNotExistingAddress_ThenFailsCorrectly() async {
+        do {
+            let nameService = EthereumNameService(client: client!)
+            _ = try await nameService.resolve(address: EthereumAddress("0xb0b874220ff95d62a676f58d186c832b3e6529c9"))
+        } catch {
+            XCTAssertEqual(error as? EthereumNameServiceError, EthereumNameServiceError.ensUnknown)
+        }
+    }
+    
+    func testGivenCustomRegistry_WhenNotExistingAddress_ThenResolvesFailsCorrectly() async {
+        do {
+            let nameService = EthereumNameService(client: client!, registryAddress: EthereumAddress("0x7D7C04B7A05539a92541105806e0971E45969F85"))
+            _ = try await nameService.resolve(address: EthereumAddress("0xb0b874220ff95d62a676f58d186c832b3e6529c9"))
+        } catch {
+            XCTAssertEqual(error as? EthereumNameServiceError, EthereumNameServiceError.ensUnknown)
+        }
+    }
+    
+    func testGivenRopstenRegistry_WhenExistingENS_ThenResolvesAddressCorrectly() async throws {
+        let nameService = EthereumNameService(client: client!)
+        let ens = try await nameService.resolve(ens: "julien.argent.test")
+        XCTAssertEqual(EthereumAddress("0xb0b874220ff95d62a676f58d186c832b3e6529c8"), ens)
+    }
+    
+    func testGivenRopstenRegistry_WhenInvalidENS_ThenErrorsRequest() async {
+        do {
+            let nameService = EthereumNameService(client: client!)
+            _ = try await nameService.resolve(ens: "**somegarbage)_!!")
+        } catch {
+            XCTAssertEqual(error as? EthereumNameServiceError, EthereumNameServiceError.ensUnknown)
+        }
+    }
+    
+    func testGivenCustomRegistry_WhenInvalidENS_ThenErrorsRequest() async {
+        do {
+            let nameService = EthereumNameService(client: client!, registryAddress: EthereumAddress("0x7D7C04B7A05539a92541105806e0971E45969F85"))
+            _ = try await nameService.resolve(ens: "**somegarbage)_!!")
+        } catch {
+            XCTAssertEqual(error as? EthereumNameServiceError, EthereumNameServiceError.ensUnknown)
+        }
+    }
+
+    func testGivenRopstenRegistry_ThenResolvesMultipleAddressesInOneCall() async throws {
+        let nameService = EthereumNameService(client: client!)
+        let results = try await nameService.resolve(addresses: [
+            EthereumAddress("0xb0b874220ff95d62a676f58d186c832b3e6529c8"),
+            EthereumAddress("0x09b5bd82f3351a4c8437fc6d7772a9e6cd5d25a1"),
+            EthereumAddress("0x7e691d7ffb007abe91d8a24d7f22fc74307dab06")
+        ]).map { $0.output }
+
+        XCTAssertEqual(
+            results,
+            [
+                .resolved("julien.argent.test"),
+                .couldNotBeResolved(.ensUnknown),
+                .resolved("davidtests.argent.xyz")
+            ]
+        )
+    }
+//    
+    func testGivenRopstenRegistry_ThenResolvesMultipleAddressesInOneCall() {
+        let expect = expectation(description: "Get the ENS reverse lookup address")
+
+        let nameService = EthereumNameService(client: client!)
+
+        var results: [EthereumNameService.ResolveOutput<String>]?
+
+        nameService.resolve(addresses: [
+            EthereumAddress("0xb0b874220ff95d62a676f58d186c832b3e6529c8"),
+            EthereumAddress("0x09b5bd82f3351a4c8437fc6d7772a9e6cd5d25a1"),
+            EthereumAddress("0x7e691d7ffb007abe91d8a24d7f22fc74307dab06")
+
+        ]) { result in
+            switch result {
+            case .success(let resolutions):
+                results = resolutions.map { $0.output }
+            case .failure:
+                break
+            }
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: 5)
+
+        XCTAssertEqual(
+            results,
+            [
+                .resolved("julien.argent.test"),
+                .couldNotBeResolved(.ensUnknown),
+                .resolved("davidtests.argent.xyz")
+            ]
+        )
+    }
+
+    func testGivenRopstenRegistry_ThenResolvesMultipleNamesInOneCall() async throws {
+
+        let nameService = EthereumNameService(client: client!)
+        let results = try await nameService.resolve(names: [
+            "julien.argent.test",
+            "davidtests.argent.xyz",
+            "somefakeens.argent.xyz",
+        ]).map { $0.output }
+        
+        XCTAssertEqual(
+            results,
+            [
+                .resolved(EthereumAddress("0xb0b874220ff95d62a676f58d186c832b3e6529c8")),
+                .resolved(EthereumAddress("0x7e691d7ffb007abe91d8a24d7f22fc74307dab06")),
+                .couldNotBeResolved(.ensUnknown)
+            ]
+        )
+    }
+}

--- a/web3sTests/ENS/ENSTests.swift
+++ b/web3sTests/ENS/ENSTests.swift
@@ -32,7 +32,7 @@ class ENSTests: XCTestCase {
             
             let tx = try function.transaction()
             
-            client?.eth_call(tx, block: .Latest, completion: { (error, dataStr) in
+            client?.eth_call(tx, block: .latest, completion: { (error, dataStr) in
                 guard let dataStr = dataStr else {
                     XCTFail()
                     expect.fulfill()

--- a/web3sTests/ERC165/ERC165AsyncTests.swift
+++ b/web3sTests/ERC165/ERC165AsyncTests.swift
@@ -1,0 +1,51 @@
+//
+//  ERC165Tests.swift
+//  web3swift
+//
+//  Created by Miguel on 10/05/2019.
+//  Copyright © 2019 Argent Labs Limited. All rights reserved.
+//
+
+import XCTest
+import BigInt
+@testable import web3
+
+class ERC165Tests: XCTestCase {
+    var client: EthereumClient!
+    var erc165: ERC165!
+    let address = EthereumAddress(TestConfig.erc165Contract)
+    
+    override func setUp() {
+        super.setUp()
+        self.client = EthereumClient(url: URL(string: TestConfig.clientUrl)!)
+        self.erc165 = ERC165(client: client)
+    }
+    
+    func test_InterfaceIDMatch() {
+        XCTAssertEqual(ERC165Functions.interfaceId.web3.hexString, "0x01ffc9a7")
+    }
+    
+    func test_GivenInterfaceffff_returnsNotSupported() {
+        let expect = expectation(description: "Supports own interface")
+        erc165.supportsInterface(contract: address,
+                                 id: "0xffffffff".web3.hexData!) { (error, supported) in
+            XCTAssertNil(error)
+            XCTAssertEqual(supported, false)
+            expect.fulfill()
+        }
+        
+        waitForExpectations(timeout: 10)
+    }
+    
+    func test_GivenInterfaceERC165_returnsSupported() {
+        let expect = expectation(description: "Supports own interface")
+        erc165.supportsInterface(contract: address,
+                                 id: ERC165Functions.interfaceId) { (error, supported) in
+                                    XCTAssertNil(error)
+                                    XCTAssertEqual(supported, true)
+                                    expect.fulfill()
+        }
+        
+        waitForExpectations(timeout: 10)
+    }
+}

--- a/web3sTests/ERC165/ERC165Tests.swift
+++ b/web3sTests/ERC165/ERC165Tests.swift
@@ -10,7 +10,7 @@ import XCTest
 import BigInt
 @testable import web3
 
-class ERC165Tests: XCTestCase {
+class ERC165AsyncTests: XCTestCase {
     var client: EthereumClient!
     var erc165: ERC165!
     let address = EthereumAddress(TestConfig.erc165Contract)
@@ -25,27 +25,15 @@ class ERC165Tests: XCTestCase {
         XCTAssertEqual(ERC165Functions.interfaceId.web3.hexString, "0x01ffc9a7")
     }
     
-    func test_GivenInterfaceffff_returnsNotSupported() {
-        let expect = expectation(description: "Supports own interface")
-        erc165.supportsInterface(contract: address,
-                                 id: "0xffffffff".web3.hexData!) { (error, supported) in
-            XCTAssertNil(error)
-            XCTAssertEqual(supported, false)
-            expect.fulfill()
-        }
-        
-        waitForExpectations(timeout: 10)
+    func test_GivenInterfaceffff_returnsNotSupported() async throws {
+        let supported = try await erc165.supportsInterface(contract: address,
+                                 id: "0xffffffff".web3.hexData!)
+        XCTAssertEqual(supported, false)
     }
     
-    func test_GivenInterfaceERC165_returnsSupported() {
-        let expect = expectation(description: "Supports own interface")
-        erc165.supportsInterface(contract: address,
-                                 id: ERC165Functions.interfaceId) { (error, supported) in
-                                    XCTAssertNil(error)
-                                    XCTAssertEqual(supported, true)
-                                    expect.fulfill()
-        }
-        
-        waitForExpectations(timeout: 10)
+    func test_GivenInterfaceERC165_returnsSupported() async throws {
+        let supported = try await erc165.supportsInterface(contract: address,
+                                 id: ERC165Functions.interfaceId)
+        XCTAssertEqual(supported, true)
     }
 }

--- a/web3sTests/ERC20/ERC20AsyncTests.swift
+++ b/web3sTests/ERC20/ERC20AsyncTests.swift
@@ -1,0 +1,80 @@
+//
+//  ERC20Tests.swift
+//  web3swiftTests
+//
+//  Created by Matt Marshall on 13/04/2018.
+//  Copyright © 2018 Argent Labs Limited. All rights reserved.
+//
+
+import XCTest
+import BigInt
+@testable import web3
+
+class ERC20AsyncTests: XCTestCase {
+    var client: EthereumClient?
+    var erc20: ERC20?
+    let testContractAddress = EthereumAddress(TestConfig.erc20Contract)
+    
+    override func setUp() {
+        super.setUp()
+        self.client = EthereumClient(url: URL(string: TestConfig.clientUrl)!)
+        self.erc20 = ERC20(client: client!)
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    func testName() async throws {
+        let name = try await erc20!.name(tokenContract: self.testContractAddress)
+        XCTAssertEqual(name, "BokkyPooBah Test Token")
+    }
+    
+    func testNonZeroDecimals() async throws {
+        let decimals = try await erc20!.decimals(tokenContract: self.testContractAddress)
+        XCTAssertEqual(decimals, 18)
+    }
+    
+    func testZeroDecimals() async throws {
+        let decimals = try await erc20!.decimals(tokenContract: EthereumAddress("0x40dd3ac2481960cf34d96e647dd0bc52a1f03f52"))
+        XCTAssertEqual(decimals, 0)
+    }
+    
+    func testSymbol() async throws {
+        let symbol = try await erc20!.symbol(tokenContract: self.testContractAddress)
+        XCTAssertEqual(symbol, "BOKKY")
+    }
+    
+    func testTransferRawEvent() async throws {
+        let result = try! ABIEncoder.encode(EthereumAddress("0x72e3b687805ef66bf2a1e6d9f03faf8b33f0267a"))
+        let sig = try! ERC20Events.Transfer.signature()
+        let topics = [ sig, result.hexString]
+    
+        let (events, unprocessed) = try await self.client!.getEvents(addresses: nil, topics: topics, fromBlock: .earliest, toBlock: .latest, eventTypes: [ERC20Events.Transfer.self])
+        XCTAssert(events.count > 0)
+    }
+    
+    func testGivenAddressWithInTransfers_ThenGetsTheTransferEvents() async throws {
+        let events = try await erc20!.transferEventsTo(recipient: EthereumAddress("0x72e3b687805ef66bf2a1e6d9f03faf8b33f0267a"), fromBlock: .earliest, toBlock: .latest)
+        XCTAssert(events.count > 0)
+    }
+    
+    func testGivenAddressWithoutInTransfers_ThenGetsNoTransferEvents() async throws {
+        let events = try await erc20!.transferEventsTo(recipient: EthereumAddress("0x78eac6878f5ef99bf2b12698f03faf8b33f02676"), fromBlock: .earliest, toBlock: .latest)
+        XCTAssertEqual(events.count, 0)
+    }
+        
+    func testGivenAddressWithOutgoingEvents_ThenGetsTheTransferEvents() async throws {
+        let events = try await erc20!.transferEventsFrom(sender: EthereumAddress("0x2FB78FA9842f20bfD515A41C3196C4b368bDbC48"), fromBlock: .earliest, toBlock: .latest)
+        XCTAssertEqual(events.first?.log.transactionHash, "0xfb6e0d7fdf8f9b97fe9b634cb5abc7041ee47a396191f23425955f9fda008efe")
+        XCTAssertEqual(events.first?.to, EthereumAddress("0xFe325C1E3396b2285d517B0CE2E3ffA472260Bce"))
+        XCTAssertEqual(events.first?.value, BigUInt(10).power(18))
+        XCTAssertEqual(events.first?.log.address, EthereumAddress("0xdb0040451f373949a4be60dcd7b6b8d6e42658b6"))
+    }
+    
+    func testGivenAddressWithoutOutgoingEvents_ThenGetsTheTransferEvents() async throws {
+        let events = try await erc20!.transferEventsFrom(sender: EthereumAddress("0x78eac6878f5ef99bf2b12698f03faf8b33f02676"), fromBlock: .earliest, toBlock: .latest)
+        XCTAssertEqual(events.count, 0)
+    }
+    
+}

--- a/web3sTests/ERC20/ERC20Tests.swift
+++ b/web3sTests/ERC20/ERC20Tests.swift
@@ -72,7 +72,7 @@ class ERC20Tests: XCTestCase {
         let sig = try! ERC20Events.Transfer.signature()
         let topics = [ sig, result.hexString]
     
-        self.client?.getEvents(addresses: nil, topics: topics, fromBlock: .Earliest, toBlock: .Latest, eventTypes: [ERC20Events.Transfer.self], completion: { (error, events, unprocessed) in
+        self.client?.getEvents(addresses: nil, topics: topics, fromBlock: .earliest, toBlock: .latest, eventTypes: [ERC20Events.Transfer.self], completion: { (error, events, unprocessed) in
             XCTAssert(events.count > 0)
             expect.fulfill()
         })
@@ -82,7 +82,7 @@ class ERC20Tests: XCTestCase {
     func testGivenAddressWithInTransfers_ThenGetsTheTransferEvents() {
         let expect = expectation(description: "Get transfer events to")
         
-        erc20?.transferEventsTo(recipient: EthereumAddress("0x72e3b687805ef66bf2a1e6d9f03faf8b33f0267a"), fromBlock: .Earliest, toBlock: .Latest, completion: { (error, events) in
+        erc20?.transferEventsTo(recipient: EthereumAddress("0x72e3b687805ef66bf2a1e6d9f03faf8b33f0267a"), fromBlock: .earliest, toBlock: .latest, completion: { (error, events) in
             XCTAssert(events!.count > 0)
             expect.fulfill()
         })
@@ -93,7 +93,7 @@ class ERC20Tests: XCTestCase {
     func testGivenAddressWithoutInTransfers_ThenGetsNoTransferEvents() {
         let expect = expectation(description: "Get transfer events to")
         
-        erc20?.transferEventsTo(recipient: EthereumAddress("0x78eac6878f5ef99bf2b12698f03faf8b33f02676"), fromBlock: .Earliest, toBlock: .Latest, completion: { (error, events) in
+        erc20?.transferEventsTo(recipient: EthereumAddress("0x78eac6878f5ef99bf2b12698f03faf8b33f02676"), fromBlock: .earliest, toBlock: .latest, completion: { (error, events) in
             XCTAssertEqual(events?.count, 0)
             expect.fulfill()
         })
@@ -105,7 +105,7 @@ class ERC20Tests: XCTestCase {
     func testGivenAddressWithOutgoingEvents_ThenGetsTheTransferEvents() {
         let expect = expectation(description: "Get transfer events to")
         
-        erc20?.transferEventsFrom(sender: EthereumAddress("0x2FB78FA9842f20bfD515A41C3196C4b368bDbC48"), fromBlock: .Earliest, toBlock: .Latest, completion: { (error, events) in
+        erc20?.transferEventsFrom(sender: EthereumAddress("0x2FB78FA9842f20bfD515A41C3196C4b368bDbC48"), fromBlock: .earliest, toBlock: .latest, completion: { (error, events) in
             XCTAssertEqual(events?.first?.log.transactionHash, "0xfb6e0d7fdf8f9b97fe9b634cb5abc7041ee47a396191f23425955f9fda008efe")
             XCTAssertEqual(events?.first?.to, EthereumAddress("0xFe325C1E3396b2285d517B0CE2E3ffA472260Bce"))
             XCTAssertEqual(events?.first?.value, BigUInt(10).power(18))
@@ -119,7 +119,7 @@ class ERC20Tests: XCTestCase {
     func testGivenAddressWithoutOutgoingEvents_ThenGetsTheTransferEvents() {
         let expect = expectation(description: "Get transfer events to")
         
-        erc20?.transferEventsFrom(sender: EthereumAddress("0x78eac6878f5ef99bf2b12698f03faf8b33f02676"), fromBlock: .Earliest, toBlock: .Latest, completion: { (error, events) in
+        erc20?.transferEventsFrom(sender: EthereumAddress("0x78eac6878f5ef99bf2b12698f03faf8b33f02676"), fromBlock: .earliest, toBlock: .latest, completion: { (error, events) in
             XCTAssertEqual(events?.count, 0)
             expect.fulfill()
         })

--- a/web3sTests/ERC721/ERC721AsyncTests.swift
+++ b/web3sTests/ERC721/ERC721AsyncTests.swift
@@ -1,0 +1,147 @@
+//
+//  ERC721Tests.swift
+//  web3swift
+//
+//  Created by Miguel on 09/05/2019.
+//  Copyright © 2019 Argent Labs Limited. All rights reserved.
+//
+
+import XCTest
+import BigInt
+@testable import web3
+
+let tokenOwner = EthereumAddress("0x69F84b91E7107206E841748C2B52294A1176D45e")
+let previousOwner = EthereumAddress("0x64d0ea4fc60f27e74f1a70aa6f39d403bbe56793")
+let nonOwner = EthereumAddress("0x64d0eA4FC60f27E74f1a70Aa6f39D403bBe56792")
+let nftImageURL = URL(string: "https://ipfs.io/ipfs/QmUDJMmiJEsueLbr6jxh7vhSSFAvjfYTLC64hgkQm1vH2C/graph.svg")!
+let nftURL = URL(string: "https://ipfs.io/ipfs/QmUtKP7LnZnL2pWw2ERvNDndP9v5EPoJH7g566XNdgoRfE")!
+
+class ERC721AsyncTests: XCTestCase {
+    var client: EthereumClient!
+    var erc721: ERC721!
+    let address = EthereumAddress(TestConfig.erc721Contract)
+    
+    
+    override func setUp() {
+        super.setUp()
+        self.client = EthereumClient(url: URL(string: TestConfig.clientUrl)!)
+        self.erc721 = ERC721(client: client)
+    }
+    
+    func test_GivenAccountWithNFT_ThenBalanceCorrect() async throws {
+        let balance = try await erc721.balanceOf(contract: address, address: tokenOwner)
+        XCTAssertEqual(balance, BigUInt(3))
+    }
+    
+    func test_GivenAccountWithNOBalance_ThenBalanceCorrect() async throws {
+        let balance = try await erc721.balanceOf(contract: address, address: nonOwner)
+        XCTAssertEqual(balance, BigUInt(0))
+    }
+    
+    func test_GivenAccountWithNFT_ThenOwnerOfNFTIsAccount() async throws {
+        let balance = try await erc721.ownerOf(contract: address, tokenId: 23)
+        XCTAssertEqual(balance, tokenOwner)
+    }
+    
+    func test_GivenAccountWithNFT_ThenOwnerOfAnotherNFTIsNotAccount() async throws {
+        let balance = try await erc721.ownerOf(contract: address, tokenId: 22)
+        XCTAssertNotEqual(balance, tokenOwner)
+    }
+    
+    func test_GivenAddressWithTransfer_FindsInTransferEvent() async throws {
+        let events = try await erc721.transferEventsTo(recipient: tokenOwner,
+                                fromBlock: .number(6948276),
+                                toBlock: .number(6948276))
+
+        XCTAssertEqual(events.first?.from, previousOwner)
+        XCTAssertEqual(events.first?.to, tokenOwner)
+        XCTAssertEqual(events.first?.tokenId, 23)
+    }
+    
+    func test_GivenAddressWithTransfer_FindsOutTransferEvent() async throws {
+        let events = try await erc721.transferEventsFrom(sender: previousOwner,
+                                fromBlock: .number(6948276),
+                                toBlock: .number(6948276))
+        XCTAssertEqual(events.first?.to, tokenOwner)
+        XCTAssertEqual(events.first?.from, previousOwner)
+        XCTAssertEqual(events.first?.tokenId, 23)
+    }
+}
+
+class ERC721MetadataAsyncTests: XCTestCase {
+    var client: EthereumClient!
+    var erc721: ERC721Metadata!
+    let address = EthereumAddress(TestConfig.erc721Contract)
+    let nftDetails = ERC721Metadata.Token(title: "Asset Metadata",
+                                          type: "object",
+                                          properties: ERC721Metadata.Token.Properties(name: ERC721Metadata.Token.Property(description: "Random Graph Token"),
+                                                                                      description: ERC721Metadata.Token.Property(description: "NFT to represent Random Graph"),
+                                                                                      image:  ERC721Metadata.Token.Property(description: nftImageURL)))
+    
+    override func setUp() {
+        super.setUp()
+        self.client = EthereumClient(url: URL(string: TestConfig.clientUrl)!)
+        self.erc721 = ERC721Metadata(client: client, metadataSession: URLSession.shared)
+    }
+    
+    
+    func test_InterfaceIDMatch() {
+        XCTAssertEqual(ERC721MetadataFunctions.interfaceId.web3.hexString, "0x5b5e139f")
+    }
+    
+    func test_ReturnsName() async throws {
+        let name = try await erc721.name(contract: address)
+        XCTAssertEqual(name, "Graph Art Token")
+    }
+    
+    func test_ReturnsSymbol() async throws {
+        let symbol = try await erc721.symbol(contract: address)
+        XCTAssertEqual(symbol, "GAT")
+    }
+    
+    func test_ReturnsMetatadaURI() async throws {
+        let url = try await erc721.tokenURI(contract: address, tokenID: 23)
+        XCTAssertEqual(url, nftURL)
+    }
+    
+    func test_ReturnsMetatada() async throws {
+        let metadata = try await erc721.tokenMetadata(contract: address, tokenID: 23)
+        XCTAssertEqual(metadata, self.nftDetails)
+    }
+}
+
+class ERC721EnumerableAsyncTests: XCTestCase {
+    var client: EthereumClient!
+    var erc721: ERC721Enumerable!
+    let address = EthereumAddress(TestConfig.erc721Contract)
+    
+    override func setUp() {
+        super.setUp()
+        self.client = EthereumClient(url: URL(string: TestConfig.clientUrl)!)
+        self.erc721 = ERC721Enumerable(client: client)
+    }
+    
+    func test_InterfaceIDMatch() {
+        XCTAssertEqual(ERC721EnumerableFunctions.interfaceId.web3.hexString, "0x780e9d63")
+    }
+    
+    func test_returnsTotalSupply() async throws {
+        let supply = try await erc721.totalSupply(contract: address)
+        XCTAssertGreaterThan(supply, 22)
+    }
+    
+    func test_returnsTokenByIndex() async throws {
+        let index = try await erc721.tokenByIndex(contract: address, index: 22)
+        XCTAssertEqual(index, 23)
+    }
+    
+    func test_GivenAddressWithNFT_returnsTokenOfOwnerByIndex() async throws {
+        let tokenID = try await erc721.tokenOfOwnerByIndex(contract: address, owner: tokenOwner, index: 2)
+        XCTAssertEqual(tokenID, 23)
+    }
+    
+    func test_GivenAddressWithNoNFT_returnsIdZero() async throws {
+        let tokenID = try await erc721.tokenOfOwnerByIndex(contract: address, owner: nonOwner, index: 0)
+        XCTAssertEqual(tokenID, 0)
+    }
+}

--- a/web3sTests/ERC721/ERC721Tests.swift
+++ b/web3sTests/ERC721/ERC721Tests.swift
@@ -10,11 +10,12 @@ import XCTest
 import BigInt
 @testable import web3
 
-let tokenOwner = EthereumAddress("0x69F84b91E7107206E841748C2B52294A1176D45e")
-let previousOwner = EthereumAddress("0x64d0ea4fc60f27e74f1a70aa6f39d403bbe56793")
-let nonOwner = EthereumAddress("0x64d0eA4FC60f27E74f1a70Aa6f39D403bBe56792")
-let nftImageURL = URL(string: "https://ipfs.io/ipfs/QmUDJMmiJEsueLbr6jxh7vhSSFAvjfYTLC64hgkQm1vH2C/graph.svg")!
-let nftURL = URL(string: "https://ipfs.io/ipfs/QmUtKP7LnZnL2pWw2ERvNDndP9v5EPoJH7g566XNdgoRfE")!
+// Moved to ERC721AsyncTests
+//let tokenOwner = EthereumAddress("0x69F84b91E7107206E841748C2B52294A1176D45e")
+//let previousOwner = EthereumAddress("0x64d0ea4fc60f27e74f1a70aa6f39d403bbe56793")
+//let nonOwner = EthereumAddress("0x64d0eA4FC60f27E74f1a70Aa6f39D403bBe56792")
+//let nftImageURL = URL(string: "https://ipfs.io/ipfs/QmUDJMmiJEsueLbr6jxh7vhSSFAvjfYTLC64hgkQm1vH2C/graph.svg")!
+//let nftURL = URL(string: "https://ipfs.io/ipfs/QmUtKP7LnZnL2pWw2ERvNDndP9v5EPoJH7g566XNdgoRfE")!
 
 class ERC721Tests: XCTestCase {
     var client: EthereumClient!

--- a/web3sTests/ERC721/ERC721Tests.swift
+++ b/web3sTests/ERC721/ERC721Tests.swift
@@ -76,9 +76,9 @@ class ERC721Tests: XCTestCase {
         let expect = expectation(description: "Events")
         
         erc721.transferEventsTo(recipient: tokenOwner,
-                                fromBlock: .Number(
+                                fromBlock: .number(
                                     6948276),
-                                toBlock: .Number(
+                                toBlock: .number(
                                     6948276),
                                 completion: { (error, events) in
             XCTAssertEqual(events?.first?.from, previousOwner)
@@ -94,9 +94,9 @@ class ERC721Tests: XCTestCase {
         let expect = expectation(description: "Events")
         
         erc721.transferEventsFrom(sender: previousOwner,
-                                fromBlock: .Number(
+                                fromBlock: .number(
                                     6948276),
-                                toBlock: .Number(
+                                toBlock: .number(
                                     6948276),
                                 completion: { (error, events) in
             XCTAssertEqual(events?.first?.to, tokenOwner)

--- a/web3sTests/Multicall/MulticallTests.swift
+++ b/web3sTests/Multicall/MulticallTests.swift
@@ -59,4 +59,30 @@ class MulticallTests: XCTestCase {
         XCTAssertEqual(decimals, 18)
         XCTAssertEqual(name, "BokkyPooBah Test Token")
     }
+    
+    func testNameAndSymbolAsync() async throws {
+        var aggregator = Multicall.Aggregator()
+        
+        var name: String?
+        var decimals: UInt8?
+        
+        try aggregator.append(ERC20Functions.decimals(contract: testContractAddress)) { output in
+            decimals = try ERC20Responses.decimalsResponse(data: output.get())?.value
+        }
+        
+        try aggregator.append(
+            function: ERC20Functions.name(contract: testContractAddress),
+            response: ERC20Responses.nameResponse.self
+        ) { result in
+            name = try result.get()
+        }
+        
+        try aggregator.append(ERC20Functions.symbol(contract: testContractAddress))
+        let response = try await multicall.aggregate(calls: aggregator.calls)
+        let symbol = try ERC20Responses.symbolResponse(data: try response.outputs[2].get())?.value
+        
+        XCTAssertEqual(symbol, "BOKKY")
+        XCTAssertEqual(decimals, 18)
+        XCTAssertEqual(name, "BokkyPooBah Test Token")
+    }
 }

--- a/web3swift/src/Client/EthereumClient.swift
+++ b/web3swift/src/Client/EthereumClient.swift
@@ -122,7 +122,7 @@ public class EthereumClient: EthereumClientProtocol {
                 let result = try await net_version()
                 completion(nil, result)
             } catch {
-                completion(error as? EthereumClientError, nil)
+                completion(error as? EthereumClientError ?? EthereumClientError.unexpectedReturnValue, nil)
             }
         }
     }
@@ -143,7 +143,7 @@ public class EthereumClient: EthereumClientProtocol {
                 let result = try await eth_gasPrice()
                 completion(nil, result)
             } catch {
-                completion(error as? EthereumClientError, nil)
+                completion(error as? EthereumClientError ?? EthereumClientError.unexpectedReturnValue, nil)
             }
         }
     }
@@ -164,7 +164,7 @@ public class EthereumClient: EthereumClientProtocol {
                 let result = try await eth_blockNumber()
                 completion(nil, result)
             } catch {
-                completion(error as? EthereumClientError, nil)
+                completion(error as? EthereumClientError ?? EthereumClientError.unexpectedReturnValue, nil)
             }
         }
     }
@@ -188,7 +188,7 @@ public class EthereumClient: EthereumClientProtocol {
                 let result = try await eth_getBalance(address: address, block: block)
                 completion(nil, result)
             } catch {
-                completion(error as? EthereumClientError, nil)
+                completion(error as? EthereumClientError ?? EthereumClientError.unexpectedReturnValue, nil)
             }
         }
     }
@@ -208,7 +208,7 @@ public class EthereumClient: EthereumClientProtocol {
                 let result = try await eth_getCode(address: address, block: block)
                 completion(nil, result)
             } catch {
-                completion(error as? EthereumClientError, nil)
+                completion(error as? EthereumClientError ?? EthereumClientError.unexpectedReturnValue, nil)
             }
         }
     }
@@ -228,7 +228,7 @@ public class EthereumClient: EthereumClientProtocol {
                 let result = try await eth_estimateGas(transaction, withAccount: account)
                 completion(nil, result)
             } catch {
-                completion(error as? EthereumClientError, nil)
+                completion(error as? EthereumClientError ?? EthereumClientError.unexpectedReturnValue, nil)
             }
         }
     }
@@ -315,7 +315,7 @@ public class EthereumClient: EthereumClientProtocol {
                 let result = try await eth_sendRawTransaction(transaction, withAccount: account)
                 completion(nil, result)
             } catch {
-                completion(error as? EthereumClientError, nil)
+                completion(error as? EthereumClientError ?? EthereumClientError.unexpectedReturnValue, nil)
             }
         }
     }
@@ -352,7 +352,7 @@ public class EthereumClient: EthereumClientProtocol {
                 let result = try await eth_getTransactionCount(address: address, block: block)
                 completion(nil, result)
             } catch {
-                completion(error as? EthereumClientError, nil)
+                completion(error as? EthereumClientError ?? EthereumClientError.unexpectedReturnValue, nil)
             }
         }
     }
@@ -372,7 +372,7 @@ public class EthereumClient: EthereumClientProtocol {
                 let result = try await eth_getTransactionReceipt(txHash: txHash)
                 completion(nil, result)
             } catch {
-                completion(error as? EthereumClientError, nil)
+                completion(error as? EthereumClientError ?? EthereumClientError.unexpectedReturnValue, nil)
             }
         }
     }
@@ -393,7 +393,7 @@ public class EthereumClient: EthereumClientProtocol {
                 let result = try await eth_getTransaction(byHash: txHash)
                 completion(nil, result)
             } catch {
-                completion(error as? EthereumClientError, nil)
+                completion(error as? EthereumClientError ?? EthereumClientError.unexpectedReturnValue, nil)
             }
         }
     }
@@ -414,7 +414,7 @@ public class EthereumClient: EthereumClientProtocol {
                 let result = try await eth_call(transaction, block: block)
                 completion(nil, result)
             } catch {
-                completion(error as? EthereumClientError, nil)
+                completion(error as? EthereumClientError ?? EthereumClientError.unexpectedReturnValue, nil)
             }
         }
     }
@@ -480,7 +480,7 @@ public class EthereumClient: EthereumClientProtocol {
                 let result = try await eth_getLogs(addresses: addresses, topics: topics, fromBlock: from, toBlock: to)
                 completion(nil, result)
             } catch {
-                completion(error as? EthereumClientError, nil)
+                completion(error as? EthereumClientError ?? EthereumClientError.unexpectedReturnValue, nil)
             }
         }
     }
@@ -496,7 +496,7 @@ public class EthereumClient: EthereumClientProtocol {
                 let result = try await eth_getLogs(addresses: addresses, orTopics: topics, fromBlock: from, toBlock: to)
                 completion(nil, result)
             } catch {
-                completion(error as? EthereumClientError, nil)
+                completion(error as? EthereumClientError ?? EthereumClientError.unexpectedReturnValue, nil)
             }
         }
     }
@@ -513,7 +513,7 @@ public class EthereumClient: EthereumClientProtocol {
                 let result = try await eth_getLogs(addresses: addresses, topics: topics, fromBlock: from, toBlock: to)
                 completion(nil, result)
             } catch {
-                completion(error as? EthereumClientError, nil)
+                completion(error as? EthereumClientError ?? EthereumClientError.unexpectedReturnValue, nil)
             }
         }
     }
@@ -543,7 +543,7 @@ public class EthereumClient: EthereumClientProtocol {
                 let result = try await getLogs(addresses: addresses, topics: topics, fromBlock: fromBlock, toBlock: toBlock)
                 completion(.success(result))
             } catch {
-                completion(.failure(error as! EthereumClientError))
+                completion(.failure(error as? EthereumClientError ?? EthereumClientError.unexpectedReturnValue))
             }
         }
     }
@@ -584,7 +584,7 @@ public class EthereumClient: EthereumClientProtocol {
                 let result = try await eth_getBlockByNumber(block)
                 completion(nil, result)
             } catch {
-                completion(error as? EthereumClientError, nil)
+                completion(error as? EthereumClientError ?? EthereumClientError.unexpectedReturnValue, nil)
             }
         }
     }

--- a/web3swift/src/Client/JSONRPC.swift
+++ b/web3swift/src/Client/JSONRPC.swift
@@ -60,46 +60,57 @@ public class EthereumRPC {
         
     // Swift4 warning bug - https://bugs.swift.org/browse/SR-6265
    // static func execute<T: Encodable, U: Decodable>(session: URLSession, url: URL, method: String, params: T, receive: U.Type, id: Int = 1, completion: @escaping ((Error?, JSONRPCResult<U>?) -> Void)) -> Void {
+    @available(*, deprecated, message: "Prefer async alternative instead")
     public static func execute<T: Encodable, U: Decodable>(session: URLSession, url: URL, method: String, params: T, receive: U.Type, id: Int = 1, completion: @escaping ((Error?, Any?) -> Void)) -> Void {
+        async {
+            do {
+                let result: Any? = try await execute(session: session, url: url, method: method, params: params, receive: receive, id: id)
+                completion(nil, result)
+            } catch {
+                completion(error, nil)
+            }
+        }
+    }
+    
+    
+    public static func execute<T: Encodable, U: Decodable>(session: URLSession, url: URL, method: String, params: T, receive: U.Type, id: Int = 1) async throws -> Any {
         
         if type(of: params) == [Any].self {
             // If params are passed in with Array<Any> and not caught, runtime fatal error
-            completion(JSONRPCError.encodingError, nil)
-            return
+            throw JSONRPCError.encodingError
         }
-
+        
         var request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData)
         request.httpMethod = "POST"
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
         request.addValue("application/json", forHTTPHeaderField: "Accept")
         
         let rpcRequest = JSONRPCRequest(jsonrpc: "2.0", method: method, params: params, id: id)
-        guard let encoded = try? JSONEncoder().encode(rpcRequest) else {
-            completion(JSONRPCError.encodingError, nil)
-            return
-        }
+        let encoded = try JSONEncoder().encode(rpcRequest)
         request.httpBody = encoded
-        
-        let task = session.dataTask(with: request) { (data, response, error) in
-            if let data = data {
-                if let result = try? JSONDecoder().decode(JSONRPCResult<U>.self, from: data) {
-                    return completion(nil, result.result)
-                } else if let result = try? JSONDecoder().decode([JSONRPCResult<U>].self, from: data) {
-                    let resultObjects = result.map{ return $0.result }
-                    return completion(nil, resultObjects)
-                } else if let errorResult = try? JSONDecoder().decode(JSONRPCErrorResult.self, from: data) {
-                    print("Ethereum response error: \(errorResult.error)")
-                    return completion(JSONRPCError.executionError(errorResult), nil)
-                } else if let response = response as? HTTPURLResponse, response.statusCode < 200 || response.statusCode > 299 {
-                    return completion(JSONRPCError.requestRejected(data), nil)
-                } else {
-                    return completion(JSONRPCError.noResult, nil)
+                
+        return try await withCheckedThrowingContinuation { continuation in
+            let task = session.dataTask(with: request) { (data, response, error) in
+                if let data = data {
+                    if let result = try? JSONDecoder().decode(JSONRPCResult<U>.self, from: data) {
+                        return continuation.resume(returning: (result.result))
+                    } else if let result = try? JSONDecoder().decode([JSONRPCResult<U>].self, from: data) {
+                        let resultObjects = result.map{ return $0.result }
+                        return continuation.resume(returning: (resultObjects))
+                    } else if let errorResult = try? JSONDecoder().decode(JSONRPCErrorResult.self, from: data) {
+                        print("Ethereum response error: \(errorResult.error)")
+                        return continuation.resume(throwing: JSONRPCError.executionError(errorResult))
+                    } else if let response = response as? HTTPURLResponse, response.statusCode < 200 || response.statusCode > 299 {
+                        return continuation.resume(throwing: JSONRPCError.requestRejected(data))
+                    } else {
+                        return continuation.resume(throwing: JSONRPCError.noResult)
+                    }
                 }
+                
+                continuation.resume(throwing: JSONRPCError.unknownError)
             }
             
-            completion(JSONRPCError.unknownError, nil)
+            task.resume()
         }
-        
-        task.resume()
     }
 }

--- a/web3swift/src/Client/JSONRPC.swift
+++ b/web3swift/src/Client/JSONRPC.swift
@@ -72,7 +72,7 @@ public class EthereumRPC {
         }
     }
     
-    
+    // TODO: Instead of Any, can't we return U?
     public static func execute<T: Encodable, U: Decodable>(session: URLSession, url: URL, method: String, params: T, receive: U.Type, id: Int = 1) async throws -> Any {
         
         if type(of: params) == [Any].self {

--- a/web3swift/src/Client/Models/EthereumBlock.swift
+++ b/web3swift/src/Client/Models/EthereumBlock.swift
@@ -9,27 +9,27 @@
 import Foundation
 
 public enum EthereumBlock: Hashable {
-    case Latest
-    case Earliest
-    case Pending
-    case Number(Int)
+    case latest
+    case earliest
+    case pending
+    case number(Int)
     
     public var stringValue: String {
         switch self {
-        case .Latest:
+        case .latest:
             return "latest"
-        case .Earliest:
+        case .earliest:
             return "earliest"
-        case .Pending:
+        case .pending:
             return "pending"
-        case .Number(let int):
+        case .number(let int):
             return int.web3.hexString
         }
     }
     
     public var intValue: Int? {
         switch self {
-        case .Number(let int):
+        case .number(let int):
             return int
         default:
             return nil
@@ -37,18 +37,18 @@ public enum EthereumBlock: Hashable {
     }
     
     public init(rawValue: Int) {
-        self = .Number(rawValue)
+        self = .number(rawValue)
     }
     
     public init(rawValue: String) {
         if rawValue == "latest" {
-            self = .Latest
+            self = .latest
         } else if rawValue == "earliest" {
-            self = .Earliest
+            self = .earliest
         } else if rawValue == "pending" {
-            self = .Pending
+            self = .pending
         } else {
-            self = .Number(Int(hex: rawValue) ?? 0)
+            self = .number(Int(hex: rawValue) ?? 0)
         }
     }
 }
@@ -73,21 +73,21 @@ extension EthereumBlock: Comparable {
     
     static public func < (lhs: EthereumBlock, rhs: EthereumBlock) -> Bool {
         switch lhs {
-        case .Earliest:
+        case .earliest:
             return false
-        case .Latest:
-            return rhs != .Pending ? true : false
-        case .Pending:
+        case .latest:
+            return rhs != .pending ? true : false
+        case .pending:
             return true
-        case .Number(let lhsInt):
+        case .number(let lhsInt):
             switch rhs {
-            case .Earliest:
+            case .earliest:
                 return false
-            case .Latest:
+            case .latest:
                 return true
-            case .Pending:
+            case .pending:
                 return true
-            case .Number(let rhsInt):
+            case .number(let rhsInt):
                 return lhsInt < rhsInt
             }
         }

--- a/web3swift/src/Client/Models/EthereumLog.swift
+++ b/web3swift/src/Client/Models/EthereumLog.swift
@@ -60,7 +60,7 @@ extension EthereumLog: Codable {
         if let blockNumberString = try? values.decode(String.self, forKey: .blockNumber) {
             self.blockNumber = EthereumBlock(rawValue: blockNumberString)
         } else {
-            self.blockNumber = EthereumBlock.Earliest
+            self.blockNumber = EthereumBlock.earliest
         }
     }
     

--- a/web3swift/src/Contract/ABIEncoder.swift
+++ b/web3swift/src/Contract/ABIEncoder.swift
@@ -36,7 +36,7 @@ public class ABIEncoder {
             switch self {
             case .value(_, _, let staticLength):
                 return staticLength
-            case .container(let values, let isDynamic, let size):
+            case .container(let values, let isDynamic, _): // let size
                 if isDynamic {
                     return 32
                 } else {

--- a/web3swift/src/Contract/Statically Typed/EthereumClient+Static.swift
+++ b/web3swift/src/Contract/Statically Typed/EthereumClient+Static.swift
@@ -26,7 +26,7 @@ public extension ABIFunction {
         
     }
     
-    func call<T: ABIResponse>(withClient client: EthereumClientProtocol, responseType: T.Type, block: EthereumBlock = .Latest, completion: @escaping((EthereumClientError?, T?) -> Void)) {
+    func call<T: ABIResponse>(withClient client: EthereumClientProtocol, responseType: T.Type, block: EthereumBlock = .latest, completion: @escaping((EthereumClientError?, T?) -> Void)) {
         
         guard let tx = try? self.transaction() else {
             return completion(EthereumClientError.encodeIssue, nil)

--- a/web3swift/src/Contract/Statically Typed/EthereumClient+Static.swift
+++ b/web3swift/src/Contract/Statically Typed/EthereumClient+Static.swift
@@ -58,66 +58,122 @@ public struct EventFilter {
 }
 
 public extension EthereumClient {
+    
     typealias EventsCompletion = (EthereumClientError?, [ABIEvent], [EthereumLog]) -> Void
+    
+    @available(*, deprecated, message: "Prefer async alternative instead")
     func getEvents(addresses: [EthereumAddress]?,
                    orTopics: [[String]?]?,
                    fromBlock: EthereumBlock,
                    toBlock: EthereumBlock,
                    matching matches: [EventFilter],
                    completion: @escaping EventsCompletion) {
-        self.eth_getLogs(addresses: addresses, orTopics: orTopics, fromBlock: fromBlock, toBlock: toBlock) { [weak self] (error, logs) in
-            self?.handleLogs(error, logs, matches, completion)
+        async {
+            do {
+            let result = try await getEvents(addresses: addresses, orTopics: orTopics, fromBlock: fromBlock, toBlock: toBlock, matching: matches)
+                completion(nil, result.0, result.1)
+            } catch {
+                completion(error as? EthereumClientError, [], [])
+            }
         }
     }
     
+    
+    func getEvents(addresses: [EthereumAddress]?,
+                   orTopics: [[String]?]?,
+                   fromBlock: EthereumBlock,
+                   toBlock: EthereumBlock,
+                   matching matches: [EventFilter]) async throws -> ([ABIEvent], [EthereumLog]) {
+        
+        let logs = try await self.eth_getLogs(addresses: addresses, orTopics: orTopics, fromBlock: fromBlock, toBlock: toBlock)
+        return try await self.handleLogs(logs, matches)
+    }
+    
+    @available(*, deprecated, message: "Prefer async alternative instead")
     func getEvents(addresses: [EthereumAddress]?,
                    orTopics: [[String]?]?,
                    fromBlock: EthereumBlock,
                    toBlock: EthereumBlock,
                    eventTypes: [ABIEvent.Type],
                    completion: @escaping EventsCompletion) {
-        let unfiltered = eventTypes.map { EventFilter(type: $0, allowedSenders: []) }
-        self.eth_getLogs(addresses: addresses, orTopics: orTopics, fromBlock: fromBlock, toBlock: toBlock) { [weak self] (error, logs) in
-            self?.handleLogs(error, logs, unfiltered, completion)
+        async {
+            do {
+                let result = try await getEvents(addresses: addresses, orTopics: orTopics, fromBlock: fromBlock, toBlock: toBlock, eventTypes: eventTypes)
+                completion(nil, result.0, result.1)
+            } catch {
+                completion(error as? EthereumClientError, [], [])
+            }
         }
+    }
+    
+    
+    func getEvents(addresses: [EthereumAddress]?,
+                   orTopics: [[String]?]?,
+                   fromBlock: EthereumBlock,
+                   toBlock: EthereumBlock,
+                   eventTypes: [ABIEvent.Type]) async throws -> ([ABIEvent], [EthereumLog]) {
+        let unfiltered = eventTypes.map { EventFilter(type: $0, allowedSenders: []) }
+        let logs = try await self.eth_getLogs(addresses: addresses, orTopics: orTopics, fromBlock: fromBlock, toBlock: toBlock)
+        return try await self.handleLogs(logs, unfiltered)
     }
 
+    @available(*, deprecated, message: "Prefer async alternative instead")
     func getEvents(addresses: [EthereumAddress]?,
                    topics: [String?]?,
                    fromBlock: EthereumBlock,
                    toBlock: EthereumBlock,
                    eventTypes: [ABIEvent.Type],
                    completion: @escaping EventsCompletion) {
-        let unfiltered = eventTypes.map { EventFilter(type: $0, allowedSenders: []) }
-        getEvents(addresses: addresses,
-                  topics: topics,
-                  fromBlock: fromBlock,
-                  toBlock: toBlock,
-                  matching: unfiltered,
-                  completion: completion)
+        async {
+            do {
+                let result = try await getEvents(addresses: addresses, topics: topics, fromBlock: fromBlock, toBlock: toBlock, eventTypes: eventTypes)
+                completion(nil, result.0, result.1)
+            } catch {
+                completion(error as? EthereumClientError, [], [])
+            }
+        }
     }
     
     func getEvents(addresses: [EthereumAddress]?,
                    topics: [String?]?,
                    fromBlock: EthereumBlock,
                    toBlock: EthereumBlock,
+                   eventTypes: [ABIEvent.Type]) async throws -> ([ABIEvent], [EthereumLog]) {
+        let unfiltered = eventTypes.map { EventFilter(type: $0, allowedSenders: []) }
+        return try await getEvents(addresses: addresses, topics: topics, fromBlock: fromBlock, toBlock: toBlock, matching: unfiltered)
+    }
+    
+    @available(*, deprecated, message: "Prefer async alternative instead")
+    func getEvents(addresses: [EthereumAddress]?,
+                   topics: [String?]?,
+                   fromBlock: EthereumBlock,
+                   toBlock: EthereumBlock,
                    matching matches: [EventFilter],
                    completion: @escaping EventsCompletion) {
-        
-        self.eth_getLogs(addresses: addresses, topics: topics, fromBlock: fromBlock, toBlock: toBlock) { [weak self] (error, logs) in
-            self?.handleLogs(error, logs, matches, completion)
+        async {
+            do {
+                let result = try await getEvents(addresses: addresses, topics: topics, fromBlock: fromBlock, toBlock: toBlock, matching: matches)
+                completion(nil, result.0, result.1)
+            } catch {
+                completion(error as? EthereumClientError, [], [])
+            }
         }
     }
+    
+    func getEvents(addresses: [EthereumAddress]?,
+                   topics: [String?]?,
+                   fromBlock: EthereumBlock,
+                   toBlock: EthereumBlock,
+                   matching matches: [EventFilter]) async throws -> ([ABIEvent], [EthereumLog]) {
         
-    private func handleLogs(_ error: EthereumClientError?,
-                            _ logs: [EthereumLog]?,
-                            _ matches: [EventFilter],
-                            _ completion: EventsCompletion) {
-        if let error = error {
-            return completion(error, [], [])
-        }
+        let logs = try await self.eth_getLogs(addresses: addresses, topics: topics, fromBlock: fromBlock, toBlock: toBlock)
+        return try await handleLogs(logs, matches)
+    }
         
-        guard let logs = logs else { return completion(nil, [], []) }
+    private func handleLogs(_ logs: [EthereumLog]?,
+                            _ matches: [EventFilter]) async throws -> ([ABIEvent], [EthereumLog]) {
+        
+        guard let logs1 = logs else { return ([], []) }
         
         var events: [ABIEvent] = []
         var unprocessed: [EthereumLog] = []
@@ -131,7 +187,7 @@ public extension EthereumClient {
             }
         }
         
-        let parseEvent: (EthereumLog, ABIEvent.Type) -> ABIEvent? = { log, eventType in
+        let parseEvent: (EthereumLog, ABIEvent.Type) throws -> ABIEvent = { log, eventType in
             let topicTypes = eventType.types.enumerated()
                 .filter { eventType.typesIndexed[$0.offset] == true }
                 .compactMap { $0.element }
@@ -140,41 +196,38 @@ public extension EthereumClient {
                 .filter { eventType.typesIndexed[$0.offset] == false }
                 .compactMap { $0.element }
             
-            guard let data = try? ABIDecoder.decodeData(log.data, types: dataTypes, asArray: true) else {
-                return nil
-            }
+            let data = try ABIDecoder.decodeData(log.data, types: dataTypes, asArray: true)
             
             guard data.count == dataTypes.count else {
-                return nil
+                throw EthereumClientError.unexpectedReturnValue
             }
             
             let rawTopics = Array(log.topics.dropFirst())
             
-            guard let parsedTopics = (try? zip(rawTopics, topicTypes).map { pair in
+            let parsedTopics = try zip(rawTopics, topicTypes).map { pair in
                 try ABIDecoder.decodeData(pair.0, types: [pair.1])
-                }) else {
-                    return nil
             }
             
-            guard let eventOpt = ((try? eventType.init(topics: parsedTopics.flatMap { $0 }, data: data, log: log)) as ABIEvent??), let event = eventOpt else {
-                return nil
+            let eventOpt = try eventType.init(topics: parsedTopics.flatMap { $0 }, data: data, log: log) // as ABIEvent??)
+            guard let event = eventOpt else {
+                throw EthereumClientError.unexpectedReturnValue
             }
             
             return event
         }
         
-        for log in logs {
+        for log in logs1 {
             guard let signature = log.topics.first,
-                let filters = filtersBySignature[signature] else {
-                    unprocessed.append(log)
-                    continue
-            }
+                  let filters = filtersBySignature[signature] else {
+                      unprocessed.append(log)
+                      continue
+                  }
             
             for filter in filters {
                 let allowedSenders = Set(filter.allowedSenders)
                 if allowedSenders.count > 0 && !allowedSenders.contains(log.address) {
                     unprocessed.append(log)
-                } else if let event = parseEvent(log, filter.type) {
+                } else if let event = try? parseEvent(log, filter.type) {
                     events.append(event)
                 } else {
                     unprocessed.append(log)
@@ -182,6 +235,6 @@ public extension EthereumClient {
             }
         }
         
-        return completion(error, events, unprocessed)
+        return (events, unprocessed)
     }
 }

--- a/web3swift/src/ENS/ENSMultiResolver.swift
+++ b/web3swift/src/ENS/ENSMultiResolver.swift
@@ -284,12 +284,8 @@ extension EthereumNameService {
                     }
                 }
                 
-//                do {
-                    let result = try await multicall.aggregate(calls: aggegator.calls)
-                    return registryOutput.intermediaryResponses.compactMap { $0 }
-//                } catch {
-//                    throw .noNetwork
-//                }
+                let result = try await multicall.aggregate(calls: aggegator.calls)
+                return registryOutput.intermediaryResponses.compactMap { $0 }
             }
 
         private func resolveAddress(

--- a/web3swift/src/ENS/EthereumNameService.swift
+++ b/web3swift/src/ENS/EthereumNameService.swift
@@ -127,46 +127,6 @@ public class EthereumNameService: EthereumNameServiceProtocol {
             throw EthereumNameServiceError.decodeIssue
         }
         return ensAddress
-        
-//        let ensAddress: EthereumAddress = try? (try? ABIDecoder.decodeData(data1, types: [EthereumAddress.self]))?.first?.decoded() {
-//            continuation.resume(returning: (nil, ensAddress))
-//        } else {
-//            continuation.resume(returning: (EthereumNameServiceError.decodeIssue, nil))
-//        }
-//
-//
-//        return await withCheckedContinuation { continuation in
-//            client.eth_call(registryTransaction, block: .latest, completion: { (error, resolverData) in
-//                guard let resolverData1 = resolverData else {
-//                    return continuation.resume(returning: (EthereumNameServiceError.noResolver, nil))
-//                }
-//
-//                guard resolverData1 != "0x" else {
-//                    return continuation.resume(returning: (EthereumNameServiceError.ensUnknown, nil))
-//                }
-//
-//                let idx = resolverData1.index(resolverData1.endIndex, offsetBy: -40)
-//                let resolverAddress = EthereumAddress(String(resolverData1[idx...]).web3.withHexPrefix)
-//
-//                let function = ENSContracts.ENSResolverFunctions.addr(contract: resolverAddress, _node: nameHash1.web3.hexData ?? Data())
-//                guard let addressTransaction = try? function.transaction() else {
-//                    continuation.resume(returning: (EthereumNameServiceError.invalidInput, nil))
-//                    return
-//                }
-//                // till here
-//                self.client.eth_call(addressTransaction, block: .latest, completion: { (error, data) in
-//                    guard let data1 = data, data1 != "0x" else {
-//                        return continuation.resume(returning: (EthereumNameServiceError.ensUnknown, nil))
-//                    }
-//
-//                    if let ensAddress: EthereumAddress = try? (try? ABIDecoder.decodeData(data1, types: [EthereumAddress.self]))?.first?.decoded() {
-//                        continuation.resume(returning: (nil, ensAddress))
-//                    } else {
-//                        continuation.resume(returning: (EthereumNameServiceError.decodeIssue, nil))
-//                    }
-//                })
-//            })
-//        }
     }
 
     static func nameHash(name: String) -> String {

--- a/web3swift/src/ENS/EthereumNameService.swift
+++ b/web3swift/src/ENS/EthereumNameService.swift
@@ -49,7 +49,7 @@ public class EthereumNameService: EthereumNameServiceProtocol {
             return
         }
 
-        client.eth_call(registryTransaction, block: .Latest, completion: { (error, resolverData) in
+        client.eth_call(registryTransaction, block: .latest, completion: { (error, resolverData) in
             guard let resolverData = resolverData else {
                 return completion(EthereumNameServiceError.noResolver, nil)
             }
@@ -68,7 +68,7 @@ public class EthereumNameService: EthereumNameServiceProtocol {
                 return
             }
             
-            self.client.eth_call(addressTransaction, block: .Latest, completion: { (error, data) in
+            self.client.eth_call(addressTransaction, block: .latest, completion: { (error, data) in
                 guard let data = data, data != "0x" else {
                     return completion(EthereumNameServiceError.ensUnknown, nil)
                 }
@@ -98,7 +98,7 @@ public class EthereumNameService: EthereumNameServiceProtocol {
             return
         }
 
-        client.eth_call(registryTransaction, block: .Latest, completion: { (error, resolverData) in
+        client.eth_call(registryTransaction, block: .latest, completion: { (error, resolverData) in
             guard let resolverData = resolverData else {
                 return completion(EthereumNameServiceError.noResolver, nil)
             }
@@ -116,7 +116,7 @@ public class EthereumNameService: EthereumNameServiceProtocol {
                 return
             }
             
-            self.client.eth_call(addressTransaction, block: .Latest, completion: { (error, data) in
+            self.client.eth_call(addressTransaction, block: .latest, completion: { (error, data) in
                 guard let data = data, data != "0x" else {
                     return completion(EthereumNameServiceError.ensUnknown, nil)
                 }

--- a/web3swift/src/ERC165/ERC165.swift
+++ b/web3swift/src/ERC165/ERC165.swift
@@ -15,14 +15,24 @@ public class ERC165 {
         self.client = client
     }
     
+    @available(*, deprecated, message: "Prefer async alternative instead")
     public func supportsInterface(contract: EthereumAddress,
                                   id: Data,
                                   completion: @escaping((Error?, Bool?) -> Void)) {
-        let function = ERC165Functions.supportsInterface(contract: contract, interfaceId: id)
-        function.call(withClient: self.client,
-                      responseType: ERC165Responses.supportsInterfaceResponse.self) { (error, response) in
-            return completion(error, response?.supported)
+        async {
+            do {
+                let result = try await supportsInterface(contract: contract, id: id)
+                completion(nil, result)
+            } catch {
+                completion(error, nil)
+            }
         }
+    }
+    
+    public func supportsInterface(contract: EthereumAddress, id: Data) async throws -> Bool {
+        let function = ERC165Functions.supportsInterface(contract: contract, interfaceId: id)
+        let response = try await function.call(withClient: self.client, responseType: ERC165Responses.supportsInterfaceResponse.self)
+        return response.supported
     }
 
 }

--- a/web3swift/src/ERC20/ERC20.swift
+++ b/web3swift/src/ERC20/ERC20.swift
@@ -16,97 +16,165 @@ public class ERC20 {
         self.client = client
     }
         
+    @available(*, deprecated, message: "Prefer async alternative instead")
     public func name(tokenContract: EthereumAddress,
                      completion: @escaping((Error?, String?) -> Void)) {
-        let function = ERC20Functions.name(contract: tokenContract)
-        function.call(withClient: self.client, responseType: ERC20Responses.nameResponse.self) { (error, nameResponse) in
-            return completion(error, nameResponse?.value)
+        async {
+            do {
+                let result = try await name(tokenContract: tokenContract)
+                completion(nil, result)
+            } catch {
+                completion(error, nil)
+            }
         }
     }
     
+    public func name(tokenContract: EthereumAddress) async throws -> String {
+        let function = ERC20Functions.name(contract: tokenContract)
+        let nameResponse = try await function.call(withClient: self.client, responseType: ERC20Responses.nameResponse.self)
+        return nameResponse.value
+    }
+    
+    @available(*, deprecated, message: "Prefer async alternative instead")
     public func symbol(tokenContract: EthereumAddress,
                        completion: @escaping((Error?, String?) -> Void)) {
-        let function = ERC20Functions.symbol(contract: tokenContract)
-        function.call(withClient: self.client, responseType: ERC20Responses.symbolResponse.self) { (error, symbolResponse) in
-            return completion(error, symbolResponse?.value)
+        async {
+            do {
+                let result = try await symbol(tokenContract: tokenContract)
+                completion(nil, result)
+            } catch {
+                completion(error, nil)
+            }
         }
     }
     
+    public func symbol(tokenContract: EthereumAddress) async throws -> String {
+        let function = ERC20Functions.symbol(contract: tokenContract)
+        let symbolResponse = try await function.call(withClient: self.client, responseType: ERC20Responses.symbolResponse.self)
+        return symbolResponse.value
+    }
+    
+    @available(*, deprecated, message: "Prefer async alternative instead")
     public func decimals(tokenContract: EthereumAddress,
                          completion: @escaping((Error?, UInt8?) -> Void)) {
+        async {
+            do {
+                let result = try await decimals(tokenContract: tokenContract)
+                completion(nil, result)
+            } catch {
+                completion(error, nil)
+            }
+        }
+    }
+    
+    public func decimals(tokenContract: EthereumAddress) async throws -> UInt8? {
         let function = ERC20Functions.decimals(contract: tokenContract)
-        function.call(withClient: self.client, responseType: ERC20Responses.decimalsResponse.self) { (error, decimalsResponse) in
-            return completion(error, decimalsResponse?.value)
+        let decimalsResponse = try await function.call(withClient: self.client, responseType: ERC20Responses.decimalsResponse.self)
+        return decimalsResponse.value
+    }
+    
+    @available(*, deprecated, message: "Prefer async alternative instead")
+    public func balanceOf(tokenContract: EthereumAddress,
+                          address: EthereumAddress,
+                          completion: @escaping((Error?, BigUInt?) -> Void)) {
+        async {
+            do {
+                let result = try await balanceOf(tokenContract: tokenContract, address: address)
+                completion(nil, result)
+            } catch {
+                completion(error, nil)
+            }
         }
     }
     
     public func balanceOf(tokenContract: EthereumAddress,
-                          address: EthereumAddress,
-                          completion: @escaping((Error?, BigUInt?) -> Void)) {
+                          address: EthereumAddress) async throws -> BigUInt {
         let function = ERC20Functions.balanceOf(contract: tokenContract, account: address)
-        function.call(withClient: self.client, responseType: ERC20Responses.balanceResponse.self) { (error, balanceResponse) in
-            return completion(error, balanceResponse?.value)
+        let balanceResponse = try await function.call(withClient: self.client, responseType: ERC20Responses.balanceResponse.self)
+        return balanceResponse.value
+    }
+    
+    @available(*, deprecated, message: "Prefer async alternative instead")
+    public func allowance(tokenContract: EthereumAddress,
+                          address: EthereumAddress,
+                          spender: EthereumAddress,
+                          completion: @escaping((Error?, BigUInt?) -> Void)) {
+        async {
+            do {
+                let result = try await allowance(tokenContract: tokenContract, address: address, spender: spender)
+                completion(nil, result)
+            } catch {
+                completion(error, nil)
+            }
         }
     }
     
     public func allowance(tokenContract: EthereumAddress,
                           address: EthereumAddress,
-                          spender: EthereumAddress,
-                          completion: @escaping((Error?, BigUInt?) -> Void)) {
+                          spender: EthereumAddress) async throws -> BigUInt {
         let function = ERC20Functions.allowance(contract: tokenContract, owner: address, spender: spender)
-        function.call(withClient: self.client, responseType: ERC20Responses.balanceResponse.self) { (error, balanceResponse) in
-            return completion(error, balanceResponse?.value)
-        }
+        let balanceResponse = try await function.call(withClient: self.client, responseType: ERC20Responses.balanceResponse.self)
+        return balanceResponse.value
     }
     
+    @available(*, deprecated, message: "Prefer async alternative instead")
     public func transferEventsTo(recipient: EthereumAddress,
                                  fromBlock: EthereumBlock,
                                  toBlock: EthereumBlock,
                                  completion: @escaping((Error?, [ERC20Events.Transfer]?) -> Void)) {
-        
-        guard let result = try? ABIEncoder.encode(recipient).bytes, let sig = try? ERC20Events.Transfer.signature() else {
-            completion(EthereumSignerError.unknownError, nil)
-            return
-        }
-        
-        self.client.getEvents(addresses: nil,
-                              topics: [ sig, nil, String(hexFromBytes: result)],
-                              fromBlock: fromBlock,
-                              toBlock: toBlock,
-                              eventTypes: [ERC20Events.Transfer.self]) { (error, events, unprocessedLogs) in
-            
-            if let events = events as? [ERC20Events.Transfer] {
-                return completion(error, events)
-            } else {
-                return completion(error ?? EthereumClientError.decodeIssue, nil)
+        async {
+            do {
+                let result = try await transferEventsTo(recipient: recipient, fromBlock: fromBlock, toBlock: toBlock)
+                completion(nil, result)
+            } catch {
+                completion(error, nil)
             }
-            
         }
     }
     
+    
+    public func transferEventsTo(recipient: EthereumAddress,
+                                 fromBlock: EthereumBlock = .earliest,
+                                 toBlock: EthereumBlock = .latest) async throws -> [ERC20Events.Transfer] {
+        
+        let result = try ABIEncoder.encode(recipient).bytes
+        let sig = try ERC20Events.Transfer.signature()
+                
+        let (events, _) = try await self.client.getEvents(addresses: nil, topics: [ sig, nil, String(hexFromBytes: result)], fromBlock: fromBlock, toBlock: toBlock, eventTypes: [ERC20Events.Transfer.self])
+        guard let events = events as? [ERC20Events.Transfer] else {
+            throw EthereumClientError.decodeIssue
+        }
+        return events
+    }
+    
+    @available(*, deprecated, message: "Prefer async alternative instead")
     public func transferEventsFrom(sender: EthereumAddress,
                                    fromBlock: EthereumBlock,
                                    toBlock: EthereumBlock,
                                    completion: @escaping((Error?, [ERC20Events.Transfer]?) -> Void)) {
-        
-        guard let result = try? ABIEncoder.encode(sender).bytes, let sig = try? ERC20Events.Transfer.signature() else {
-            completion(EthereumSignerError.unknownError, nil)
-            return
-        }
-        
-        self.client.getEvents(addresses: nil,
-                              topics: [ sig, String(hexFromBytes: result), nil ],
-                              fromBlock: fromBlock,
-                              toBlock: toBlock,
-                              eventTypes: [ERC20Events.Transfer.self]) { (error, events, unprocessedLogs) in
-            
-            if let events = events as? [ERC20Events.Transfer] {
-                return completion(error, events)
-            } else {
-                return completion(error ?? EthereumClientError.decodeIssue, nil)
+        async {
+            do {
+                let result = try await transferEventsFrom(sender: sender, fromBlock: fromBlock, toBlock: toBlock)
+                completion(nil, result)
+            } catch {
+                completion(error, nil)
             }
-            
         }
+    }    
+    
+    public func transferEventsFrom(sender: EthereumAddress,
+                                   fromBlock: EthereumBlock = .earliest,
+                                   toBlock: EthereumBlock = .latest) async throws -> [ERC20Events.Transfer] {
+        
+        let result = try ABIEncoder.encode(sender).bytes
+        let sig = try ERC20Events.Transfer.signature()
+        
+        let (events, unprocessedLogs) = try await self.client.getEvents(addresses: nil, topics: [ sig, String(hexFromBytes: result), nil ], fromBlock: fromBlock, toBlock: toBlock, eventTypes: [ERC20Events.Transfer.self])
+        
+        guard let events = events as? [ERC20Events.Transfer] else {
+            throw EthereumClientError.decodeIssue
+        }
+        return events
     }
 
 }

--- a/web3swift/src/ERC20/ERC20.swift
+++ b/web3swift/src/ERC20/ERC20.swift
@@ -169,7 +169,7 @@ public class ERC20 {
         let result = try ABIEncoder.encode(sender).bytes
         let sig = try ERC20Events.Transfer.signature()
         
-        let (events, unprocessedLogs) = try await self.client.getEvents(addresses: nil, topics: [ sig, String(hexFromBytes: result), nil ], fromBlock: fromBlock, toBlock: toBlock, eventTypes: [ERC20Events.Transfer.self])
+        let (events, _) = try await self.client.getEvents(addresses: nil, topics: [ sig, String(hexFromBytes: result), nil ], fromBlock: fromBlock, toBlock: toBlock, eventTypes: [ERC20Events.Transfer.self])
         
         guard let events = events as? [ERC20Events.Transfer] else {
             throw EthereumClientError.decodeIssue


### PR DESCRIPTION
I took a stab at solving issue #147. The current request has some backward compatibility issues others may want to look at before merging.

All original closure-based methods are still present, but marked deprecated. The closure-based methods call the new async version of the method. However, the async versions handle errors differently than the closure-based methods, which might result in unexpected behavior when calling the closure-based methods. The async version might also throw different errors than closure-based equivalent.

For simplicity's sake I pass errors from the lowest layer up to the next (throws in async methods aren't typecasted anyway), but that is not how the current web3 library works. In the current closure-based version, every layer in the library currently has its own Error enum, and errors get converted as an errors bubble up the stack. For example a JSONRPCError.decodingError could convert to an EthereumClientError.decodeIssue and then an EthereumNameServiceError.decodeIssue. 

In current pull-request, it is possible that some closure-based methods default to a generic decodeIssue  error. The async version always pass the lowest level error. So in the example above, the closure-based method could return EthereumNameServiceError.decodeIssue while the async version will return JSONRPCError.decodingError.

Unless it matters to the end-user where in the stack the decoding error occurred, I think it might make sense to use a single Error enum in the library, e.g. Web3Error. It would make error conversions much simpler. Looking for feedback.

There are additional optimizations possible in the aggregators that are not in the pull request. A refactor using async let will run multiple fetches concurrently and will greatly simplify the code.

I've also replaced a two fatalError() calls with throwing errors. If the fatalErrors were there for a reason, I suggest to add an assertionFailure() before the throw to avoid crashes in the release build.