### PR TITLE
Add async APIs for callbacks, add tests for async methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ client.eth_gasPrice { (error, currentPrice) in
     print("The current gas price is \(currentPrice)")
 }
 ```
+If using `async/await` you can `await` on the result
+```swift
+let gasPrice = try await client.eth_gasPrice()
+```
 
 ### Smart contracts: Static types
 
@@ -98,6 +102,10 @@ let transaction = try function.transaction()
 client.eth_sendRawTransaction(transacton, withAccount: account) { (error, txHash) in
     print("TX Hash: \(txHash)")
 }
+```
+If using `async/await` you can `await` on the result
+```swift
+let txHash = try await client.eth_sendRawTransaction(transacton, withAccount: account)
 ```
 
 ### Data types
@@ -162,7 +170,6 @@ There are some features that have yet to be fully implemented! Not every RPC met
 - Batch support for JSONRPC interface
 - Use a Hex struct for values to be more explicit in expected types
 - Use [Truffle](https://github.com/trufflesuite/ganache-cli) for running tests
-- Add support for Swift Package Manager
 - Bloom Filter support
 
 ## Contributors

--- a/web3sTests/Client/EthereumClientTests.swift
+++ b/web3sTests/Client/EthereumClientTests.swift
@@ -15,18 +15,18 @@ struct TransferMatchingSignatureEvent: ABIEvent {
     public static let types: [ABIType.Type] = [ EthereumAddress.self , EthereumAddress.self , BigUInt.self]
     public static let typesIndexed = [true, true, false]
     public let log: EthereumLog
-    
+
     public let from: EthereumAddress
     public let to: EthereumAddress
     public let value: BigUInt
-    
+
     public init?(topics: [ABIDecoder.DecodedValue], data: [ABIDecoder.DecodedValue], log: EthereumLog) throws {
         try TransferMatchingSignatureEvent.checkParameters(topics, data)
         self.log = log
-        
+
         self.from = try topics[0].decoded()
         self.to = try topics[1].decoded()
-        
+
         self.value = try data[0].decoded()
     }
 }
@@ -37,7 +37,7 @@ class EthereumClientTests: XCTestCase {
     var mainnetClient: EthereumClient?
     var account: EthereumAccount?
     let timeout = 10.0
-    
+
     override func setUp() {
         super.setUp()
         self.client = EthereumClient(url: URL(string: TestConfig.clientUrl)!)
@@ -45,142 +45,142 @@ class EthereumClientTests: XCTestCase {
         self.account = try? EthereumAccount(keyStorage: TestEthereumKeyStorage(privateKey: TestConfig.privateKey))
         print("Public address: \(self.account?.address.value ?? "NONE")")
     }
-    
+
     override func tearDown() {
         super.tearDown()
     }
-    
+
     func testEthGetBalance() {
         let expectation = XCTestExpectation(description: "get remote balance")
         client?.eth_getBalance(address: account?.address ?? .zero, block: .Latest, completion: { (error, balance) in
             XCTAssertNotNil(balance, "Balance not available: \(error?.localizedDescription ?? "no error")")
             expectation.fulfill()
         })
-        
+
         wait(for: [expectation], timeout: timeout)
     }
-    
+
     func testEthGetBalanceIncorrectAddress() {
         let expectation = XCTestExpectation(description: "get remote balance incorrect")
-        
+
         client?.eth_getBalance(address: EthereumAddress("0xnig42niog2"), block: .Latest, completion: { (error, balance) in
             XCTAssertNotNil(error, "Balance error not available")
             expectation.fulfill()
         })
-        
+
         wait(for: [expectation], timeout: timeout)
     }
-    
+
     func testNetVersion() {
         let expectation = XCTestExpectation(description: "get net version")
         client?.net_version(completion: { (error, network) in
             XCTAssertEqual(network, EthereumNetwork.Ropsten, "Network incorrect: \(error?.localizedDescription ?? "no error")")
             expectation.fulfill()
         })
-        
+
         wait(for: [expectation], timeout: timeout)
     }
-    
+
     func testEthGasPrice() {
         let expectation = XCTestExpectation(description: "get gas price")
         client?.eth_gasPrice(completion: { (error, gas) in
             XCTAssertNotNil(gas, "Gas not available: \(error?.localizedDescription ?? "no error")")
             expectation.fulfill()
         })
-        
+
         wait(for: [expectation], timeout: timeout)
     }
-    
+
     func testEthBlockNumber() {
         let expectation = XCTestExpectation(description: "get current block number")
         client?.eth_blockNumber(completion: { (error, block) in
             XCTAssertNotNil(block, "Block not available: \(error?.localizedDescription ?? "no error")")
             expectation.fulfill()
         })
-        
+
         wait(for: [expectation], timeout: timeout)
     }
-    
+
     func testEthGetCode() {
         let expectation = XCTestExpectation(description: "get contract code")
         client?.eth_getCode(address: EthereumAddress("0x112234455c3a32fd11230c42e7bccd4a84e02010"), completion: { (error, code) in
             XCTAssertNotNil(code, "Contract code not available: \(error?.localizedDescription ?? "no error")")
             expectation.fulfill()
         })
-        
+
         wait(for: [expectation], timeout: timeout)
     }
-    
+
     func testEthSendRawTransaction() {
         let expectation = XCTestExpectation(description: "send raw transaction")
-            
+
         let tx = EthereumTransaction(from: nil, to: EthereumAddress("0x3c1bd6b420448cf16a389c8b0115ccb3660bb854"), value: BigUInt(1600000), data: nil, nonce: 2, gasPrice: BigUInt(4000000), gasLimit: BigUInt(50000), chainId: EthereumNetwork.Ropsten.intValue)
-        
+
         self.client?.eth_sendRawTransaction(tx, withAccount: self.account!, completion: { (error, txHash) in
             XCTAssertNotNil(txHash, "No tx hash, ensure key is valid in TestConfig.swift")
             expectation.fulfill()
         })
-    
+
         wait(for: [expectation], timeout: timeout)
     }
-    
+
     func testEthGetTransactionCount() {
         let expectation = XCTestExpectation(description: "get transaction receipt")
-        
+
         client?.eth_getTransactionCount(address: account!.address, block: .Latest, completion: { (error, count) in
             XCTAssertNotNil(count, "Transaction count not available: \(error?.localizedDescription ?? "no error")")
             expectation.fulfill()
         })
-        
+
         wait(for: [expectation], timeout: timeout)
     }
-    
+
     func testEthGetTransactionCountPending() {
         let expectation = XCTestExpectation(description: "get transaction receipt")
-        
+
         client?.eth_getTransactionCount(address: account!.address, block: .Pending, completion: { (error, count) in
             XCTAssertNotNil(count, "Transaction count not available: \(error?.localizedDescription ?? "no error")")
             expectation.fulfill()
         })
-        
+
         wait(for: [expectation], timeout: timeout)
     }
-    
+
     func testEthGetTransactionReceipt() {
         let expectation = XCTestExpectation(description: "get transaction receipt")
-       
+
         let txHash = "0xc51002441dc669ad03697fd500a7096c054b1eb2ce094821e68831a3666fc878"
         client?.eth_getTransactionReceipt(txHash: txHash, completion: { (error, receipt) in
             XCTAssertNotNil(receipt, "Transaction receipt not available: \(error?.localizedDescription ?? "no error")")
             expectation.fulfill()
         })
-        
+
         wait(for: [expectation], timeout: timeout)
     }
-    
+
     func testEthCall() {
         let expectation = XCTestExpectation(description: "send raw transaction")
-        
+
         let tx = EthereumTransaction(from: nil, to: EthereumAddress("0x3c1bd6b420448cf16a389c8b0115ccb3660bb854"), value: BigUInt(1800000), data: nil, nonce: 2, gasPrice: BigUInt(400000), gasLimit: BigUInt(50000), chainId: EthereumNetwork.Ropsten.intValue)
         client?.eth_call(tx, block: .Latest, completion: { (error, txHash) in
             XCTAssertNotNil(txHash, "Transaction hash not available: \(error?.localizedDescription ?? "no error")")
             expectation.fulfill()
         })
-        
+
         wait(for: [expectation], timeout: timeout)
     }
-    
+
     func testSimpleEthGetLogs() {
         let expectation = XCTestExpectation(description: "get logs")
-        
+
         client?.eth_getLogs(addresses: [EthereumAddress("0x23d0a442580c01e420270fba6ca836a8b2353acb")], topics: nil, fromBlock: .Earliest, toBlock: .Latest, completion: { (error, logs) in
             XCTAssertNotNil(logs, "Logs not available \(error?.localizedDescription ?? "no error")")
             expectation.fulfill()
         })
-        
+
         wait(for: [expectation], timeout: timeout)
     }
-    
+
     func testOrTopicsEthGetLogs() {
         let expectation = XCTestExpectation(description: "get logs")
 
@@ -190,68 +190,68 @@ class EthereumClientTests: XCTestCase {
             XCTAssertNotNil(logs, "Logs not available \(error?.localizedDescription ?? "no error")")
             expectation.fulfill()
         })
-        
+
         wait(for: [expectation], timeout: timeout)
     }
-    
+
     func testGivenGenesisBlock_ThenReturnsByNumber() {
         let expectation = XCTestExpectation(description: "get block by number")
-        
+
         client?.eth_getBlockByNumber(.Number(0)) { error, block in
             XCTAssertNil(error)
-            
+
             XCTAssertEqual(block?.timestamp.timeIntervalSince1970, 0)
             XCTAssertEqual(block?.transactions.count, 0)
             XCTAssertEqual(block?.number, .Number(0))
             expectation.fulfill()
         }
-        
+
         wait(for: [expectation], timeout: timeout)
     }
 
     func testGivenLatestBlock_ThenReturnsByNumber() {
         let expectation = XCTestExpectation(description: "get block by number")
-        
+
         client?.eth_getBlockByNumber(.Latest) { error, block in
             XCTAssertNil(error)
             XCTAssertNotNil(block?.number.intValue)
             expectation.fulfill()
         }
-        
+
         wait(for: [expectation], timeout: timeout)
     }
-    
+
     func testGivenExistingBlock_ThenGetsBlockByNumber() {
         let expectation = XCTestExpectation(description: "get block by number")
-        
+
         client?.eth_getBlockByNumber(.Number(3415757)) { error, block in
             XCTAssertNil(error)
-            
+
             XCTAssertEqual(block?.number, .Number(3415757))
             XCTAssertEqual(block?.timestamp.timeIntervalSince1970, 1528711895)
             XCTAssertEqual(block?.transactions.count, 40)
             XCTAssertEqual(block?.transactions.first, "0x387867d052b3f89fb87937572891118aa704c1ba604c157bbd9c5a07f3a7e5cd")
             expectation.fulfill()
         }
-        
+
         wait(for: [expectation], timeout: timeout)
     }
-    
+
     func testGivenUnexistingBlockNumber_ThenGetBlockByNumberReturnsError() {
         let expectation = XCTestExpectation(description: "get block by number")
-        
+
         client?.eth_getBlockByNumber(.Number(Int.max)) { error, block in
             XCTAssertNotNil(error)
             XCTAssertNil(block)
             expectation.fulfill()
         }
-        
+
         wait(for: [expectation], timeout: timeout)
     }
-    
+
     func testGivenMinedTransactionHash_ThenGetsTransactionByHash() {
         let expectation = XCTestExpectation(description: "get transaction by hash")
-        
+
         client?.eth_getTransaction(byHash: "0x014726c783ab2fd6828a9ca556850bccfc66f70926f411274eaf886385c704af") { error, transaction in
             XCTAssertNil(error)
             XCTAssertEqual(transaction?.from?.value, "0xbbf5029fd710d227630c8b7d338051b8e76d50b3")
@@ -262,30 +262,30 @@ class EthereumClientTests: XCTestCase {
             XCTAssertEqual(transaction?.value, BigUInt(hex: "0x56bc75e2d63100000"))
             XCTAssertEqual(transaction?.blockNumber, EthereumBlock.Number(3439303))
             XCTAssertEqual(transaction?.hash?.web3.hexString, "0x014726c783ab2fd6828a9ca556850bccfc66f70926f411274eaf886385c704af")
-            
+
             expectation.fulfill()
         }
-        
+
         wait(for: [expectation], timeout: timeout)
     }
-    
+
     func testGivenUnexistingTransactionHash_ThenErrorsGetTransactionByHash() {
         let expectation = XCTestExpectation(description: "get transaction by hash")
-        
+
         client?.eth_getTransaction(byHash: "0x01234") { error, transaction in
             XCTAssertNotNil(error)
             XCTAssertNil(transaction)
             expectation.fulfill()
         }
-        
+
         wait(for: [expectation], timeout: timeout)
     }
-    
+
     func testGivenNoFilters_WhenMatchingSingleTransferEvents_AllEventsReturned() {
         let expectation = XCTestExpectation(description: "get events")
-        
+
         let to = try! ABIEncoder.encode(EthereumAddress("0x3C1Bd6B420448Cf16A389C8b0115CCB3660bB854"))
-            
+
         client?.getEvents(addresses: nil,
                           topics: [try! ERC20Events.Transfer.signature(), nil, to.hexString, nil],
                           fromBlock: .Earliest,
@@ -296,88 +296,88 @@ class EthereumClientTests: XCTestCase {
             XCTAssertEqual(logs.count, 0)
             expectation.fulfill()
         }
-        
+
         wait(for: [expectation], timeout: timeout)
     }
-    
+
     func testGivenNoFilters_WhenMatchingMultipleTransferEvents_BothEventsReturned() {
         let expectation = XCTestExpectation(description: "get events")
-        
+
         let to = try! ABIEncoder.encode(EthereumAddress("0x3C1Bd6B420448Cf16A389C8b0115CCB3660bB854"))
-        
+
         client?.getEvents(addresses: nil,
                           topics: [try! ERC20Events.Transfer.signature(), nil, to.hexString, nil],
                           fromBlock: .Earliest,
                           toBlock: .Latest,
                           eventTypes: [ERC20Events.Transfer.self, TransferMatchingSignatureEvent.self]) { (error, events, logs) in
-                            XCTAssertNil(error)
-                            XCTAssertEqual(events.count, 4)
-                            XCTAssertEqual(logs.count, 0)
-                            expectation.fulfill()
+            XCTAssertNil(error)
+            XCTAssertEqual(events.count, 4)
+            XCTAssertEqual(logs.count, 0)
+            expectation.fulfill()
         }
-        
+
         wait(for: [expectation], timeout: timeout)
     }
-    
+
     func testGivenContractFilter_WhenMatchingSingleTransferEvents_OnlyMatchingSourceEventReturned() {
         let expectation = XCTestExpectation(description: "get events")
-        
+
         let to = try! ABIEncoder.encodeRaw("0x3C1Bd6B420448Cf16A389C8b0115CCB3660bB854", forType: ABIRawType.FixedAddress)
         let filters = [
             EventFilter(type: ERC20Events.Transfer.self, allowedSenders: [EthereumAddress("0xdb0040451f373949a4be60dcd7b6b8d6e42658b6")])
         ]
-        
+
         client?.getEvents(addresses: nil,
                           topics: [try! ERC20Events.Transfer.signature(), nil, to.hexString, nil],
                           fromBlock: .Earliest,
                           toBlock: .Latest,
                           matching: filters) { (error, events, logs) in
-                            XCTAssertNil(error)
-                            XCTAssertEqual(events.count, 1)
-                            XCTAssertEqual(logs.count, 1)
-                            expectation.fulfill()
+            XCTAssertNil(error)
+            XCTAssertEqual(events.count, 1)
+            XCTAssertEqual(logs.count, 1)
+            expectation.fulfill()
         }
-        
+
         wait(for: [expectation], timeout: timeout)
     }
-    
+
     func testGivenContractFilter_WhenMatchingMultipleTransferEvents_OnlyMatchingSourceEventsReturned() {
         let expectation = XCTestExpectation(description: "get events")
-        
+
         let to = try! ABIEncoder.encode(EthereumAddress("0x3C1Bd6B420448Cf16A389C8b0115CCB3660bB854"))
         let filters = [
             EventFilter(type: ERC20Events.Transfer.self, allowedSenders: [EthereumAddress("0xdb0040451f373949a4be60dcd7b6b8d6e42658b6")]),
             EventFilter(type: TransferMatchingSignatureEvent.self, allowedSenders: [EthereumAddress("0xdb0040451f373949a4be60dcd7b6b8d6e42658b6")])
         ]
-        
+
         client?.getEvents(addresses: nil,
                           topics: [try! ERC20Events.Transfer.signature(), nil, to.hexString, nil],
                           fromBlock: .Earliest,
                           toBlock: .Latest,
                           matching: filters) { (error, events, logs) in
-                            XCTAssertNil(error)
-                            XCTAssertEqual(events.count, 2)
-                            XCTAssertEqual(logs.count, 2)
-                            expectation.fulfill()
+            XCTAssertNil(error)
+            XCTAssertEqual(events.count, 2)
+            XCTAssertEqual(logs.count, 2)
+            expectation.fulfill()
         }
-        
+
         wait(for: [expectation], timeout: timeout)
     }
-    
+
     func test_GivenDynamicArrayResponse_ThenCallReceivesData() {
         let expect = expectation(description: "call")
-        
+
         let function = GetGuardians(wallet: EthereumAddress("0x2A6295C34b4136F2C3c1445c6A0338D784fe0ddd"))
         function.call(withClient: self.client!,
                       responseType: GetGuardians.Response.self) { (error, response) in
-                        XCTAssertNil(error)
-                        XCTAssertEqual(response?.guardians, [EthereumAddress("0x44fe11c90d2bcbc8267a0e56d55235ddc2b96c4f")])
-                        expect.fulfill()
+            XCTAssertNil(error)
+            XCTAssertEqual(response?.guardians, [EthereumAddress("0x44fe11c90d2bcbc8267a0e56d55235ddc2b96c4f")])
+            expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: 10)
     }
-    
+
     // This is how geth used to work up until a recent version
     // see https://github.com/ethereum/go-ethereum/pull/21083/
     // Used to return '0x' in response, and would fail decoding
@@ -387,33 +387,33 @@ class EthereumClientTests: XCTestCase {
     // NOTE: At the time of writing, this test succeeds as-is in ropsten as nodes behaviour is different. That's why we use a mainnet check here
     func test_GivenUnimplementedMethod_WhenCallingContract_ThenFailsWith0x() {
         let expect = expectation(description: "graceful_failure")
-        
+
         let function = InvalidMethodA(param: .zero)
-        
+
         function.call(withClient: self.mainnetClient!,
                       responseType: InvalidMethodA.BoolResponse.self) { (error, response) in
-                        XCTAssertEqual(error, .decodeIssue)
-                        XCTAssertNil(response)
-                        expect.fulfill()
+            XCTAssertEqual(error, .decodeIssue)
+            XCTAssertNil(response)
+            expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: 10)
     }
     func test_GivenFailingCallMethod_WhenCallingContract_ThenFailsWith0x() {
         let expect = expectation(description: "graceful_failure")
-        
+
         let function = InvalidMethodB(param: .zero)
-        
+
         function.call(withClient: self.mainnetClient!,
                       responseType: InvalidMethodB.BoolResponse.self) { (error, response) in
-                        XCTAssertEqual(error, .decodeIssue)
-                        XCTAssertNil(response)
-                        expect.fulfill()
+            XCTAssertEqual(error, .decodeIssue)
+            XCTAssertNil(response)
+            expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: 10)
     }
-    
+
     func test_GivenValidTransaction_ThenEstimatesGas() {
         let expect = expectation(description: "estimateOK")
         let function = TransferToken(wallet: EthereumAddress("0xD18dE36e6FB4a5A069f673723Fab71cc00C6CE5F"),
@@ -428,10 +428,333 @@ class EthereumClientTests: XCTestCase {
             XCTAssert(value != 0)
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: 10)
     }
 }
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+extension EthereumClientTests {
+    func testEthGetBalance_Async() async throws {
+        do {
+            let balance = try await client?.eth_getBalance(address: account?.address ?? .zero, block: .Latest)
+            XCTAssertNotNil(balance, "Balance not available")
+        } catch {
+            XCTFail("Expected balance but failed \(error).")
+        }
+    }
+
+    func testEthGetBalanceIncorrectAddress_Async() async {
+        do {
+            _ = try await client?.eth_getBalance(address: EthereumAddress("0xnig42niog2"), block: .Latest)
+            XCTFail("Expected to throw while awaiting, but succeeded")
+        } catch {
+            XCTAssertEqual(error as? EthereumClientError, .unexpectedReturnValue)
+        }
+    }
+
+    func testNetVersion_Async() async {
+        do {
+            let network = try await client?.net_version()
+            XCTAssertEqual(network, EthereumNetwork.Ropsten, "Network incorrect")
+        } catch {
+            XCTFail("Expected network but failed \(error).")
+        }
+    }
+
+    func testEthGasPrice_Async() async {
+        do {
+            let gas = try await client?.eth_gasPrice()
+            XCTAssertNotNil(gas, "Gas not available")
+        } catch {
+            XCTFail("Expected gas but failed \(error).")
+        }
+    }
+
+    func testEthBlockNumber_Async() async {
+        do {
+            let block = try await client?.eth_blockNumber()
+            XCTAssertNotNil(block, "Block not available")
+        } catch {
+            XCTFail("Expected blockNumber but failed \(error).")
+        }
+    }
+
+    func testEthGetCode_Async() async {
+        do {
+            let code = try await client?.eth_getCode(address: EthereumAddress("0x112234455c3a32fd11230c42e7bccd4a84e02010"))
+            XCTAssertNotNil(code, "Contract code not available")
+        } catch {
+            XCTFail("Expected code but failed \(error).")
+        }
+    }
+
+    func testEthSendRawTransaction_Async() async {
+        do {
+            let tx = EthereumTransaction(from: nil, to: EthereumAddress("0x3c1bd6b420448cf16a389c8b0115ccb3660bb854"), value: BigUInt(1600000), data: nil, nonce: 2, gasPrice: BigUInt(4000000), gasLimit: BigUInt(50000), chainId: EthereumNetwork.Ropsten.intValue)
+
+            let txHash = try await client?.eth_sendRawTransaction(tx, withAccount: self.account!)
+            XCTAssertNotNil(txHash, "No tx hash, ensure key is valid in TestConfig.swift")
+        } catch {
+            XCTFail("Expected tx but failed \(error).")
+        }
+    }
+
+    func testEthGetTransactionCount_Async() async {
+        do {
+            let count = try await client?.eth_getTransactionCount(address: account!.address, block: .Latest)
+            XCTAssertNotNil(count, "Transaction count not available")
+        } catch {
+            XCTFail("Expected count but failed \(error).")
+        }
+    }
+
+    func testEthGetTransactionCountPending_Async() async {
+        do {
+            let count = try await client?.eth_getTransactionCount(address: account!.address, block: .Pending)
+            XCTAssertNotNil(count, "Transaction count not available")
+        } catch {
+            XCTFail("Expected count but failed \(error).")
+        }
+    }
+
+    func testEthGetTransactionReceipt_Async() async {
+        do {
+            let txHash = "0xc51002441dc669ad03697fd500a7096c054b1eb2ce094821e68831a3666fc878"
+            let receipt = try await client?.eth_getTransactionReceipt(txHash: txHash)
+            XCTAssertNotNil(receipt, "Transaction receipt not available")
+        } catch {
+            XCTFail("Expected receipt but failed \(error).")
+        }
+    }
+
+    func testEthCall_Async() async {
+        do {
+            let tx = EthereumTransaction(from: nil, to: EthereumAddress("0x3c1bd6b420448cf16a389c8b0115ccb3660bb854"), value: BigUInt(1800000), data: nil, nonce: 2, gasPrice: BigUInt(400000), gasLimit: BigUInt(50000), chainId: EthereumNetwork.Ropsten.intValue)
+            let txHash = try await client?.eth_call(tx, block: .Latest)
+            XCTAssertNotNil(txHash, "Transaction hash not available")
+        } catch {
+            XCTFail("Expected txHash but failed \(error).")
+        }
+    }
+
+    func testSimpleEthGetLogs_Async() async {
+        do {
+            let logs = try await client?.eth_getLogs(addresses: [EthereumAddress("0x23d0a442580c01e420270fba6ca836a8b2353acb")], topics: nil, fromBlock: .Earliest, toBlock: .Latest)
+            XCTAssertNotNil(logs, "Logs not available")
+        } catch {
+            XCTFail("Expected logs but failed \(error).")
+        }
+    }
+
+    func testOrTopicsEthGetLogs_Async() async {
+        do {
+            let logs = try await client?.eth_getLogs(addresses: nil, orTopics: [["0xe1fffcc4923d04b559f4d29a8bfc6cda04eb5b0d3c460751c2402c5c5cc9109c", "0x7fcf532c15f0a6db0bd6d0e038bea71d30d808c7d98cb3bf7268a95bf5081b65"], ["0x000000000000000000000000655ef694b98e55977a93259cb3b708560869a8f3"]], fromBlock: .Number(6540313), toBlock: .Number(6540397))
+            XCTAssertEqual(logs?.count, 2)
+            XCTAssertNotNil(logs, "Logs not available")
+        } catch {
+            XCTFail("Expected logs but failed \(error).")
+        }
+    }
+
+    func testGivenGenesisBlock_ThenReturnsByNumber_Async() async {
+        do {
+            let block = try await client?.eth_getBlockByNumber(.Number(0))
+            XCTAssertEqual(block?.timestamp.timeIntervalSince1970, 0)
+            XCTAssertEqual(block?.transactions.count, 0)
+            XCTAssertEqual(block?.number, .Number(0))
+        } catch {
+            XCTFail("Expected block but failed \(error).")
+        }
+    }
+
+    func testGivenLatestBlock_ThenReturnsByNumber_Async() async {
+        do {
+            let block = try await client?.eth_getBlockByNumber(.Latest)
+            XCTAssertNotNil(block?.number.intValue)
+        } catch {
+            XCTFail("Expected block but failed \(error).")
+        }
+    }
+
+    func testGivenExistingBlock_ThenGetsBlockByNumber_Async() async {
+        do {
+            let block = try await client?.eth_getBlockByNumber(.Number(3415757))
+            XCTAssertEqual(block?.number, .Number(3415757))
+            XCTAssertEqual(block?.timestamp.timeIntervalSince1970, 1528711895)
+            XCTAssertEqual(block?.transactions.count, 40)
+            XCTAssertEqual(block?.transactions.first, "0x387867d052b3f89fb87937572891118aa704c1ba604c157bbd9c5a07f3a7e5cd")
+        } catch {
+            XCTFail("Expected block but failed \(error).")
+        }
+    }
+
+    func testGivenUnexistingBlockNumber_ThenGetBlockByNumberReturnsError_Async() async {
+        do {
+            let _ = try await client?.eth_getBlockByNumber(.Number(Int.max))
+            XCTFail("Expected to throw while awaiting, but succeeded")
+        } catch {
+            XCTAssertEqual(error as? EthereumClientError, .unexpectedReturnValue)
+        }
+    }
+
+    func testGivenMinedTransactionHash_ThenGetsTransactionByHash_Async() async {
+        do {
+            let transaction = try await client?.eth_getTransaction(byHash: "0x014726c783ab2fd6828a9ca556850bccfc66f70926f411274eaf886385c704af")
+            XCTAssertEqual(transaction?.from?.value, "0xbbf5029fd710d227630c8b7d338051b8e76d50b3")
+            XCTAssertEqual(transaction?.to.value, "0x37f13b5ffcc285d2452c0556724afb22e58b6bbe")
+            XCTAssertEqual(transaction?.gas, "30400")
+            XCTAssertEqual(transaction?.gasPrice, BigUInt(hex: "0x9184e72a000"))
+            XCTAssertEqual(transaction?.nonce, 973253)
+            XCTAssertEqual(transaction?.value, BigUInt(hex: "0x56bc75e2d63100000"))
+            XCTAssertEqual(transaction?.blockNumber, EthereumBlock.Number(3439303))
+            XCTAssertEqual(transaction?.hash?.web3.hexString, "0x014726c783ab2fd6828a9ca556850bccfc66f70926f411274eaf886385c704af")
+        } catch {
+            XCTFail("Expected transaction but failed \(error).")
+        }
+    }
+
+    func testGivenUnexistingTransactionHash_ThenErrorsGetTransactionByHash_Async() async {
+        do {
+            let _ = try await client?.eth_getTransaction(byHash: "0x01234")
+            XCTFail("Expected to throw while awaiting, but succeeded")
+        } catch {
+            XCTAssertEqual(error as? EthereumClientError, .unexpectedReturnValue)
+        }
+    }
+
+    func testGivenNoFilters_WhenMatchingSingleTransferEvents_AllEventsReturned_Async() async {
+        do {
+            let to = try! ABIEncoder.encode(EthereumAddress("0x3C1Bd6B420448Cf16A389C8b0115CCB3660bB854"))
+
+            let eventsResult = try await client?.getEvents(addresses: nil,
+                                                           topics: [try! ERC20Events.Transfer.signature(), nil, to.hexString, nil],
+                                                           fromBlock: .Earliest,
+                                                           toBlock: .Latest,
+                                                           eventTypes: [ERC20Events.Transfer.self])
+            XCTAssertEqual(eventsResult?.events.count, 2)
+            XCTAssertEqual(eventsResult?.logs.count, 0)
+        } catch {
+            XCTFail("Expected events but failed \(error).")
+        }
+    }
+
+    func testGivenNoFilters_WhenMatchingMultipleTransferEvents_BothEventsReturned_Async() async {
+        do {
+            let to = try! ABIEncoder.encode(EthereumAddress("0x3C1Bd6B420448Cf16A389C8b0115CCB3660bB854"))
+
+            let eventsResult = try await client?.getEvents(addresses: nil,
+                                                           topics: [try! ERC20Events.Transfer.signature(), nil, to.hexString, nil],
+                                                           fromBlock: .Earliest,
+                                                           toBlock: .Latest,
+                                                           eventTypes: [ERC20Events.Transfer.self, TransferMatchingSignatureEvent.self])
+            XCTAssertEqual(eventsResult?.events.count, 4)
+            XCTAssertEqual(eventsResult?.logs.count, 0)
+        } catch {
+            XCTFail("Expected events but failed \(error).")
+        }
+    }
+
+    func testGivenContractFilter_WhenMatchingSingleTransferEvents_OnlyMatchingSourceEventReturned_Async() async {
+        do {
+            let to = try! ABIEncoder.encodeRaw("0x3C1Bd6B420448Cf16A389C8b0115CCB3660bB854", forType: ABIRawType.FixedAddress)
+            let filters = [
+                EventFilter(type: ERC20Events.Transfer.self, allowedSenders: [EthereumAddress("0xdb0040451f373949a4be60dcd7b6b8d6e42658b6")])
+            ]
+
+            let eventsResult = try await client?.getEvents(addresses: nil,
+                                                           topics: [try! ERC20Events.Transfer.signature(), nil, to.hexString, nil],
+                                                           fromBlock: .Earliest,
+                                                           toBlock: .Latest,
+                                                           matching: filters)
+            XCTAssertEqual(eventsResult?.events.count, 1)
+            XCTAssertEqual(eventsResult?.logs.count, 1)
+        } catch {
+            XCTFail("Expected events but failed \(error).")
+        }
+    }
+
+    func testGivenContractFilter_WhenMatchingMultipleTransferEvents_OnlyMatchingSourceEventsReturned_Async() async {
+        do {
+            let to = try! ABIEncoder.encode(EthereumAddress("0x3C1Bd6B420448Cf16A389C8b0115CCB3660bB854"))
+            let filters = [
+                EventFilter(type: ERC20Events.Transfer.self, allowedSenders: [EthereumAddress("0xdb0040451f373949a4be60dcd7b6b8d6e42658b6")]),
+                EventFilter(type: TransferMatchingSignatureEvent.self, allowedSenders: [EthereumAddress("0xdb0040451f373949a4be60dcd7b6b8d6e42658b6")])
+            ]
+
+            let eventsResult = try await client?.getEvents(addresses: nil,
+                                                           topics: [try! ERC20Events.Transfer.signature(), nil, to.hexString, nil],
+                                                           fromBlock: .Earliest,
+                                                           toBlock: .Latest,
+                                                           matching: filters)
+            XCTAssertEqual(eventsResult?.events.count, 2)
+            XCTAssertEqual(eventsResult?.logs.count, 2)
+        } catch {
+            XCTFail("Expected events but failed \(error).")
+        }
+    }
+
+    func test_GivenDynamicArrayResponse_ThenCallReceivesData_Async() async {
+        do {
+            let function = GetGuardians(wallet: EthereumAddress("0x2A6295C34b4136F2C3c1445c6A0338D784fe0ddd"))
+
+            let response = try await function.call(withClient: self.client!, responseType: GetGuardians.Response.self)
+            XCTAssertEqual(response.guardians, [EthereumAddress("0x44fe11c90d2bcbc8267a0e56d55235ddc2b96c4f")])
+        } catch {
+            XCTFail("Expected response but failed \(error).")
+        }
+    }
+
+    // This is how geth used to work up until a recent version
+    // see https://github.com/ethereum/go-ethereum/pull/21083/
+    // Used to return '0x' in response, and would fail decoding
+    // We'll continue to support this as user of library (and Argent in our case)
+    // works with this assumption.
+    // NOTE: This behaviour will be removed at a later time to fail as expected
+    // NOTE: At the time of writing, this test succeeds as-is in ropsten as nodes behaviour is different. That's why we use a mainnet check here
+    func test_GivenUnimplementedMethod_WhenCallingContract_ThenFailsWith0x_Async() async {
+        do {
+            let function = InvalidMethodA(param: .zero)
+            let _ = try await function.call(withClient: self.mainnetClient!,
+                                            responseType: InvalidMethodA.BoolResponse.self)
+            XCTFail("Expected to throw while awaiting, but succeeded")
+        } catch {
+            XCTAssertEqual(error as? EthereumClientError, .decodeIssue)
+        }
+    }
+
+    func test_GivenFailingCallMethod_WhenCallingContract_ThenFailsWith0x_Async() async {
+        do {
+            let function = InvalidMethodB(param: .zero)
+            let _ = try await function.call(withClient: self.mainnetClient!,
+                                            responseType: InvalidMethodB.BoolResponse.self)
+            XCTFail("Expected to throw while awaiting, but succeeded")
+        } catch {
+            XCTAssertEqual(error as? EthereumClientError, .decodeIssue)
+        }
+    }
+
+    func test_GivenValidTransaction_ThenEstimatesGas_Async() async {
+        do {
+            let function = TransferToken(wallet: EthereumAddress("0xD18dE36e6FB4a5A069f673723Fab71cc00C6CE5F"),
+                                         token: EthereumAddress("0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
+                                         to: EthereumAddress("0x2A6295C34b4136F2C3c1445c6A0338D784fe0ddd"),
+                                         amount: 1,
+                                         data: Data(),
+                                         gasPrice: 0,
+                                         gasLimit: 0)
+
+            let value = try await client!.eth_estimateGas(try! function.transaction(), withAccount: account!)
+            XCTAssert(value != 0)
+        } catch {
+            XCTFail("Expected value but failed \(error).")
+        }
+    }
+}
+
+#endif
 
 struct GetGuardians: ABIFunction {
     static let name = "getGuardians"
@@ -439,22 +762,22 @@ struct GetGuardians: ABIFunction {
     let from: EthereumAddress? = EthereumAddress("0x25BD64224b7534f7B9e3E16dd10b6dED1A412b90")
     let gasPrice: BigUInt? = nil
     let gasLimit: BigUInt? = nil
-    
+
     struct Response: ABIResponse {
         static var types: [ABIType.Type] = [ABIArray<EthereumAddress>.self]
         let guardians: [EthereumAddress]
-        
+
         init?(values: [ABIDecoder.DecodedValue]) throws {
             self.guardians = try values[0].decodedArray()
-            
+
         }
     }
-    
+
     let wallet: EthereumAddress
-    
+
     func encode(to encoder: ABIFunctionEncoder) throws {
         try encoder.encode(wallet)
-        
+
     }
 }
 
@@ -468,10 +791,10 @@ struct TransferToken: ABIFunction {
     let to: EthereumAddress
     let amount: BigUInt
     let data: Data
-    
+
     let gasPrice: BigUInt?
     let gasLimit: BigUInt?
-    
+
     func encode(to encoder: ABIFunctionEncoder) throws {
         try encoder.encode(wallet)
         try encoder.encode(token)
@@ -487,9 +810,9 @@ struct InvalidMethodA: ABIFunction {
     let from: EthereumAddress? = EthereumAddress("0xed0439eacf4c4965ae4613d77a5c2efe10e5f183")
     let gasPrice: BigUInt? = nil
     let gasLimit: BigUInt? = nil
-    
+
     let param: EthereumAddress
-    
+
     struct BoolResponse: ABIResponse {
         static var types: [ABIType.Type] = [Bool.self]
         let value: Bool
@@ -509,9 +832,9 @@ struct InvalidMethodB: ABIFunction {
     let from: EthereumAddress? = EthereumAddress("0xC011A72400E58ecD99Ee497CF89E3775d4bd732F")
     let gasPrice: BigUInt? = nil
     let gasLimit: BigUInt? = nil
-    
+
     let param: EthereumAddress
-    
+
     struct BoolResponse: ABIResponse {
         static var types: [ABIType.Type] = [Bool.self]
         let value: Bool

--- a/web3sTests/Contract/ABIEventTests.swift
+++ b/web3sTests/Contract/ABIEventTests.swift
@@ -12,56 +12,104 @@ import BigInt
 
 class ABIEventTests: XCTestCase {
     var client: EthereumClient!
-    
+
     override func setUp() {
         self.client = EthereumClient(url: URL(string: TestConfig.clientUrl)!)
     }
-    
+
     func test_givenEventWithData4_ItParsesCorrectly() {
         let expect = expectation(description: "Request")
-        
+
         let encodedAddress = (try? ABIEncoder.encode(EthereumAddress("0x3B6Def16666a23905DD29071d13E7a9db08240E2")).bytes) ?? []
-        
+
         client.getEvents(addresses: nil,
                          topics: [try? EnabledStaticCall.signature(),  String(hexFromBytes: encodedAddress), nil],
                          fromBlock: .Number(8386245),
                          toBlock: .Number(8386245),
                          eventTypes: [EnabledStaticCall.self]) { (error, events, logs) in
-                            XCTAssertNil(error)
-                            let event = events.first as? EnabledStaticCall
-                            XCTAssertEqual(event?.module, EthereumAddress("0x3b6def16666a23905dd29071d13e7a9db08240e2"))
-                            XCTAssertEqual(event?.method, Data(hex: "0x20c13b0b")!)
-                            
-                            let event1 = events.last as? EnabledStaticCall
-                            XCTAssertEqual(event1?.module, EthereumAddress("0x3b6def16666a23905dd29071d13e7a9db08240e2"))
-                            XCTAssertEqual(event1?.method, Data(hex: "0x1626ba7e")!)
-                            expect.fulfill()
+            XCTAssertNil(error)
+            let event = events.first as? EnabledStaticCall
+            XCTAssertEqual(event?.module, EthereumAddress("0x3b6def16666a23905dd29071d13e7a9db08240e2"))
+            XCTAssertEqual(event?.method, Data(hex: "0x20c13b0b")!)
+
+            let event1 = events.last as? EnabledStaticCall
+            XCTAssertEqual(event1?.module, EthereumAddress("0x3b6def16666a23905dd29071d13e7a9db08240e2"))
+            XCTAssertEqual(event1?.method, Data(hex: "0x1626ba7e")!)
+            expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: 10)
     }
-    
+
     func test_givenEventWithData32_ItParsesCorrectly() {
         let expect = expectation(description: "Request")
-        
+
         client.getEvents(addresses: nil,
                          topics: [try? UpgraderRegistered.signature()],
                          fromBlock: .Number(
-                         8110676 ),
+                            8110676 ),
                          toBlock: .Number(
-                         8110676 ),
+                            8110676 ),
                          eventTypes: [UpgraderRegistered.self]) { (error, events, logs) in
-                            XCTAssertNil(error)
-                            XCTAssertEqual(events.count, 1)
-                            let event = events.first as? UpgraderRegistered
-                            XCTAssertEqual(event?.upgrader, EthereumAddress("0x17b11d842ae09eddedf5592f8271a7d07f6931e7"))
-                            XCTAssertEqual(event?.name, Data(hex: "0x307864323664616666635f307833373731376663310000000000000000000000")!)
-                            expect.fulfill()
+            XCTAssertNil(error)
+            XCTAssertEqual(events.count, 1)
+            let event = events.first as? UpgraderRegistered
+            XCTAssertEqual(event?.upgrader, EthereumAddress("0x17b11d842ae09eddedf5592f8271a7d07f6931e7"))
+            XCTAssertEqual(event?.name, Data(hex: "0x307864323664616666635f307833373731376663310000000000000000000000")!)
+            expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: 10)
     }
 }
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+extension ABIEventTests {
+    func test_givenEventWithData4_ItParsesCorrectly_Async() async {
+        do {
+            let encodedAddress = (try? ABIEncoder.encode(EthereumAddress("0x3B6Def16666a23905DD29071d13E7a9db08240E2")).bytes) ?? []
+
+            let eventsResult = try await client.getEvents(addresses: nil,
+                                                          topics: [try? EnabledStaticCall.signature(),  String(hexFromBytes: encodedAddress), nil],
+                                                          fromBlock: .Number(8386245),
+                                                          toBlock: .Number(8386245),
+                                                          eventTypes: [EnabledStaticCall.self])
+
+            let eventFirst = eventsResult.events.first as? EnabledStaticCall
+            XCTAssertEqual(eventFirst?.module, EthereumAddress("0x3b6def16666a23905dd29071d13e7a9db08240e2"))
+            XCTAssertEqual(eventFirst?.method, Data(hex: "0x20c13b0b")!)
+
+            let eventLast = eventsResult.events.last as? EnabledStaticCall
+            XCTAssertEqual(eventLast?.module, EthereumAddress("0x3b6def16666a23905dd29071d13e7a9db08240e2"))
+            XCTAssertEqual(eventLast?.method, Data(hex: "0x1626ba7e")!)
+        } catch {
+            XCTFail("Expected events but failed \(error).")
+        }
+    }
+
+    func test_givenEventWithData32_ItParsesCorrectly_Async() async {
+        do {
+            let eventsResult = try await client.getEvents(addresses: nil,
+                                                          topics: [try? UpgraderRegistered.signature()],
+                                                          fromBlock: .Number(
+                                                            8110676 ),
+                                                          toBlock: .Number(
+                                                            8110676 ),
+                                                          eventTypes: [UpgraderRegistered.self])
+
+            XCTAssertEqual(eventsResult.events.count, 1)
+            let event = eventsResult.events.first as? UpgraderRegistered
+            XCTAssertEqual(event?.upgrader, EthereumAddress("0x17b11d842ae09eddedf5592f8271a7d07f6931e7"))
+            XCTAssertEqual(event?.name, Data(hex: "0x307864323664616666635f307833373731376663310000000000000000000000")!)
+        } catch {
+            XCTFail("Expected events but failed \(error).")
+        }
+    }
+}
+
+#endif
 
 struct EnabledStaticCall: ABIEvent {
     static let name = "EnabledStaticCall"
@@ -87,14 +135,14 @@ struct UpgraderRegistered: ABIEvent {
     static let types: [ABIType.Type] = [EthereumAddress.self,Data32.self]
     static let typesIndexed = [true,false]
     let log: EthereumLog
-    
+
     let upgrader: EthereumAddress
     let name: Data
-    
+
     init?(topics: [ABIDecoder.DecodedValue], data: [ABIDecoder.DecodedValue], log: EthereumLog) throws {
         try UpgraderRegistered.checkParameters(topics, data)
         self.log = log
-        
+
         self.upgrader = try topics[0].decoded()
         self.name = try data[0].decoded()
     }

--- a/web3sTests/ENS/ENSTests.swift
+++ b/web3sTests/ENS/ENSTests.swift
@@ -17,21 +17,21 @@ class ENSTests: XCTestCase {
         super.setUp()
         self.client = EthereumClient(url: URL(string: TestConfig.clientUrl)!)
     }
-    
+
     func testGivenName_ThenResolvesNameHash() {
         let name = "argent.test"
         let nameHash = EthereumNameService.nameHash(name: name)
         XCTAssertEqual(nameHash, "0x3e58ef7a2e196baf0b9d36a65cc590ac9edafb3395b7cdeb8f39206049b4534c")
     }
-    
+
     func testGivenRopstenRegistry_WhenExistingDomainName_ResolvesOwnerAddressCorrectly() {
         let expect = expectation(description: "Get the ENS owner")
-        
+
         do {
             let function = ENSContracts.ENSRegistryFunctions.owner(contract: ENSContracts.RopstenAddress, _node: EthereumNameService.nameHash(name: "test").web3.hexData ?? Data())
-            
+
             let tx = try function.transaction()
-            
+
             client?.eth_call(tx, block: .Latest, completion: { (error, dataStr) in
                 guard let dataStr = dataStr else {
                     XCTFail()
@@ -42,88 +42,88 @@ class ENSTests: XCTestCase {
                 XCTAssertEqual(owner.web3.noHexPrefix,"09b5bd82f3351a4c8437fc6d7772a9e6cd5d25a1")
                 expect.fulfill()
             })
-            
+
         } catch {
             XCTFail()
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: 20)
     }
-    
+
     func testGivenRopstenRegistry_WhenExistingAddress_ThenResolvesCorrectly() {
         let expect = expectation(description: "Get the ENS address")
-        
+
         let nameService = EthereumNameService(client: client!)
         nameService.resolve(address: EthereumAddress("0xb0b874220ff95d62a676f58d186c832b3e6529c8"), completion: { (error, ens) in
             XCTAssertEqual("julien.argent.test", ens)
             expect.fulfill()
         })
-        
+
         waitForExpectations(timeout: 20)
     }
-    
+
     func testGivenRopstenRegistry_WhenNotExistingAddress_ThenFailsCorrectly() {
         let expect = expectation(description: "Get the ENS address")
-        
+
         let nameService = EthereumNameService(client: client!)
         nameService.resolve(address: EthereumAddress("0xb0b874220ff95d62a676f58d186c832b3e6529c9"), completion: { (error, ens) in
             XCTAssertNil(ens)
             XCTAssertEqual(error, .ensUnknown)
             expect.fulfill()
         })
-        
+
         waitForExpectations(timeout: 20)
     }
-    
+
     func testGivenCustomRegistry_WhenNotExistingAddress_ThenResolvesFailsCorrectly() {
         let expect = expectation(description: "Get the ENS address")
-        
+
         let nameService = EthereumNameService(client: client!, registryAddress: EthereumAddress("0x7D7C04B7A05539a92541105806e0971E45969F85"))
         nameService.resolve(address: EthereumAddress("0xb0b874220ff95d62a676f58d186c832b3e6529c9"), completion: { (error, ens) in
             XCTAssertNil(ens)
             XCTAssertEqual(error, .ensUnknown)
             expect.fulfill()
         })
-        
+
         waitForExpectations(timeout: 20)
     }
-    
+
     func testGivenRopstenRegistry_WhenExistingENS_ThenResolvesAddressCorrectly() {
         let expect = expectation(description: "Get the ENS reverse lookup address")
-        
+
         let nameService = EthereumNameService(client: client!)
         nameService.resolve(ens: "julien.argent.test", completion: { (error, ens) in
             XCTAssertEqual(EthereumAddress("0xb0b874220ff95d62a676f58d186c832b3e6529c8"), ens)
             expect.fulfill()
         })
-        
+
         waitForExpectations(timeout: 20)
     }
-    
+
     func testGivenRopstenRegistry_WhenInvalidENS_ThenErrorsRequest() {
         let expect = expectation(description: "Get the ENS reverse lookup address")
-        
+
         let nameService = EthereumNameService(client: client!)
         nameService.resolve(ens: "**somegarbage)_!!", completion: { (error, ens) in
             XCTAssertNil(ens)
             XCTAssertEqual(error, .ensUnknown)
             expect.fulfill()
         })
-        
+
         waitForExpectations(timeout: 20)
     }
-    
+
     func testGivenCustomRegistry_WhenInvalidENS_ThenErrorsRequest() {
         let expect = expectation(description: "Get the ENS reverse lookup address")
-        
+
         let nameService = EthereumNameService(client: client!, registryAddress: EthereumAddress("0x7D7C04B7A05539a92541105806e0971E45969F85"))
         nameService.resolve(ens: "**somegarbage)_!!", completion: { (error, ens) in
             XCTAssertNil(ens)
             XCTAssertEqual(error, .ensUnknown)
             expect.fulfill()
         })
-        
+
         waitForExpectations(timeout: 20)
     }
 
@@ -195,3 +195,146 @@ class ENSTests: XCTestCase {
         )
     }
 }
+
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+extension ENSTests {
+    func testGivenRopstenRegistry_WhenExistingDomainName_ResolvesOwnerAddressCorrectly_Async() async {
+        do {
+            let function = ENSContracts.ENSRegistryFunctions.owner(contract: ENSContracts.RopstenAddress, _node: EthereumNameService.nameHash(name: "test").web3.hexData ?? Data())
+
+            let tx = try function.transaction()
+
+            let dataStr = try await client?.eth_call(tx, block: .Latest)
+            guard let dataStr = dataStr else {
+                XCTFail()
+                return
+            }
+
+            let owner = String(dataStr[dataStr.index(dataStr.endIndex, offsetBy: -40)...])
+            XCTAssertEqual(owner.web3.noHexPrefix,"09b5bd82f3351a4c8437fc6d7772a9e6cd5d25a1")
+        } catch {
+            XCTFail("Expected dataStr but failed \(error).")
+        }
+    }
+
+    func testGivenRopstenRegistry_WhenExistingAddress_ThenResolvesCorrectly_Async() async {
+        do {
+            let nameService = EthereumNameService(client: client!)
+            let ens = try await nameService.resolve(address: EthereumAddress("0xb0b874220ff95d62a676f58d186c832b3e6529c8"))
+            XCTAssertEqual("julien.argent.test", ens)
+        } catch {
+            XCTFail("Expected ens but failed \(error).")
+        }
+    }
+
+    func testGivenRopstenRegistry_WhenNotExistingAddress_ThenFailsCorrectly_Async() async {
+        do {
+            let nameService = EthereumNameService(client: client!)
+            _ = try await nameService.resolve(address: EthereumAddress("0xb0b874220ff95d62a676f58d186c832b3e6529c9"))
+            XCTFail("Expected to throw while awaiting, but succeeded")
+        } catch {
+            XCTAssertEqual(error as? EthereumNameServiceError, .ensUnknown)
+        }
+    }
+
+    func testGivenCustomRegistry_WhenNotExistingAddress_ThenResolvesFailsCorrectly_Async() async {
+        do {
+            let nameService = EthereumNameService(client: client!, registryAddress: EthereumAddress("0x7D7C04B7A05539a92541105806e0971E45969F85"))
+            _ = try await nameService.resolve(address: EthereumAddress("0xb0b874220ff95d62a676f58d186c832b3e6529c9"))
+            XCTFail("Expected to throw while awaiting, but succeeded")
+        } catch {
+            XCTAssertEqual(error as? EthereumNameServiceError, .ensUnknown)
+        }
+    }
+
+    func testGivenRopstenRegistry_WhenExistingENS_ThenResolvesAddressCorrectly_Async() async {
+        do {
+            let nameService = EthereumNameService(client: client!)
+            let ens = try await nameService.resolve(ens: "julien.argent.test")
+            XCTAssertEqual(EthereumAddress("0xb0b874220ff95d62a676f58d186c832b3e6529c8"), ens)
+        } catch {
+            XCTFail("Expected ens but failed \(error).")
+        }
+    }
+
+    func testGivenRopstenRegistry_WhenInvalidENS_ThenErrorsRequest_Async() async {
+        do {
+            let nameService = EthereumNameService(client: client!)
+            _ = try await nameService.resolve(ens: "**somegarbage)_!!")
+            XCTFail("Expected to throw while awaiting, but succeeded")
+        } catch {
+            XCTAssertEqual(error as? EthereumNameServiceError, .ensUnknown)
+        }
+    }
+
+    func testGivenCustomRegistry_WhenInvalidENS_ThenErrorsRequest_Async() async {
+        do {
+            let nameService = EthereumNameService(client: client!, registryAddress: EthereumAddress("0x7D7C04B7A05539a92541105806e0971E45969F85"))
+            _ = try await nameService.resolve(ens: "**somegarbage)_!!")
+            XCTFail("Expected to throw while awaiting, but succeeded")
+        } catch {
+            XCTAssertEqual(error as? EthereumNameServiceError, .ensUnknown)
+        }
+    }
+
+    func testGivenRopstenRegistry_ThenResolvesMultipleAddressesInOneCall_Async() async {
+        let nameService = EthereumNameService(client: client!)
+
+        var results: [EthereumNameService.ResolveOutput<String>]?
+
+        let result = await nameService.resolve(addresses: [
+            EthereumAddress("0xb0b874220ff95d62a676f58d186c832b3e6529c8"),
+            EthereumAddress("0x09b5bd82f3351a4c8437fc6d7772a9e6cd5d25a1"),
+            EthereumAddress("0x7e691d7ffb007abe91d8a24d7f22fc74307dab06")
+        ])
+
+        switch result {
+        case .success(let resolutions):
+            results = resolutions.map { $0.output }
+        case .failure:
+            break
+        }
+
+        XCTAssertEqual(
+            results,
+            [
+                .resolved("julien.argent.test"),
+                .couldNotBeResolved(.ensUnknown),
+                .resolved("davidtests.argent.xyz")
+            ]
+        )
+    }
+
+    func testGivenRopstenRegistry_ThenResolvesMultipleNamesInOneCall_Async() async {
+        let nameService = EthereumNameService(client: client!)
+
+        var results: [EthereumNameService.ResolveOutput<EthereumAddress>]?
+
+        let result = await nameService.resolve(names: [
+            "julien.argent.test",
+            "davidtests.argent.xyz",
+            "somefakeens.argent.xyz"
+        ])
+
+        switch result {
+        case .success(let resolutions):
+            results = resolutions.map { $0.output }
+        case .failure:
+            break
+        }
+
+        XCTAssertEqual(
+            results,
+            [
+                .resolved(EthereumAddress("0xb0b874220ff95d62a676f58d186c832b3e6529c8")),
+                .resolved(EthereumAddress("0x7e691d7ffb007abe91d8a24d7f22fc74307dab06")),
+                .couldNotBeResolved(.ensUnknown)
+            ]
+        )
+    }
+}
+
+#endif

--- a/web3sTests/ERC165/ERC165Tests.swift
+++ b/web3sTests/ERC165/ERC165Tests.swift
@@ -14,17 +14,17 @@ class ERC165Tests: XCTestCase {
     var client: EthereumClient!
     var erc165: ERC165!
     let address = EthereumAddress(TestConfig.erc165Contract)
-    
+
     override func setUp() {
         super.setUp()
         self.client = EthereumClient(url: URL(string: TestConfig.clientUrl)!)
         self.erc165 = ERC165(client: client)
     }
-    
+
     func test_InterfaceIDMatch() {
         XCTAssertEqual(ERC165Functions.interfaceId.web3.hexString, "0x01ffc9a7")
     }
-    
+
     func test_GivenInterfaceffff_returnsNotSupported() {
         let expect = expectation(description: "Supports own interface")
         erc165.supportsInterface(contract: address,
@@ -33,19 +33,44 @@ class ERC165Tests: XCTestCase {
             XCTAssertEqual(supported, false)
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: 10)
     }
-    
+
     func test_GivenInterfaceERC165_returnsSupported() {
         let expect = expectation(description: "Supports own interface")
         erc165.supportsInterface(contract: address,
                                  id: ERC165Functions.interfaceId) { (error, supported) in
-                                    XCTAssertNil(error)
-                                    XCTAssertEqual(supported, true)
-                                    expect.fulfill()
+            XCTAssertNil(error)
+            XCTAssertEqual(supported, true)
+            expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: 10)
     }
 }
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+extension ERC165Tests {
+    func test_GivenInterfaceffff_returnsNotSupported_Async() async {
+        do {
+            let supported = try await erc165.supportsInterface(contract: address, id: "0xffffffff".web3.hexData!)
+            XCTAssertEqual(supported, false)
+        } catch {
+            XCTFail("Expected supported but failed \(error).")
+        }
+    }
+
+    func test_GivenInterfaceERC165_returnsSupported_Async() async {
+        do {
+            let supported = try await erc165.supportsInterface(contract: address, id: ERC165Functions.interfaceId)
+            XCTAssertEqual(supported, true)
+        } catch {
+            XCTFail("Expected supported but failed \(error).")
+        }
+    }
+}
+
+#endif

--- a/web3sTests/ERC20/ERC20Tests.swift
+++ b/web3sTests/ERC20/ERC20Tests.swift
@@ -14,17 +14,17 @@ class ERC20Tests: XCTestCase {
     var client: EthereumClient?
     var erc20: ERC20?
     let testContractAddress = EthereumAddress(TestConfig.erc20Contract)
-    
+
     override func setUp() {
         super.setUp()
         self.client = EthereumClient(url: URL(string: TestConfig.clientUrl)!)
         self.erc20 = ERC20(client: client!)
     }
-    
+
     override func tearDown() {
         super.tearDown()
     }
-    
+
     func testName() {
         let expect = expectation(description: "Get token name")
         erc20?.name(tokenContract: self.testContractAddress, completion: { (error, name) in
@@ -34,7 +34,7 @@ class ERC20Tests: XCTestCase {
         })
         waitForExpectations(timeout: 10)
     }
-    
+
     func testNonZeroDecimals() {
         let expect = expectation(description: "Get token decimals")
         erc20?.decimals(tokenContract: self.testContractAddress, completion: { (error, decimals) in
@@ -44,7 +44,7 @@ class ERC20Tests: XCTestCase {
         })
         waitForExpectations(timeout: 10)
     }
-    
+
     func testZeroDecimals() {
         let expect = expectation(description: "Get token decimals (0)")
         erc20?.decimals(tokenContract: EthereumAddress("0x40dd3ac2481960cf34d96e647dd0bc52a1f03f52"), completion: { (error, decimals) in
@@ -54,7 +54,7 @@ class ERC20Tests: XCTestCase {
         })
         waitForExpectations(timeout: 10)
     }
-    
+
     func testSymbol() {
         let expect = expectation(description: "Get token symbol")
         erc20?.symbol(tokenContract: self.testContractAddress, completion: { (error, symbol) in
@@ -64,47 +64,47 @@ class ERC20Tests: XCTestCase {
         })
         waitForExpectations(timeout: 10)
     }
-    
+
     func testTransferRawEvent() {
         let expect = expectation(description: "Get transfer event")
-        
+
         let result = try! ABIEncoder.encode(EthereumAddress("0x72e3b687805ef66bf2a1e6d9f03faf8b33f0267a"))
         let sig = try! ERC20Events.Transfer.signature()
         let topics = [ sig, result.hexString]
-    
+
         self.client?.getEvents(addresses: nil, topics: topics, fromBlock: .Earliest, toBlock: .Latest, eventTypes: [ERC20Events.Transfer.self], completion: { (error, events, unprocessed) in
             XCTAssert(events.count > 0)
             expect.fulfill()
         })
         waitForExpectations(timeout: 10)
     }
-    
+
     func testGivenAddressWithInTransfers_ThenGetsTheTransferEvents() {
         let expect = expectation(description: "Get transfer events to")
-        
+
         erc20?.transferEventsTo(recipient: EthereumAddress("0x72e3b687805ef66bf2a1e6d9f03faf8b33f0267a"), fromBlock: .Earliest, toBlock: .Latest, completion: { (error, events) in
             XCTAssert(events!.count > 0)
             expect.fulfill()
         })
-        
+
         waitForExpectations(timeout: 10)
     }
-    
+
     func testGivenAddressWithoutInTransfers_ThenGetsNoTransferEvents() {
         let expect = expectation(description: "Get transfer events to")
-        
+
         erc20?.transferEventsTo(recipient: EthereumAddress("0x78eac6878f5ef99bf2b12698f03faf8b33f02676"), fromBlock: .Earliest, toBlock: .Latest, completion: { (error, events) in
             XCTAssertEqual(events?.count, 0)
             expect.fulfill()
         })
-        
+
         waitForExpectations(timeout: 10)
     }
-    
-    
+
+
     func testGivenAddressWithOutgoingEvents_ThenGetsTheTransferEvents() {
         let expect = expectation(description: "Get transfer events to")
-        
+
         erc20?.transferEventsFrom(sender: EthereumAddress("0x2FB78FA9842f20bfD515A41C3196C4b368bDbC48"), fromBlock: .Earliest, toBlock: .Latest, completion: { (error, events) in
             XCTAssertEqual(events?.first?.log.transactionHash, "0xfb6e0d7fdf8f9b97fe9b634cb5abc7041ee47a396191f23425955f9fda008efe")
             XCTAssertEqual(events?.first?.to, EthereumAddress("0xFe325C1E3396b2285d517B0CE2E3ffA472260Bce"))
@@ -112,19 +112,115 @@ class ERC20Tests: XCTestCase {
             XCTAssertEqual(events?.first?.log.address, EthereumAddress("0xdb0040451f373949a4be60dcd7b6b8d6e42658b6"))
             expect.fulfill()
         })
-        
+
         waitForExpectations(timeout: 10)
     }
-    
+
     func testGivenAddressWithoutOutgoingEvents_ThenGetsTheTransferEvents() {
         let expect = expectation(description: "Get transfer events to")
-        
+
         erc20?.transferEventsFrom(sender: EthereumAddress("0x78eac6878f5ef99bf2b12698f03faf8b33f02676"), fromBlock: .Earliest, toBlock: .Latest, completion: { (error, events) in
             XCTAssertEqual(events?.count, 0)
             expect.fulfill()
         })
-        
+
         waitForExpectations(timeout: 10)
     }
-    
+
 }
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+extension ERC20Tests {
+    func testName_Async() async {
+        do {
+            let name = try await erc20?.name(tokenContract: self.testContractAddress)
+            XCTAssertEqual(name, "BokkyPooBah Test Token")
+        } catch {
+            XCTFail("Expected name but failed \(error).")
+        }
+    }
+
+    func testNonZeroDecimals_Async() async {
+        do {
+            let decimals = try await erc20?.decimals(tokenContract: self.testContractAddress)
+            XCTAssertEqual(decimals, 18)
+        } catch {
+            XCTFail("Expected decimals but failed \(error).")
+        }
+    }
+
+    func testZeroDecimals_Async() async {
+        do {
+            let decimals = try await erc20?.decimals(tokenContract: EthereumAddress("0x40dd3ac2481960cf34d96e647dd0bc52a1f03f52"))
+            XCTAssertEqual(decimals, 0)
+        } catch {
+            XCTFail("Expected decimals but failed \(error).")
+        }
+    }
+
+    func testSymbol_Async() async {
+        do {
+            let symbol = try await erc20?.symbol(tokenContract: self.testContractAddress)
+            XCTAssertEqual(symbol, "BOKKY")
+        } catch {
+            XCTFail("Expected symbol but failed \(error).")
+        }
+    }
+
+    func testTransferRawEvent_Async() async {
+        do {
+            let result = try! ABIEncoder.encode(EthereumAddress("0x72e3b687805ef66bf2a1e6d9f03faf8b33f0267a"))
+            let sig = try! ERC20Events.Transfer.signature()
+            let topics = [ sig, result.hexString]
+
+            let eventResults = try await self.client?.getEvents(addresses: nil, topics: topics, fromBlock: .Earliest, toBlock: .Latest, eventTypes: [ERC20Events.Transfer.self])
+            XCTAssert(eventResults!.events.count > 0)
+        } catch {
+            XCTFail("Expected eventResults but failed \(error).")
+        }
+    }
+
+    func testGivenAddressWithInTransfers_ThenGetsTheTransferEvents_Async() async {
+        do {
+            let events = try await erc20?.transferEventsTo(recipient: EthereumAddress("0x72e3b687805ef66bf2a1e6d9f03faf8b33f0267a"), fromBlock: .Earliest, toBlock: .Latest)
+            XCTAssert(events!.count > 0)
+        } catch {
+            XCTFail("Expected events but failed \(error).")
+        }
+    }
+
+    func testGivenAddressWithoutInTransfers_ThenGetsNoTransferEvents_Async() async {
+        do {
+            let events = try await erc20?.transferEventsTo(recipient: EthereumAddress("0x78eac6878f5ef99bf2b12698f03faf8b33f02676"), fromBlock: .Earliest, toBlock: .Latest)
+            XCTAssertEqual(events?.count, 0)
+        } catch {
+            XCTFail("Expected events but failed \(error).")
+        }
+    }
+
+
+    func testGivenAddressWithOutgoingEvents_ThenGetsTheTransferEvents_Async() async {
+        do {
+            let events = try await erc20?.transferEventsFrom(sender: EthereumAddress("0x2FB78FA9842f20bfD515A41C3196C4b368bDbC48"), fromBlock: .Earliest, toBlock: .Latest)
+            XCTAssertEqual(events?.first?.log.transactionHash, "0xfb6e0d7fdf8f9b97fe9b634cb5abc7041ee47a396191f23425955f9fda008efe")
+            XCTAssertEqual(events?.first?.to, EthereumAddress("0xFe325C1E3396b2285d517B0CE2E3ffA472260Bce"))
+            XCTAssertEqual(events?.first?.value, BigUInt(10).power(18))
+            XCTAssertEqual(events?.first?.log.address, EthereumAddress("0xdb0040451f373949a4be60dcd7b6b8d6e42658b6"))
+        } catch {
+            XCTFail("Expected events but failed \(error).")
+        }
+    }
+
+    func testGivenAddressWithoutOutgoingEvents_ThenGetsTheTransferEvents_Async() async {
+        do {
+            let events = try await erc20?.transferEventsFrom(sender: EthereumAddress("0x78eac6878f5ef99bf2b12698f03faf8b33f02676"), fromBlock: .Earliest, toBlock: .Latest)
+            XCTAssertEqual(events?.count, 0)
+        } catch {
+            XCTFail("Expected events but failed \(error).")
+        }
+    }
+}
+
+#endif

--- a/web3sTests/ERC721/ERC721Tests.swift
+++ b/web3sTests/ERC721/ERC721Tests.swift
@@ -24,14 +24,14 @@ class ERC721Tests: XCTestCase {
     var client: EthereumClient!
     var erc721: ERC721!
     let address = EthereumAddress(TestConfig.erc721Contract)
-    
-    
+
+
     override func setUp() {
         super.setUp()
         self.client = EthereumClient(url: URL(string: TestConfig.clientUrl)!)
         self.erc721 = ERC721(client: client)
     }
-    
+
     func test_GivenAccountWithNFT_ThenBalanceCorrect() {
         let expect = expectation(description: "BalanceOf")
         erc721.balanceOf(contract: address, address: tokenOwner) { (error, balance) in
@@ -39,10 +39,10 @@ class ERC721Tests: XCTestCase {
             XCTAssertEqual(balance, BigUInt(3))
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: 10)
     }
-    
+
     func test_GivenAccountWithNOBalance_ThenBalanceCorrect() {
         let expect = expectation(description: "BalanceOf")
         erc721.balanceOf(contract: address, address: nonOwner) { (error, balance) in
@@ -50,10 +50,10 @@ class ERC721Tests: XCTestCase {
             XCTAssertEqual(balance, BigUInt(0))
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: 10)
     }
-    
+
     func test_GivenAccountWithNFT_ThenOwnerOfNFTIsAccount() {
         let expect = expectation(description: "OwnerOf")
         erc721.ownerOf(contract: address, tokenId: 23) { (error, balance) in
@@ -61,10 +61,10 @@ class ERC721Tests: XCTestCase {
             XCTAssertEqual(balance, tokenOwner)
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: 10)
     }
-    
+
     func test_GivenAccountWithNFT_ThenOwnerOfAnotherNFTIsNotAccount() {
         let expect = expectation(description: "OwnerOf")
         erc721.ownerOf(contract: address, tokenId: 22) { (error, balance) in
@@ -72,13 +72,13 @@ class ERC721Tests: XCTestCase {
             XCTAssertNotEqual(balance, tokenOwner)
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: 10)
     }
-    
+
     func test_GivenAddressWithTransfer_FindsInTransferEvent() {
         let expect = expectation(description: "Events")
-        
+
         erc721.transferEventsTo(recipient: tokenOwner,
                                 fromBlock: .Number(
                                     6948276),
@@ -90,25 +90,25 @@ class ERC721Tests: XCTestCase {
             XCTAssertEqual(events?.first?.tokenId, 23)
             expect.fulfill()
         })
-        
+
         waitForExpectations(timeout: 10)
     }
-    
+
     func test_GivenAddressWithTransfer_FindsOutTransferEvent() {
         let expect = expectation(description: "Events")
-        
+
         erc721.transferEventsFrom(sender: previousOwner,
-                                fromBlock: .Number(
+                                  fromBlock: .Number(
                                     6948276),
-                                toBlock: .Number(
+                                  toBlock: .Number(
                                     6948276),
-                                completion: { (error, events) in
+                                  completion: { (error, events) in
             XCTAssertEqual(events?.first?.to, tokenOwner)
             XCTAssertEqual(events?.first?.from, previousOwner)
             XCTAssertEqual(events?.first?.tokenId, 23)
             expect.fulfill()
         })
-        
+
         waitForExpectations(timeout: 10)
     }
 }
@@ -122,18 +122,18 @@ class ERC721MetadataTests: XCTestCase {
                                           properties: ERC721Metadata.Token.Properties(name: ERC721Metadata.Token.Property(description: "Random Graph Token"),
                                                                                       description: ERC721Metadata.Token.Property(description: "NFT to represent Random Graph"),
                                                                                       image:  ERC721Metadata.Token.Property(description: nftImageURL)))
-    
+
     override func setUp() {
         super.setUp()
         self.client = EthereumClient(url: URL(string: TestConfig.clientUrl)!)
         self.erc721 = ERC721Metadata(client: client, metadataSession: URLSession.shared)
     }
-    
-    
+
+
     func test_InterfaceIDMatch() {
         XCTAssertEqual(ERC721MetadataFunctions.interfaceId.web3.hexString, "0x5b5e139f")
     }
-    
+
     func test_ReturnsName() {
         let expect = expectation(description: "name")
         erc721.name(contract: address) { (error, name) in
@@ -141,10 +141,10 @@ class ERC721MetadataTests: XCTestCase {
             XCTAssertEqual(name, "Graph Art Token")
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: 10)
     }
-    
+
     func test_ReturnsSymbol() {
         let expect = expectation(description: "symbol")
         erc721.symbol(contract: address) { (error, symbol) in
@@ -152,10 +152,10 @@ class ERC721MetadataTests: XCTestCase {
             XCTAssertEqual(symbol, "GAT")
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: 10)
     }
-    
+
     func test_ReturnsMetatadaURI() {
         let expect = expectation(description: "tokenURI")
         erc721.tokenURI(contract: address, tokenID: 23) { (error, url) in
@@ -163,10 +163,10 @@ class ERC721MetadataTests: XCTestCase {
             XCTAssertEqual(url, nftURL)
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: 10)
     }
-    
+
     func test_ReturnsMetatada() {
         let expect = expectation(description: "tokenMetadata")
         erc721.tokenMetadata(contract: address, tokenID: 23) { (error, metadata) in
@@ -174,7 +174,7 @@ class ERC721MetadataTests: XCTestCase {
             XCTAssertEqual(metadata, self.nftDetails)
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: 10)
     }
 }
@@ -183,17 +183,17 @@ class ERC721EnumerableTests: XCTestCase {
     var client: EthereumClient!
     var erc721: ERC721Enumerable!
     let address = EthereumAddress(TestConfig.erc721Contract)
-    
+
     override func setUp() {
         super.setUp()
         self.client = EthereumClient(url: URL(string: TestConfig.clientUrl)!)
         self.erc721 = ERC721Enumerable(client: client)
     }
-    
+
     func test_InterfaceIDMatch() {
         XCTAssertEqual(ERC721EnumerableFunctions.interfaceId.web3.hexString, "0x780e9d63")
     }
-    
+
     func test_returnsTotalSupply() {
         let expect = expectation(description: "totalSupply")
         erc721.totalSupply(contract: address) { (error, supply) in
@@ -201,10 +201,10 @@ class ERC721EnumerableTests: XCTestCase {
             XCTAssertGreaterThan(supply ?? 0, 22)
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: 10)
     }
-    
+
     func test_returnsTokenByIndex() {
         let expect = expectation(description: "tokenByIndex")
         erc721.tokenByIndex(contract: address, index: 22) { (error, index) in
@@ -212,10 +212,10 @@ class ERC721EnumerableTests: XCTestCase {
             XCTAssertEqual(index, 23)
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: 10)
     }
-    
+
     func test_GivenAddressWithNFT_returnsTokenOfOwnerByIndex() {
         let expect = expectation(description: "tokenByIndex")
         erc721.tokenOfOwnerByIndex(contract: address, owner: tokenOwner, index: 2) { error, tokenID in
@@ -223,10 +223,10 @@ class ERC721EnumerableTests: XCTestCase {
             XCTAssertEqual(tokenID, 23)
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: 10)
     }
-    
+
     func test_GivenAddressWithNoNFT_returnsIdZero() {
         let expect = expectation(description: "tokenByIndex")
         erc721.tokenOfOwnerByIndex(contract: address, owner: nonOwner, index: 0) { error, tokenID in
@@ -234,7 +234,159 @@ class ERC721EnumerableTests: XCTestCase {
             XCTAssertEqual(tokenID, 0)
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: 10)
     }
 }
+
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+extension ERC721Tests {
+    func test_GivenAccountWithNFT_ThenBalanceCorrect_Async() async {
+        do {
+            let balance = try await erc721.balanceOf(contract: address, address: tokenOwner)
+            XCTAssertEqual(balance, BigUInt(3))
+        } catch {
+            XCTFail("Expected balance but failed \(error).")
+        }
+    }
+
+    func test_GivenAccountWithNOBalance_ThenBalanceCorrect_Async() async {
+        do {
+            let balance = try await erc721.balanceOf(contract: address, address: nonOwner)
+            XCTAssertEqual(balance, BigUInt(0))
+        } catch {
+            XCTFail("Expected balance but failed \(error).")
+        }
+    }
+
+    func test_GivenAccountWithNFT_ThenOwnerOfNFTIsAccount_Async() async {
+        do {
+            let balance = try await erc721.ownerOf(contract: address, tokenId: 23)
+            XCTAssertEqual(balance, tokenOwner)
+        } catch {
+            XCTFail("Expected OwnerOf but failed \(error).")
+        }
+    }
+
+    func test_GivenAccountWithNFT_ThenOwnerOfAnotherNFTIsNotAccount_Async() async {
+        do {
+            let balance = try await erc721.ownerOf(contract: address, tokenId: 22)
+            XCTAssertNotEqual(balance, tokenOwner)
+        } catch {
+            XCTFail("Expected OwnerOf but failed \(error).")
+        }
+    }
+
+    func test_GivenAddressWithTransfer_FindsInTransferEvent_Async() async {
+        do {
+            let events = try await erc721.transferEventsTo(recipient: tokenOwner,
+                                                           fromBlock: .Number(
+                                                            6948276),
+                                                           toBlock: .Number(
+                                                            6948276))
+            XCTAssertEqual(events.first?.from, previousOwner)
+            XCTAssertEqual(events.first?.to, tokenOwner)
+            XCTAssertEqual(events.first?.tokenId, 23)
+        } catch {
+            XCTFail("Expected Events but failed \(error).")
+        }
+    }
+
+    func test_GivenAddressWithTransfer_FindsOutTransferEvent_Async() async {
+        do {
+            let events = try await erc721.transferEventsFrom(sender: previousOwner,
+                                                             fromBlock: .Number(
+                                                                6948276),
+                                                             toBlock: .Number(
+                                                                6948276))
+            XCTAssertEqual(events.first?.to, tokenOwner)
+            XCTAssertEqual(events.first?.from, previousOwner)
+            XCTAssertEqual(events.first?.tokenId, 23)
+        } catch {
+            XCTFail("Expected Events but failed \(error).")
+        }
+    }
+}
+
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+extension ERC721MetadataTests {
+    func test_ReturnsName_Async() async {
+        do {
+            let name = try await erc721.name(contract: address)
+            XCTAssertEqual(name, "Graph Art Token")
+        } catch {
+            XCTFail("Expected name but failed \(error).")
+        }
+    }
+
+    func test_ReturnsSymbol_Async() async {
+        do {
+            let symbol = try await erc721.symbol(contract: address)
+            XCTAssertEqual(symbol, "GAT")
+        } catch {
+            XCTFail("Expected symbol but failed \(error).")
+        }
+    }
+
+    func test_ReturnsMetatadaURI_Async() async {
+        do {
+            let url = try await erc721.tokenURI(contract: address, tokenID: 23)
+            XCTAssertEqual(url, nftURL)
+        } catch {
+            XCTFail("Expected tokenURI but failed \(error).")
+        }
+    }
+
+    func test_ReturnsMetatada_Async() async {
+        do {
+            let metadata = try await erc721.tokenMetadata(contract: address, tokenID: 23)
+            XCTAssertEqual(metadata, self.nftDetails)
+        } catch {
+            XCTFail("Expected tokenMetadata but failed \(error).")
+        }
+    }
+}
+
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+extension ERC721EnumerableTests {
+    func test_returnsTotalSupply_Async() async {
+        do {
+            let supply = try await erc721.totalSupply(contract: address)
+            XCTAssertGreaterThan(supply, 22)
+        } catch {
+            XCTFail("Expected totalSupply but failed \(error).")
+        }
+    }
+
+    func test_returnsTokenByIndex_Async() async {
+        do {
+            let index = try await erc721.tokenByIndex(contract: address, index: 22)
+            XCTAssertEqual(index, 23)
+        } catch {
+            XCTFail("Expected tokenByIndex but failed \(error).")
+        }
+    }
+
+    func test_GivenAddressWithNFT_returnsTokenOfOwnerByIndex_Async() async {
+        do {
+            let tokenID = try await erc721.tokenOfOwnerByIndex(contract: address, owner: tokenOwner, index: 2)
+            XCTAssertEqual(tokenID, 23)
+        } catch {
+            XCTFail("Expected tokenByIndex but failed \(error).")
+        }
+    }
+
+    func test_GivenAddressWithNoNFT_returnsIdZero_Async() async {
+        do {
+            let tokenID = try await erc721.tokenOfOwnerByIndex(contract: address, owner: nonOwner, index: 0)
+            XCTAssertEqual(tokenID, 0)
+        } catch {
+            XCTFail("Expected tokenByIndex but failed \(error).")
+        }
+    }
+}
+
+#endif

--- a/web3swift/src/Client/EthereumClient.swift
+++ b/web3swift/src/Client/EthereumClient.swift
@@ -17,7 +17,7 @@ public protocol EthereumClientProtocol {
     init(url: URL, sessionConfig: URLSessionConfiguration)
     init(url: URL)
     var network: EthereumNetwork? { get }
-    
+
     func net_version(completion: @escaping((EthereumClientError?, EthereumNetwork?) -> Void))
     func eth_gasPrice(completion: @escaping((EthereumClientError?, BigUInt?) -> Void))
     func eth_blockNumber(completion: @escaping((EthereumClientError?, Int?) -> Void))
@@ -32,6 +32,50 @@ public protocol EthereumClientProtocol {
     func eth_getLogs(addresses: [EthereumAddress]?, topics: [String?]?, fromBlock: EthereumBlock, toBlock: EthereumBlock, completion: @escaping((EthereumClientError?, [EthereumLog]?) -> Void))
     func eth_getLogs(addresses: [EthereumAddress]?, orTopics: [[String]?]?, fromBlock: EthereumBlock, toBlock: EthereumBlock, completion: @escaping((EthereumClientError?, [EthereumLog]?) -> Void))
     func eth_getBlockByNumber(_ block: EthereumBlock, completion: @escaping((EthereumClientError?, EthereumBlockInfo?) -> Void))
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func net_version() async throws -> EthereumNetwork
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func eth_gasPrice() async throws -> BigUInt
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func eth_blockNumber() async throws -> Int
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func eth_getBalance(address: EthereumAddress, block: EthereumBlock) async throws -> BigUInt
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func eth_getCode(address: EthereumAddress, block: EthereumBlock) async throws -> String
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func eth_estimateGas(_ transaction: EthereumTransaction, withAccount account: EthereumAccountProtocol) async throws -> BigUInt
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func eth_sendRawTransaction(_ transaction: EthereumTransaction, withAccount account: EthereumAccountProtocol) async throws -> String
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func eth_getTransactionCount(address: EthereumAddress, block: EthereumBlock) async throws -> Int
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func eth_getTransaction(byHash txHash: String) async throws -> EthereumTransaction
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func eth_getTransactionReceipt(txHash: String) async throws -> EthereumTransactionReceipt
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func eth_call(_ transaction: EthereumTransaction, block: EthereumBlock) async throws -> String
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func eth_getLogs(addresses: [EthereumAddress]?, topics: [String?]?, fromBlock: EthereumBlock, toBlock: EthereumBlock) async throws ->  [EthereumLog]
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func eth_getLogs(addresses: [EthereumAddress]?, orTopics: [[String]?]?, fromBlock: EthereumBlock, toBlock: EthereumBlock) async throws ->  [EthereumLog]
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func eth_getBlockByNumber(_ block: EthereumBlock) async throws -> EthereumBlockInfo
+#endif
 }
 
 public enum EthereumClientError: Error, Equatable {
@@ -47,20 +91,20 @@ public enum EthereumClientError: Error, Equatable {
 public class EthereumClient: EthereumClientProtocol {
     public let url: URL
     private var retreivedNetwork: EthereumNetwork?
-    
+
     private let networkQueue: OperationQueue
     private let concurrentQueue: OperationQueue
-    
+
     public let session: URLSession
-    
+
     public var network: EthereumNetwork? {
         if let _ = self.retreivedNetwork {
             return self.retreivedNetwork
         }
-        
+
         let group = DispatchGroup()
         group.enter()
-        
+
         var network: EthereumNetwork?
         self.net_version { (error, retreivedNetwork) in
             if let error = error {
@@ -69,14 +113,14 @@ public class EthereumClient: EthereumClientProtocol {
                 network = retreivedNetwork
                 self.retreivedNetwork = network
             }
-            
+
             group.leave()
         }
-        
+
         group.wait()
         return network
     }
-    
+
     required public init(url: URL, sessionConfig: URLSessionConfiguration) {
         self.url = url
         let networkQueue = OperationQueue()
@@ -84,24 +128,24 @@ public class EthereumClient: EthereumClientProtocol {
         networkQueue.qualityOfService = .background
         networkQueue.maxConcurrentOperationCount = 4
         self.networkQueue = networkQueue
-        
+
         let txQueue = OperationQueue()
         txQueue.name = "web3swift.client.rawTxQueue"
         txQueue.qualityOfService = .background
         txQueue.maxConcurrentOperationCount = 1
         self.concurrentQueue = txQueue
-        
+
         self.session = URLSession(configuration: sessionConfig, delegate: nil, delegateQueue: networkQueue)
     }
-    
+
     required public convenience init(url: URL) {
         self.init(url: url, sessionConfig: URLSession.shared.configuration)
     }
-    
+
     deinit {
         self.session.invalidateAndCancel()
     }
-    
+
     public func net_version(completion: @escaping ((EthereumClientError?, EthereumNetwork?) -> Void)) {
         let emptyParams: Array<Bool> = []
         EthereumRPC.execute(session: session, url: url, method: "net_version", params: emptyParams, receive: String.self) { (error, response) in
@@ -113,7 +157,7 @@ public class EthereumClient: EthereumClientProtocol {
             }
         }
     }
-    
+
     public func eth_gasPrice(completion: @escaping ((EthereumClientError?, BigUInt?) -> Void)) {
         let emptyParams: Array<Bool> = []
         EthereumRPC.execute(session: session, url: url, method: "eth_gasPrice", params: emptyParams, receive: String.self) { (error, response) in
@@ -124,7 +168,7 @@ public class EthereumClient: EthereumClientProtocol {
             }
         }
     }
-    
+
     public func eth_blockNumber(completion: @escaping ((EthereumClientError?, Int?) -> Void)) {
         let emptyParams: Array<Bool> = []
         EthereumRPC.execute(session: session, url: url, method: "eth_blockNumber", params: emptyParams, receive: String.self) { (error, response) in
@@ -139,7 +183,7 @@ public class EthereumClient: EthereumClientProtocol {
             }
         }
     }
-    
+
     public func eth_getBalance(address: EthereumAddress, block: EthereumBlock, completion: @escaping ((EthereumClientError?, BigUInt?) -> Void)) {
         EthereumRPC.execute(session: session, url: url, method: "eth_getBalance", params: [address.value, block.stringValue], receive: String.self) { (error, response) in
             if let resString = response as? String, let balanceInt = BigUInt(hex: resString.web3.noHexPrefix) {
@@ -149,7 +193,7 @@ public class EthereumClient: EthereumClientProtocol {
             }
         }
     }
-    
+
     public func eth_getCode(address: EthereumAddress, block: EthereumBlock = .Latest, completion: @escaping((EthereumClientError?, String?) -> Void)) {
         EthereumRPC.execute(session: session, url: url, method: "eth_getCode", params: [address.value, block.stringValue], receive: String.self) { (error, response) in
             if let resDataString = response as? String {
@@ -159,9 +203,9 @@ public class EthereumClient: EthereumClientProtocol {
             }
         }
     }
-    
+
     public func eth_estimateGas(_ transaction: EthereumTransaction, withAccount account: EthereumAccountProtocol, completion: @escaping((EthereumClientError?, BigUInt?) -> Void)) {
-        
+
         struct CallParams: Encodable {
             let from: String?
             let to: String
@@ -169,7 +213,7 @@ public class EthereumClient: EthereumClientProtocol {
             let gasPrice: String?
             let value: String?
             let data: String?
-            
+
             enum TransactionCodingKeys: String, CodingKey {
                 case from
                 case to
@@ -178,7 +222,7 @@ public class EthereumClient: EthereumClientProtocol {
                 case value
                 case data
             }
-            
+
             func encode(to encoder: Encoder) throws {
                 var container = encoder.unkeyedContainer()
                 var nested = container.nestedContainer(keyedBy: TransactionCodingKeys.self)
@@ -186,11 +230,11 @@ public class EthereumClient: EthereumClientProtocol {
                     try nested.encode(from, forKey: .from)
                 }
                 try nested.encode(to, forKey: .to)
-                
+
                 let jsonRPCAmount: (String) -> String = { amount in
                     amount == "0x00" ? "0x0" : amount
                 }
-                
+
                 if let gas = gas.map(jsonRPCAmount) {
                     try nested.encode(gas, forKey: .gas)
                 }
@@ -205,14 +249,14 @@ public class EthereumClient: EthereumClientProtocol {
                 }
             }
         }
-        
+
         let value: BigUInt?
         if let txValue = transaction.value, txValue > .zero {
             value = txValue
         } else {
             value = nil
         }
-        
+
         let params = CallParams(from: transaction.from?.value,
                                 to: transaction.to.value,
                                 gas: transaction.gasLimit?.web3.hexString,
@@ -229,32 +273,32 @@ public class EthereumClient: EthereumClientProtocol {
             }
         }
     }
-    
+
     public func eth_sendRawTransaction(_ transaction: EthereumTransaction, withAccount account: EthereumAccountProtocol, completion: @escaping ((EthereumClientError?, String?) -> Void)) {
-        
+
         concurrentQueue.addOperation {
             let group = DispatchGroup()
             group.enter()
-            
+
             // Inject pending nonce
             self.eth_getTransactionCount(address: account.address, block: .Pending) { (error, count) in
                 guard let nonce = count else {
                     group.leave()
                     return completion(EthereumClientError.unexpectedReturnValue, nil)
                 }
-                
+
                 var transaction = transaction
                 transaction.nonce = nonce
-                
+
                 if transaction.chainId == nil, let network = self.network {
                     transaction.chainId = network.intValue
                 }
-                
+
                 guard let _ = transaction.chainId, let signedTx = (try? account.sign(transaction: transaction)), let transactionHex = signedTx.raw?.web3.hexString else {
                     group.leave()
                     return completion(EthereumClientError.encodeIssue, nil)
                 }
-                
+
                 EthereumRPC.execute(session: self.session, url: self.url, method: "eth_sendRawTransaction", params: [transactionHex], receive: String.self) { (error, response) in
                     group.leave()
                     if let resDataString = response as? String {
@@ -263,12 +307,12 @@ public class EthereumClient: EthereumClientProtocol {
                         completion(EthereumClientError.unexpectedReturnValue, nil)
                     }
                 }
-                
+
             }
             group.wait()
         }
     }
-    
+
     public func eth_getTransactionCount(address: EthereumAddress, block: EthereumBlock, completion: @escaping ((EthereumClientError?, Int?) -> Void)) {
         EthereumRPC.execute(session: session, url: url, method: "eth_getTransactionCount", params: [address.value, block.stringValue], receive: String.self) { (error, response) in
             if let resString = response as? String {
@@ -279,7 +323,7 @@ public class EthereumClient: EthereumClientProtocol {
             }
         }
     }
-    
+
     public func eth_getTransactionReceipt(txHash: String, completion: @escaping ((EthereumClientError?, EthereumTransactionReceipt?) -> Void)) {
         EthereumRPC.execute(session: session, url: url, method: "eth_getTransactionReceipt", params: [txHash], receive: EthereumTransactionReceipt.self) { (error, response) in
             if let receipt = response as? EthereumTransactionReceipt {
@@ -291,9 +335,9 @@ public class EthereumClient: EthereumClientProtocol {
             }
         }
     }
-    
+
     public func eth_getTransaction(byHash txHash: String, completion: @escaping((EthereumClientError?, EthereumTransaction?) -> Void)) {
-        
+
         EthereumRPC.execute(session: session, url: url, method: "eth_getTransactionByHash", params: [txHash], receive: EthereumTransaction.self) { (error, response) in
             if let transaction = response as? EthereumTransaction {
                 completion(nil, transaction)
@@ -302,24 +346,24 @@ public class EthereumClient: EthereumClientProtocol {
             }
         }
     }
-    
+
     public func eth_call(_ transaction: EthereumTransaction, block: EthereumBlock = .Latest, completion: @escaping ((EthereumClientError?, String?) -> Void)) {
         guard let transactionData = transaction.data else {
             return completion(EthereumClientError.noInputData, nil)
         }
-        
+
         struct CallParams: Encodable {
             let from: String?
             let to: String
             let data: String
             let block: String
-            
+
             enum TransactionCodingKeys: String, CodingKey {
                 case from
                 case to
                 case data
             }
-            
+
             func encode(to encoder: Encoder) throws {
                 var container = encoder.unkeyedContainer()
                 var nested = container.nestedContainer(keyedBy: TransactionCodingKeys.self)
@@ -331,7 +375,7 @@ public class EthereumClient: EthereumClientProtocol {
                 try container.encode(block)
             }
         }
-        
+
         let params = CallParams(from: transaction.from?.value, to: transaction.to.value, data: transactionData.web3.hexString, block: block.stringValue)
         EthereumRPC.execute(session: session, url: url, method: "eth_call", params: params, receive: String.self) { (error, response) in
             if let resDataString = response as? String {
@@ -346,11 +390,11 @@ public class EthereumClient: EthereumClientProtocol {
             }
         }
     }
-    
+
     public func eth_getLogs(addresses: [EthereumAddress]?, topics: [String?]?, fromBlock from: EthereumBlock = .Earliest, toBlock to: EthereumBlock = .Latest, completion: @escaping ((EthereumClientError?, [EthereumLog]?) -> Void)) {
         eth_getLogs(addresses: addresses, topics: topics.map(Topics.plain), fromBlock: from, toBlock: to, completion: completion)
     }
-    
+
     public func eth_getLogs(addresses: [EthereumAddress]?, orTopics topics: [[String]?]?, fromBlock from: EthereumBlock = .Earliest, toBlock to: EthereumBlock = .Latest, completion: @escaping((EthereumClientError?, [EthereumLog]?) -> Void)) {
         eth_getLogs(addresses: addresses, topics: topics.map(Topics.composed), fromBlock: from, toBlock: to, completion: completion)
     }
@@ -397,20 +441,20 @@ public class EthereumClient: EthereumClientProtocol {
     }
 
     public func eth_getBlockByNumber(_ block: EthereumBlock, completion: @escaping((EthereumClientError?, EthereumBlockInfo?) -> Void)) {
-        
+
         struct CallParams: Encodable {
             let block: EthereumBlock
             let fullTransactions: Bool
-            
+
             func encode(to encoder: Encoder) throws {
                 var container = encoder.unkeyedContainer()
                 try container.encode(block.stringValue)
                 try container.encode(fullTransactions)
             }
         }
-        
+
         let params = CallParams(block: block, fullTransactions: false)
-        
+
         EthereumRPC.execute(session: session, url: url, method: "eth_getBlockByNumber", params: params, receive: EthereumBlockInfo.self) { (error, response) in
             if let blockData = response as? EthereumBlockInfo {
                 completion(nil, blockData)
@@ -421,3 +465,176 @@ public class EthereumClient: EthereumClientProtocol {
     }
 }
 
+#if compiler(>=5.5) && canImport(_Concurrency)
+
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+extension EthereumClient {
+    public func net_version() async throws -> EthereumNetwork {
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<EthereumNetwork, Error>) in
+            net_version { error, ethereumNetwork in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else if let ethereumNetwork = ethereumNetwork {
+                    continuation.resume(returning: ethereumNetwork)
+                }
+            }
+        }
+    }
+
+    public func eth_gasPrice() async throws -> BigUInt {
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<BigUInt, Error>) in
+            eth_gasPrice { error, gasPrice in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else if let gasPrice = gasPrice {
+                    continuation.resume(returning: gasPrice)
+                }
+            }
+        }
+    }
+
+    public func eth_blockNumber() async throws -> Int {
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Int, Error>) in
+            eth_blockNumber { error, blockNumber in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else if let blockNumber = blockNumber {
+                    continuation.resume(returning: blockNumber)
+                }
+            }
+        }
+    }
+
+    public func eth_getBalance(address: EthereumAddress, block: EthereumBlock) async throws -> BigUInt {
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<BigUInt, Error>) in
+            eth_getBalance(address: address, block: block) { error, balance in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else if let balance = balance {
+                    continuation.resume(returning: balance)
+                }
+            }
+        }
+    }
+
+    public func eth_getCode(address: EthereumAddress, block: EthereumBlock = .Latest) async throws -> String {
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<String, Error>) in
+            eth_getCode(address: address, block: block) { error, code in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else if let code = code {
+                    continuation.resume(returning: code)
+                }
+            }
+        }
+    }
+
+    public func eth_estimateGas(_ transaction: EthereumTransaction, withAccount account: EthereumAccountProtocol) async throws -> BigUInt {
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<BigUInt, Error>) in
+            eth_estimateGas(transaction, withAccount: account) { error, gas in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else if let gas = gas {
+                    continuation.resume(returning: gas)
+                }
+            }
+        }
+    }
+
+    public func eth_sendRawTransaction(_ transaction: EthereumTransaction, withAccount account: EthereumAccountProtocol) async throws -> String {
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<String, Error>) in
+            eth_sendRawTransaction(transaction, withAccount: account) { error, txHash in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else if let txHash = txHash {
+                    continuation.resume(returning: txHash)
+                }
+            }
+        }
+    }
+
+    public func eth_getTransactionCount(address: EthereumAddress, block: EthereumBlock) async throws -> Int {
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Int, Error>) in
+            eth_getTransactionCount(address: address, block: block) { error, count in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else if let count = count {
+                    continuation.resume(returning: count)
+                }
+            }
+        }
+    }
+
+    public func eth_getTransaction(byHash txHash: String) async throws -> EthereumTransaction {
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<EthereumTransaction, Error>) in
+            eth_getTransaction(byHash: txHash) { error, transaction in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else if let transaction = transaction {
+                    continuation.resume(returning: transaction)
+                }
+            }
+        }
+    }
+
+    public func eth_getTransactionReceipt(txHash: String) async throws -> EthereumTransactionReceipt {
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<EthereumTransactionReceipt, Error>) in
+            eth_getTransactionReceipt(txHash: txHash) { error, transactionReceipt in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else if let transactionReceipt = transactionReceipt {
+                    continuation.resume(returning: transactionReceipt)
+                }
+            }
+        }
+    }
+
+    public func eth_call(_ transaction: EthereumTransaction, block: EthereumBlock = .Latest) async throws -> String {
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<String, Error>) in
+            eth_call(transaction, block: block) { error, txHash in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else if let txHash = txHash {
+                    continuation.resume(returning: txHash)
+                }
+            }
+        }
+    }
+
+    public func eth_getLogs(addresses: [EthereumAddress]?, topics: [String?]?, fromBlock from: EthereumBlock = .Earliest, toBlock to: EthereumBlock = .Latest) async throws -> [EthereumLog] {
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<[EthereumLog], Error>) in
+            eth_getLogs(addresses: addresses, topics: topics, fromBlock: from, toBlock: to) { error, logs in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else if let logs = logs {
+                    continuation.resume(returning: logs)
+                }
+            }
+        }
+    }
+
+    public func eth_getLogs(addresses: [EthereumAddress]?, orTopics topics: [[String]?]?, fromBlock from: EthereumBlock = .Earliest, toBlock to: EthereumBlock = .Latest) async throws ->  [EthereumLog] {
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<[EthereumLog], Error>) in
+            eth_getLogs(addresses: addresses, orTopics: topics, fromBlock: from, toBlock: to) { error, logs in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else if let logs = logs {
+                    continuation.resume(returning: logs)
+                }
+            }
+        }
+    }
+
+    public func eth_getBlockByNumber(_ block: EthereumBlock) async throws -> EthereumBlockInfo {
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<EthereumBlockInfo, Error>) in
+            eth_getBlockByNumber(block) { error, blockInfo in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else if let blockInfo = blockInfo {
+                    continuation.resume(returning: blockInfo)
+                }
+            }
+        }
+    }
+}
+#endif

--- a/web3swift/src/Contract/Statically Typed/EthereumClient+Static.swift
+++ b/web3swift/src/Contract/Statically Typed/EthereumClient+Static.swift
@@ -10,46 +10,76 @@ import Foundation
 
 public extension ABIFunction {
     func execute(withClient client: EthereumClientProtocol, account: EthereumAccountProtocol, completion: @escaping((EthereumClientError?, String?) -> Void)) {
-        
+
         guard let tx = try? self.transaction() else {
             return completion(EthereumClientError.encodeIssue, nil)
         }
-        
-        
+
+
         client.eth_sendRawTransaction(tx, withAccount: account) { (error, res) in
             guard let res = res, error == nil else {
                 return completion(EthereumClientError.unexpectedReturnValue, nil)
             }
-            
+
             return completion(nil, res)
         }
-        
+
     }
-    
+
     func call<T: ABIResponse>(withClient client: EthereumClientProtocol, responseType: T.Type, block: EthereumBlock = .Latest, completion: @escaping((EthereumClientError?, T?) -> Void)) {
-        
+
         guard let tx = try? self.transaction() else {
             return completion(EthereumClientError.encodeIssue, nil)
         }
-        
+
         client.eth_call(tx, block: block) { (error, res) in
             guard let res = res, error == nil else {
                 return completion(EthereumClientError.unexpectedReturnValue, nil)
             }
-            
+
             guard let response = (try? T(data: res)) else {
                 return completion(EthereumClientError.decodeIssue, nil)
             }
-            
+
             return completion(nil, response)
         }
     }
 }
 
+#if compiler(>=5.5) && canImport(_Concurrency)
+
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+public extension ABIFunction {
+    func execute(withClient client: EthereumClientProtocol, account: EthereumAccountProtocol) async throws -> String  {
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<String, Error>) in
+            execute(withClient: client, account: account) { error, response in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else if let response = response {
+                    continuation.resume(returning: response)
+                }
+            }
+        }
+    }
+
+    func call<T: ABIResponse>(withClient client: EthereumClientProtocol, responseType: T.Type, block: EthereumBlock = .Latest) async throws -> T {
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<T, Error>) in
+            call(withClient: client, responseType: responseType) { error, response in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else if let response = response {
+                    continuation.resume(returning: response)
+                }
+            }
+        }
+    }
+}
+#endif
+
 public struct EventFilter {
     public let type: ABIEvent.Type
     public let allowedSenders: [EthereumAddress]
-    
+
     public init(type: ABIEvent.Type,
                 allowedSenders: [EthereumAddress]) {
         self.type = type
@@ -69,7 +99,7 @@ public extension EthereumClient {
             self?.handleLogs(error, logs, matches, completion)
         }
     }
-    
+
     func getEvents(addresses: [EthereumAddress]?,
                    orTopics: [[String]?]?,
                    fromBlock: EthereumBlock,
@@ -96,19 +126,19 @@ public extension EthereumClient {
                   matching: unfiltered,
                   completion: completion)
     }
-    
+
     func getEvents(addresses: [EthereumAddress]?,
                    topics: [String?]?,
                    fromBlock: EthereumBlock,
                    toBlock: EthereumBlock,
                    matching matches: [EventFilter],
                    completion: @escaping EventsCompletion) {
-        
+
         self.eth_getLogs(addresses: addresses, topics: topics, fromBlock: fromBlock, toBlock: toBlock) { [weak self] (error, logs) in
             self?.handleLogs(error, logs, matches, completion)
         }
     }
-        
+
     private func handleLogs(_ error: EthereumClientError?,
                             _ logs: [EthereumLog]?,
                             _ matches: [EventFilter],
@@ -116,12 +146,12 @@ public extension EthereumClient {
         if let error = error {
             return completion(error, [], [])
         }
-        
+
         guard let logs = logs else { return completion(nil, [], []) }
-        
+
         var events: [ABIEvent] = []
         var unprocessed: [EthereumLog] = []
-        
+
         var filtersBySignature: [String: [EventFilter]] = [:]
         for filter in matches {
             if let sig = try? filter.type.signature() {
@@ -130,46 +160,46 @@ public extension EthereumClient {
                 filtersBySignature[sig] = filters
             }
         }
-        
+
         let parseEvent: (EthereumLog, ABIEvent.Type) -> ABIEvent? = { log, eventType in
             let topicTypes = eventType.types.enumerated()
                 .filter { eventType.typesIndexed[$0.offset] == true }
                 .compactMap { $0.element }
-            
+
             let dataTypes = eventType.types.enumerated()
                 .filter { eventType.typesIndexed[$0.offset] == false }
                 .compactMap { $0.element }
-            
+
             guard let data = try? ABIDecoder.decodeData(log.data, types: dataTypes, asArray: true) else {
                 return nil
             }
-            
+
             guard data.count == dataTypes.count else {
                 return nil
             }
-            
+
             let rawTopics = Array(log.topics.dropFirst())
-            
+
             guard let parsedTopics = (try? zip(rawTopics, topicTypes).map { pair in
                 try ABIDecoder.decodeData(pair.0, types: [pair.1])
-                }) else {
-                    return nil
+            }) else {
+                return nil
             }
-            
+
             guard let eventOpt = ((try? eventType.init(topics: parsedTopics.flatMap { $0 }, data: data, log: log)) as ABIEvent??), let event = eventOpt else {
                 return nil
             }
-            
+
             return event
         }
-        
+
         for log in logs {
             guard let signature = log.topics.first,
-                let filters = filtersBySignature[signature] else {
-                    unprocessed.append(log)
-                    continue
-            }
-            
+                  let filters = filtersBySignature[signature] else {
+                      unprocessed.append(log)
+                      continue
+                  }
+
             for filter in filters {
                 let allowedSenders = Set(filter.allowedSenders)
                 if allowedSenders.count > 0 && !allowedSenders.contains(log.address) {
@@ -181,7 +211,88 @@ public extension EthereumClient {
                 }
             }
         }
-        
+
         return completion(error, events, unprocessed)
     }
 }
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+public struct Events {
+    let events: [ABIEvent]
+    let logs: [EthereumLog]
+}
+
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+public extension EthereumClient {
+    func getEvents(addresses: [EthereumAddress]?,
+                   orTopics: [[String]?]?,
+                   fromBlock: EthereumBlock,
+                   toBlock: EthereumBlock,
+                   matching matches: [EventFilter]) async throws -> Events {
+
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Events, Error>) in
+            self.eth_getLogs(addresses: addresses, orTopics: orTopics, fromBlock: fromBlock, toBlock: toBlock) { [weak self] (error, logs) in
+                self?.handleLogs(error, logs, matches) { error, events, logs in
+                    if let error = error {
+                        continuation.resume(throwing: error)
+                    }
+                    continuation.resume(returning: Events(events: events, logs: logs))
+                }
+            }
+        }
+    }
+
+    func getEvents(addresses: [EthereumAddress]?,
+                   orTopics: [[String]?]?,
+                   fromBlock: EthereumBlock,
+                   toBlock: EthereumBlock,
+                   eventTypes: [ABIEvent.Type]) async throws -> Events {
+        let unfiltered = eventTypes.map { EventFilter(type: $0, allowedSenders: []) }
+
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Events, Error>) in
+            self.eth_getLogs(addresses: addresses, orTopics: orTopics, fromBlock: fromBlock, toBlock: toBlock) { [weak self] (error, logs) in
+                self?.handleLogs(error, logs, unfiltered) { error, events, logs in
+                    if let error = error {
+                        continuation.resume(throwing: error)
+                    }
+                    continuation.resume(returning: Events(events: events, logs: logs))
+                }
+            }
+        }
+    }
+
+    func getEvents(addresses: [EthereumAddress]?,
+                   topics: [String?]?,
+                   fromBlock: EthereumBlock,
+                   toBlock: EthereumBlock,
+                   eventTypes: [ABIEvent.Type]) async throws -> Events {
+        let unfiltered = eventTypes.map { EventFilter(type: $0, allowedSenders: []) }
+        return try await getEvents(addresses: addresses,
+                                   topics: topics,
+                                   fromBlock: fromBlock,
+                                   toBlock: toBlock,
+                                   matching: unfiltered)
+    }
+
+    func getEvents(addresses: [EthereumAddress]?,
+                   topics: [String?]?,
+                   fromBlock: EthereumBlock,
+                   toBlock: EthereumBlock,
+                   matching matches: [EventFilter]) async throws -> Events {
+
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Events, Error>) in
+            self.eth_getLogs(addresses: addresses, topics: topics, fromBlock: fromBlock, toBlock: toBlock) { [weak self] (error, logs) in
+                self?.handleLogs(error, logs, matches) { error, events, logs in
+                    if let error = error {
+                        continuation.resume(throwing: error)
+                    }
+                    continuation.resume(returning: Events(events: events, logs: logs))
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/web3swift/src/ENS/EthereumNameService.swift
+++ b/web3swift/src/ENS/EthereumNameService.swift
@@ -12,6 +12,14 @@ protocol EthereumNameServiceProtocol {
     init(client: EthereumClientProtocol, registryAddress: EthereumAddress?)
     func resolve(address: EthereumAddress, completion: @escaping((EthereumNameServiceError?, String?) -> Void)) -> Void
     func resolve(ens: String, completion: @escaping((EthereumNameServiceError?, EthereumAddress?) -> Void)) -> Void
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func resolve(address: EthereumAddress) async throws -> String
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func resolve(ens: String) async throws -> EthereumAddress
+#endif
 }
 
 public enum EthereumNameServiceError: Error, Equatable {
@@ -26,7 +34,7 @@ public enum EthereumNameServiceError: Error, Equatable {
 public class EthereumNameService: EthereumNameServiceProtocol {
     let client: EthereumClientProtocol
     let registryAddress: EthereumAddress?
-    
+
     required public init(client: EthereumClientProtocol, registryAddress: EthereumAddress? = nil) {
         self.client = client
         self.registryAddress = registryAddress
@@ -36,12 +44,12 @@ public class EthereumNameService: EthereumNameServiceProtocol {
         guard
             let network = client.network,
             let registryAddress = self.registryAddress ?? ENSContracts.registryAddress(for: network) else {
-            return completion(EthereumNameServiceError.noNetwork, nil)
-        }
-        
+                return completion(EthereumNameServiceError.noNetwork, nil)
+            }
+
         let ensReverse = address.value.web3.noHexPrefix + ".addr.reverse"
         let nameHash = Self.nameHash(name: ensReverse)
-        
+
         let function = ENSContracts.ENSRegistryFunctions.resolver(contract: registryAddress,
                                                                   _node: nameHash.web3.hexData ?? Data())
         guard let registryTransaction = try? function.transaction() else {
@@ -53,21 +61,21 @@ public class EthereumNameService: EthereumNameServiceProtocol {
             guard let resolverData = resolverData else {
                 return completion(EthereumNameServiceError.noResolver, nil)
             }
-            
+
             guard resolverData != "0x" else {
                 return completion(EthereumNameServiceError.ensUnknown, nil)
             }
-            
+
             let idx = resolverData.index(resolverData.endIndex, offsetBy: -40)
             let resolverAddress = EthereumAddress(String(resolverData[idx...]).web3.withHexPrefix)
-            
+
             let function = ENSContracts.ENSResolverFunctions.name(contract: resolverAddress,
                                                                   _node: nameHash.web3.hexData ?? Data())
             guard let addressTransaction = try? function.transaction() else {
                 completion(EthereumNameServiceError.invalidInput, nil)
                 return
             }
-            
+
             self.client.eth_call(addressTransaction, block: .Latest, completion: { (error, data) in
                 guard let data = data, data != "0x" else {
                     return completion(EthereumNameServiceError.ensUnknown, nil)
@@ -77,22 +85,22 @@ public class EthereumNameService: EthereumNameServiceProtocol {
                 } else {
                     completion(EthereumNameServiceError.decodeIssue, nil)
                 }
-                
+
             })
         })
     }
-    
+
     public func resolve(ens: String, completion: @escaping ((EthereumNameServiceError?, EthereumAddress?) -> Void)) {
-        
+
         guard
             let network = client.network,
             let registryAddress = self.registryAddress ?? ENSContracts.registryAddress(for: network) else {
-            return completion(EthereumNameServiceError.noNetwork, nil)
-        }
+                return completion(EthereumNameServiceError.noNetwork, nil)
+            }
         let nameHash = Self.nameHash(name: ens)
         let function = ENSContracts.ENSRegistryFunctions.resolver(contract: registryAddress,
                                                                   _node: nameHash.web3.hexData ?? Data())
-        
+
         guard let registryTransaction = try? function.transaction() else {
             completion(EthereumNameServiceError.invalidInput, nil)
             return
@@ -102,25 +110,25 @@ public class EthereumNameService: EthereumNameServiceProtocol {
             guard let resolverData = resolverData else {
                 return completion(EthereumNameServiceError.noResolver, nil)
             }
-            
+
             guard resolverData != "0x" else {
                 return completion(EthereumNameServiceError.ensUnknown, nil)
             }
-            
+
             let idx = resolverData.index(resolverData.endIndex, offsetBy: -40)
             let resolverAddress = EthereumAddress(String(resolverData[idx...]).web3.withHexPrefix)
-            
+
             let function = ENSContracts.ENSResolverFunctions.addr(contract: resolverAddress, _node: nameHash.web3.hexData ?? Data())
             guard let addressTransaction = try? function.transaction() else {
                 completion(EthereumNameServiceError.invalidInput, nil)
                 return
             }
-            
+
             self.client.eth_call(addressTransaction, block: .Latest, completion: { (error, data) in
                 guard let data = data, data != "0x" else {
                     return completion(EthereumNameServiceError.ensUnknown, nil)
                 }
-                
+
                 if let ensAddress: EthereumAddress = try? (try? ABIDecoder.decodeData(data, types: [EthereumAddress.self]))?.first?.decoded() {
                     completion(nil, ensAddress)
                 } else {
@@ -141,3 +149,34 @@ public class EthereumNameService: EthereumNameServiceProtocol {
     }
 
 }
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+extension EthereumNameService {
+    func resolve(address: EthereumAddress) async throws -> String {
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<String, Error>) in
+            resolve(address: address) { error, ensHex in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else if let ensHex = ensHex {
+                    continuation.resume(returning: ensHex)
+                }
+            }
+        }
+    }
+
+    func resolve(ens: String) async throws -> EthereumAddress {
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<EthereumAddress, Error>) in
+            resolve(ens: ens) { error, address in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else if let address = address {
+                    continuation.resume(returning: address)
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/web3swift/src/ERC165/ERC165.swift
+++ b/web3swift/src/ERC165/ERC165.swift
@@ -11,36 +11,52 @@ import BigInt
 
 public class ERC165 {
     public let client: EthereumClient
-    public init(client: EthereumClient) {
+    required public init(client: EthereumClient) {
         self.client = client
     }
-    
-    public func supportsInterface(contract: EthereumAddress,
-                                  id: Data,
-                                  completion: @escaping((Error?, Bool?) -> Void)) {
+
+    public func supportsInterface(contract: EthereumAddress, id: Data, completion: @escaping((Error?, Bool?) -> Void)) {
         let function = ERC165Functions.supportsInterface(contract: contract, interfaceId: id)
-        function.call(withClient: self.client,
-                      responseType: ERC165Responses.supportsInterfaceResponse.self) { (error, response) in
+
+        function.call(withClient: self.client, responseType: ERC165Responses.supportsInterfaceResponse.self) { (error, response) in
             return completion(error, response?.supported)
         }
     }
 
 }
 
+#if compiler(>=5.5) && canImport(_Concurrency)
+
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+extension ERC165 {
+    public func supportsInterface(contract: EthereumAddress, id: Data) async throws -> Bool {
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Bool, Error>) in
+            supportsInterface(contract: contract, id: id) { error, supported in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else if let supported = supported {
+                    continuation.resume(returning: supported)
+                }
+            }
+        }
+    }
+}
+#endif
+
 public enum ERC165Functions {
     public static var interfaceId: Data {
         return "supportsInterface(bytes4)".web3.keccak256.web3.bytes4
     }
-    
+
     struct supportsInterface: ABIFunction {
         public static let name = "supportsInterface"
         public let gasPrice: BigUInt?
         public let gasLimit: BigUInt?
         public var contract: EthereumAddress
         public let from: EthereumAddress?
-        
+
         let interfaceId: Data
-        
+
         public init(contract: EthereumAddress,
                     from: EthereumAddress? = nil,
                     interfaceId: Data,
@@ -52,7 +68,7 @@ public enum ERC165Functions {
             self.gasPrice = gasPrice
             self.gasLimit = gasLimit
         }
-        
+
         public func encode(to encoder: ABIFunctionEncoder) throws {
             assert(interfaceId.count == 4, "Interface data should contain exactly 4 bytes")
             try encoder.encode(interfaceId, staticSize: 4)
@@ -64,7 +80,7 @@ public enum ERC165Responses {
     public struct supportsInterfaceResponse: ABIResponse {
         public static var types: [ABIType.Type] = [ Bool.self ]
         public let supported: Bool
-        
+
         public init?(values: [ABIDecoder.DecodedValue]) throws {
             self.supported = try values[0].decoded()
         }

--- a/web3swift/src/ERC20/ERC20.swift
+++ b/web3swift/src/ERC20/ERC20.swift
@@ -9,104 +9,213 @@
 import Foundation
 import BigInt
 
-public class ERC20 {
+public protocol ERC20Protocol {
+    init(client: EthereumClient)
+    func name(tokenContract: EthereumAddress, completion: @escaping((Error?, String?) -> Void))
+    func symbol(tokenContract: EthereumAddress, completion: @escaping((Error?, String?) -> Void))
+    func decimals(tokenContract: EthereumAddress, completion: @escaping((Error?, UInt8?) -> Void))
+    func balanceOf(tokenContract: EthereumAddress, address: EthereumAddress, completion: @escaping((Error?, BigUInt?) -> Void))
+    func allowance(tokenContract: EthereumAddress, address: EthereumAddress, spender: EthereumAddress, completion: @escaping((Error?, BigUInt?) -> Void))
+    func transferEventsTo(recipient: EthereumAddress, fromBlock: EthereumBlock, toBlock: EthereumBlock, completion: @escaping((Error?, [ERC20Events.Transfer]?) -> Void))
+    func transferEventsFrom(sender: EthereumAddress, fromBlock: EthereumBlock, toBlock: EthereumBlock, completion: @escaping((Error?, [ERC20Events.Transfer]?) -> Void))
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func name(tokenContract: EthereumAddress) async throws -> String
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func symbol(tokenContract: EthereumAddress) async throws -> String
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func decimals(tokenContract: EthereumAddress) async throws -> UInt8
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func balanceOf(tokenContract: EthereumAddress, address: EthereumAddress) async throws -> BigUInt
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func allowance(tokenContract: EthereumAddress, address: EthereumAddress, spender: EthereumAddress) async throws -> BigUInt
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func transferEventsTo(recipient: EthereumAddress, fromBlock: EthereumBlock, toBlock: EthereumBlock) async throws -> [ERC20Events.Transfer]
+
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+    func transferEventsFrom(sender: EthereumAddress, fromBlock: EthereumBlock, toBlock: EthereumBlock) async throws -> [ERC20Events.Transfer]
+#endif
+}
+
+public class ERC20: ERC20Protocol {
     let client: EthereumClient
-    
-    public init(client: EthereumClient) {
+
+    required public init(client: EthereumClient) {
         self.client = client
     }
-        
-    public func name(tokenContract: EthereumAddress,
-                     completion: @escaping((Error?, String?) -> Void)) {
+
+    public func name(tokenContract: EthereumAddress, completion: @escaping((Error?, String?) -> Void)) {
         let function = ERC20Functions.name(contract: tokenContract)
         function.call(withClient: self.client, responseType: ERC20Responses.nameResponse.self) { (error, nameResponse) in
             return completion(error, nameResponse?.value)
         }
     }
-    
-    public func symbol(tokenContract: EthereumAddress,
-                       completion: @escaping((Error?, String?) -> Void)) {
+
+    public func symbol(tokenContract: EthereumAddress, completion: @escaping((Error?, String?) -> Void)) {
         let function = ERC20Functions.symbol(contract: tokenContract)
         function.call(withClient: self.client, responseType: ERC20Responses.symbolResponse.self) { (error, symbolResponse) in
             return completion(error, symbolResponse?.value)
         }
     }
-    
-    public func decimals(tokenContract: EthereumAddress,
-                         completion: @escaping((Error?, UInt8?) -> Void)) {
+
+    public func decimals(tokenContract: EthereumAddress, completion: @escaping((Error?, UInt8?) -> Void)) {
         let function = ERC20Functions.decimals(contract: tokenContract)
         function.call(withClient: self.client, responseType: ERC20Responses.decimalsResponse.self) { (error, decimalsResponse) in
             return completion(error, decimalsResponse?.value)
         }
     }
-    
-    public func balanceOf(tokenContract: EthereumAddress,
-                          address: EthereumAddress,
-                          completion: @escaping((Error?, BigUInt?) -> Void)) {
+
+    public func balanceOf(tokenContract: EthereumAddress, address: EthereumAddress, completion: @escaping((Error?, BigUInt?) -> Void)) {
         let function = ERC20Functions.balanceOf(contract: tokenContract, account: address)
         function.call(withClient: self.client, responseType: ERC20Responses.balanceResponse.self) { (error, balanceResponse) in
             return completion(error, balanceResponse?.value)
         }
     }
-    
-    public func allowance(tokenContract: EthereumAddress,
-                          address: EthereumAddress,
-                          spender: EthereumAddress,
-                          completion: @escaping((Error?, BigUInt?) -> Void)) {
+
+    public func allowance(tokenContract: EthereumAddress, address: EthereumAddress, spender: EthereumAddress, completion: @escaping((Error?, BigUInt?) -> Void)) {
         let function = ERC20Functions.allowance(contract: tokenContract, owner: address, spender: spender)
         function.call(withClient: self.client, responseType: ERC20Responses.balanceResponse.self) { (error, balanceResponse) in
             return completion(error, balanceResponse?.value)
         }
     }
-    
-    public func transferEventsTo(recipient: EthereumAddress,
-                                 fromBlock: EthereumBlock,
-                                 toBlock: EthereumBlock,
-                                 completion: @escaping((Error?, [ERC20Events.Transfer]?) -> Void)) {
-        
+
+    public func transferEventsTo(recipient: EthereumAddress, fromBlock: EthereumBlock, toBlock: EthereumBlock, completion: @escaping((Error?, [ERC20Events.Transfer]?) -> Void)) {
+
         guard let result = try? ABIEncoder.encode(recipient).bytes, let sig = try? ERC20Events.Transfer.signature() else {
             completion(EthereumSignerError.unknownError, nil)
             return
         }
-        
+
         self.client.getEvents(addresses: nil,
                               topics: [ sig, nil, String(hexFromBytes: result)],
                               fromBlock: fromBlock,
                               toBlock: toBlock,
                               eventTypes: [ERC20Events.Transfer.self]) { (error, events, unprocessedLogs) in
-            
+
             if let events = events as? [ERC20Events.Transfer] {
                 return completion(error, events)
             } else {
                 return completion(error ?? EthereumClientError.decodeIssue, nil)
             }
-            
+
         }
     }
-    
-    public func transferEventsFrom(sender: EthereumAddress,
-                                   fromBlock: EthereumBlock,
-                                   toBlock: EthereumBlock,
-                                   completion: @escaping((Error?, [ERC20Events.Transfer]?) -> Void)) {
-        
+
+    public func transferEventsFrom(sender: EthereumAddress, fromBlock: EthereumBlock, toBlock: EthereumBlock, completion: @escaping((Error?, [ERC20Events.Transfer]?) -> Void)) {
+
         guard let result = try? ABIEncoder.encode(sender).bytes, let sig = try? ERC20Events.Transfer.signature() else {
             completion(EthereumSignerError.unknownError, nil)
             return
         }
-        
+
         self.client.getEvents(addresses: nil,
                               topics: [ sig, String(hexFromBytes: result), nil ],
                               fromBlock: fromBlock,
                               toBlock: toBlock,
                               eventTypes: [ERC20Events.Transfer.self]) { (error, events, unprocessedLogs) in
-            
+
             if let events = events as? [ERC20Events.Transfer] {
                 return completion(error, events)
             } else {
                 return completion(error ?? EthereumClientError.decodeIssue, nil)
             }
-            
+
+        }
+    }
+}
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+extension ERC20 {
+    public func name(tokenContract: EthereumAddress) async throws -> String {
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<String, Error>) in
+            name(tokenContract: tokenContract) { error, name in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else if let name = name {
+                    continuation.resume(returning: name)
+                }
+            }
         }
     }
 
+    public func symbol(tokenContract: EthereumAddress) async throws -> String {
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<String, Error>) in
+            symbol(tokenContract: tokenContract) { error, symbol in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else if let symbol = symbol {
+                    continuation.resume(returning: symbol)
+                }
+            }
+        }
+    }
+
+    public func decimals(tokenContract: EthereumAddress) async throws -> UInt8 {
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<UInt8, Error>) in
+            decimals(tokenContract: tokenContract) { error, decimals in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else if let decimals = decimals {
+                    continuation.resume(returning: decimals)
+                }
+            }
+        }
+    }
+
+    public func balanceOf(tokenContract: EthereumAddress, address: EthereumAddress) async throws -> BigUInt {
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<BigUInt, Error>) in
+            balanceOf(tokenContract: tokenContract, address: address) { error, balance in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else if let balance = balance {
+                    continuation.resume(returning: balance)
+                }
+            }
+        }
+    }
+
+    public func allowance(tokenContract: EthereumAddress, address: EthereumAddress, spender: EthereumAddress) async throws -> BigUInt {
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<BigUInt, Error>) in
+            allowance(tokenContract: tokenContract, address: address, spender: spender) { error, allowance in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else if let allowance = allowance {
+                    continuation.resume(returning: allowance)
+                }
+            }
+        }
+    }
+
+    public func transferEventsTo(recipient: EthereumAddress, fromBlock: EthereumBlock, toBlock: EthereumBlock) async throws -> [ERC20Events.Transfer] {
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<[ERC20Events.Transfer], Error>) in
+            transferEventsTo(recipient: recipient, fromBlock: fromBlock, toBlock: toBlock) { error, events in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else if let events = events {
+                    continuation.resume(returning: events)
+                }
+            }
+        }
+    }
+
+    public func transferEventsFrom(sender: EthereumAddress, fromBlock: EthereumBlock, toBlock: EthereumBlock) async throws -> [ERC20Events.Transfer] {
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<[ERC20Events.Transfer], Error>) in
+            transferEventsFrom(sender: sender, fromBlock: fromBlock, toBlock: toBlock) { error, events in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else if let events = events {
+                    continuation.resume(returning: events)
+                }
+            }
+        }
+    }
 }
+#endif


### PR DESCRIPTION
Adds support for async/await. All the async methods call the original closure based methods. 
We must not remove/deprecate closure based methods for backwards compatibility

Fixes: #147

Heavily tested on my Project and work like a charm!