### PR TITLE
Throw the actual error 

### DIFF
--- a/web3swift/src/Client/EthereumClient.swift
+++ b/web3swift/src/Client/EthereumClient.swift
@@ -380,11 +380,8 @@ public class EthereumClient: EthereumClientProtocol {
         EthereumRPC.execute(session: session, url: url, method: "eth_call", params: params, receive: String.self) { (error, response) in
             if let resDataString = response as? String {
                 completion(nil, resDataString)
-            } else if
-                let error = error,
-                case let JSONRPCError.executionError(result) = error,
-                (result.error.code == JSONRPCErrorCode.invalidInput || result.error.code == JSONRPCErrorCode.contractExecution) {
-                completion(nil, "0x")
+			}  else if case let .executionError(errorResult) = error as? JSONRPCError {
+				completion(EthereumClientError.executionError(description: "\(errorResult.error)"), nil)
             } else {
                 completion(EthereumClientError.unexpectedReturnValue, nil)
             }


### PR DESCRIPTION
Its good to throw in case of error to handle different cases of the error instead of returning just a zero result.
The error must get to the caller!

@DarthMike  whats your opinion? Why you manage it like that? Is there a specific case?