### PR TITLE
Add Linux Swift 5.1 support

### DIFF
--- a/web3sTests/ERC721/ERC721Tests.swift
+++ b/web3sTests/ERC721/ERC721Tests.swift
@@ -10,6 +10,10 @@ import XCTest
 import BigInt
 @testable import web3
 
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
 let tokenOwner = EthereumAddress("0x69F84b91E7107206E841748C2B52294A1176D45e")
 let previousOwner = EthereumAddress("0x64d0ea4fc60f27e74f1a70aa6f39d403bbe56793")
 let nonOwner = EthereumAddress("0x64d0eA4FC60f27E74f1a70Aa6f39D403bBe56792")

--- a/web3swift/src/Client/EthereumClient.swift
+++ b/web3swift/src/Client/EthereumClient.swift
@@ -9,6 +9,10 @@
 import Foundation
 import BigInt
 
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
 public protocol EthereumClientProtocol {
     init(url: URL, sessionConfig: URLSessionConfiguration)
     init(url: URL)

--- a/web3swift/src/Client/JSONRPC.swift
+++ b/web3swift/src/Client/JSONRPC.swift
@@ -8,6 +8,10 @@
 
 import Foundation
 
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
 struct JSONRPCRequest<T: Encodable>: Encodable {
     let jsonrpc: String
     let method: String

--- a/web3swift/src/ERC721/ERC721.swift
+++ b/web3swift/src/ERC721/ERC721.swift
@@ -9,6 +9,10 @@
 import Foundation
 import BigInt
 
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
 public class ERC721: ERC165 {
     public func balanceOf(contract: EthereumAddress,
                           address: EthereumAddress,


### PR DESCRIPTION

Hi,

Im using your framework and I love it. I tried to use build on Docker swift 5.5 version and I got the following error:

> #14 10.61 /build/.build/checkouts/web3.swift/web3swift/src/Client/EthereumClient.swift:13:35: error: 'URLSessionConfiguration' is unavailable: This type has moved to the FoundationNetworking module. Import that module to use it.
#14 10.61     init(url: URL, sessionConfig: URLSessionConfiguration)
#14 10.61                                   ^~~~~~~~~~~~~~~~~~~~~~~
#14 10.61 Foundation.URLSessionConfiguration:2:18: note: 'URLSessionConfiguration' has been explicitly marked unavailable here
#14 10.61 public typealias URLSessionConfiguration = AnyObject
#14 10.61                  ^
#14 10.61 /build/.build/checkouts/web3.swift/web3swift/src/Client/EthereumClient.swift:50:25: error: 'URLSession' is unavailable: This type has moved to the FoundationNetworking module. Import that module to use it.
#14 10.61     public let session: URLSession
#14 10.61                         ^~~~~~~~~~
#14 10.61 Foundation.URLSession:2:18: note: 'URLSession' has been explicitly marked unavailable here
#14 10.61 public typealias URLSession = AnyObject

In Swift 5.1 on Linux, the network stuff is moved to `FoundationNetworking`
It looks like we need to import FoundationNetworking now, so I've done just that (conditionally, when it's available).
