### PR TITLE
fix: add inhertied to pod_target_xcconfig

### DIFF
--- a/web3.swift.podspec
+++ b/web3.swift.podspec
@@ -13,8 +13,8 @@ Pod::Spec.new do |s|
 
   s.source_files = 'web3swift/src/**/*.swift', 'web3swift/lib/**/*.{c,h}'
   s.pod_target_xcconfig = {
-    'SWIFT_INCLUDE_PATHS[sdk=iphonesimulator*]' => '$(PODS_TARGET_SRCROOT)/web3swift/lib/**',
-    'SWIFT_INCLUDE_PATHS[sdk=iphoneos*]' => '$(PODS_TARGET_SRCROOT)/web3swift/lib/**'
+    'SWIFT_INCLUDE_PATHS[sdk=iphonesimulator*]' => '$(inherited) $(PODS_TARGET_SRCROOT)/web3swift/lib/**',
+    'SWIFT_INCLUDE_PATHS[sdk=iphoneos*]' => '$(inherited) $(PODS_TARGET_SRCROOT)/web3swift/lib/**'
   }
   s.preserve_paths = 'web3swift/lib/**/module.map'
 


### PR DESCRIPTION
It is found that in React Native builds, which does not seems to `use_framework!`, the swift compiler is unable to find the `BigInt` and `GenericJSON` dependencies for the `web3.swift` during the build process, causing build failure. After reviewing the project configuration, I have found the `pod_target_xcconfig` in podspec to be supcisious, and the problem was fixed after adding `$(inherited)` to the config. 