### PR TITLE
[ADD] Offchain Read support (EIP-3668) for eth_call and ENS resolution

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,8 +4,8 @@ import PackageDescription
 let package = Package(
     name: "web3.swift",
     platforms: [
-        .iOS(SupportedPlatform.IOSVersion.v11),
-        .macOS(SupportedPlatform.MacOSVersion.v10_12)
+        .iOS(SupportedPlatform.IOSVersion.v13),
+        .macOS(SupportedPlatform.MacOSVersion.v11)
     ],
     products: [
         .library(name: "web3.swift", targets: ["web3"]),

--- a/web3sTests/Client/EthereumClientTests.swift
+++ b/web3sTests/Client/EthereumClientTests.swift
@@ -334,7 +334,7 @@ extension EthereumClientTests {
             XCTAssertEqual(
                 error as? EthereumClientError,
                 .executionError(
-                    .init(code: -32000, message: "execution reverted")
+                    .init(code: -32000, message: "execution reverted", data: nil)
                 )
             )
         }

--- a/web3sTests/ENS/ENSOffchainTests.swift
+++ b/web3sTests/ENS/ENSOffchainTests.swift
@@ -1,0 +1,72 @@
+//
+//  ENSOffchainTests.swift
+//  web3sTests
+//
+//  Created by Miguel on 17/05/2022.
+//  Copyright © 2022 Argent Labs Limited. All rights reserved.
+//
+
+import XCTest
+@testable import web3
+
+class ENSOffchainTests: XCTestCase {
+    var account: EthereumAccount?
+    var client: EthereumClient!
+
+    override func setUp() {
+        super.setUp()
+        self.client = EthereumClient(url: URL(string: TestConfig.clientUrl)!)
+    }
+
+    func testDNSEncode() {
+        XCTAssertEqual(
+            EthereumNameService.dnsEncode(name: "offchainexample.eth").web3.hexString,
+            "0x0f6f6666636861696e6578616d706c650365746800"
+            )
+        XCTAssertEqual(
+            EthereumNameService.dnsEncode(name: "1.offchainexample.eth").web3.hexString,
+            "0x01310f6f6666636861696e6578616d706c650365746800"
+            )
+
+    }
+
+    func testGivenRopstenRegistry_WhenResolvingOffchainENS_ResolvesCorrectly() async {
+        do {
+            let nameService = EthereumNameService(client: client!)
+            let ens = try await nameService.resolve(
+                ens: "offchainexample.eth",
+                mode: .allowOffchainLookup
+            )
+            XCTAssertEqual(EthereumAddress("0xd8da6bf26964af9d7eed9e03e53415d37aa96045"), ens)
+        } catch {
+            XCTFail("Expected ens but failed \(error).")
+        }
+    }
+
+    func testGivenRopstenRegistry_WhenResolvingOffchainENSAndDisabled_ThenFails() async {
+        do {
+            let nameService = EthereumNameService(client: client!)
+            let _ = try await nameService.resolve(
+                ens: "offchainexample.eth",
+                mode: .onchain
+            )
+            XCTFail("Expecting error")
+        } catch let error {
+            XCTAssertEqual(error as? EthereumNameServiceError, .ensUnknown)
+        }
+    }
+
+    func testGivenRopstenRegistry_WhenResolvingNonOffchainENS_ThenResolves() async {
+        do {
+            let nameService = EthereumNameService(client: client!)
+            let ens = try await nameService.resolve(
+                ens: "resolver.eth",
+                mode: .allowOffchainLookup
+            )
+            XCTAssertEqual(EthereumAddress("0x42d63ae25990889e35f215bc95884039ba354115"), ens)
+        } catch {
+            XCTFail("Expected ens but failed \(error).")
+        }
+    }
+}
+

--- a/web3sTests/ENS/ENSTests.swift
+++ b/web3sTests/ENS/ENSTests.swift
@@ -24,184 +24,7 @@ class ENSTests: XCTestCase {
         XCTAssertEqual(nameHash, "0x3e58ef7a2e196baf0b9d36a65cc590ac9edafb3395b7cdeb8f39206049b4534c")
     }
 
-    func testGivenRopstenRegistry_WhenExistingDomainName_ResolvesOwnerAddressCorrectly() {
-        let expect = expectation(description: "Get the ENS owner")
-
-        do {
-            let function = ENSContracts.ENSRegistryFunctions.owner(contract: ENSContracts.RopstenAddress, _node: EthereumNameService.nameHash(name: "test").web3.hexData ?? Data())
-
-            let tx = try function.transaction()
-
-            client?.eth_call(tx, block: .Latest, completion: { (error, dataStr) in
-                guard let dataStr = dataStr else {
-                    XCTFail()
-                    expect.fulfill()
-                    return
-                }
-                let owner = String(dataStr[dataStr.index(dataStr.endIndex, offsetBy: -40)...])
-                XCTAssertEqual(owner.web3.noHexPrefix,"09b5bd82f3351a4c8437fc6d7772a9e6cd5d25a1")
-                expect.fulfill()
-            })
-
-        } catch {
-            XCTFail()
-            expect.fulfill()
-        }
-
-        waitForExpectations(timeout: 20)
-    }
-
-    func testGivenRopstenRegistry_WhenExistingAddress_ThenResolvesCorrectly() {
-        let expect = expectation(description: "Get the ENS address")
-
-        let nameService = EthereumNameService(client: client!)
-        nameService.resolve(address: EthereumAddress("0xb0b874220ff95d62a676f58d186c832b3e6529c8"), completion: { (error, ens) in
-            XCTAssertEqual("julien.argent.test", ens)
-            expect.fulfill()
-        })
-
-        waitForExpectations(timeout: 20)
-    }
-
-    func testGivenRopstenRegistry_WhenNotExistingAddress_ThenFailsCorrectly() {
-        let expect = expectation(description: "Get the ENS address")
-
-        let nameService = EthereumNameService(client: client!)
-        nameService.resolve(address: EthereumAddress("0xb0b874220ff95d62a676f58d186c832b3e6529c9"), completion: { (error, ens) in
-            XCTAssertNil(ens)
-            XCTAssertEqual(error, .ensUnknown)
-            expect.fulfill()
-        })
-
-        waitForExpectations(timeout: 20)
-    }
-
-    func testGivenCustomRegistry_WhenNotExistingAddress_ThenResolvesFailsCorrectly() {
-        let expect = expectation(description: "Get the ENS address")
-
-        let nameService = EthereumNameService(client: client!, registryAddress: EthereumAddress("0x7D7C04B7A05539a92541105806e0971E45969F85"))
-        nameService.resolve(address: EthereumAddress("0xb0b874220ff95d62a676f58d186c832b3e6529c9"), completion: { (error, ens) in
-            XCTAssertNil(ens)
-            XCTAssertEqual(error, .ensUnknown)
-            expect.fulfill()
-        })
-
-        waitForExpectations(timeout: 20)
-    }
-
-    func testGivenRopstenRegistry_WhenExistingENS_ThenResolvesAddressCorrectly() {
-        let expect = expectation(description: "Get the ENS reverse lookup address")
-
-        let nameService = EthereumNameService(client: client!)
-        nameService.resolve(ens: "julien.argent.test", completion: { (error, ens) in
-            XCTAssertEqual(EthereumAddress("0xb0b874220ff95d62a676f58d186c832b3e6529c8"), ens)
-            expect.fulfill()
-        })
-
-        waitForExpectations(timeout: 20)
-    }
-
-    func testGivenRopstenRegistry_WhenInvalidENS_ThenErrorsRequest() {
-        let expect = expectation(description: "Get the ENS reverse lookup address")
-
-        let nameService = EthereumNameService(client: client!)
-        nameService.resolve(ens: "**somegarbage)_!!", completion: { (error, ens) in
-            XCTAssertNil(ens)
-            XCTAssertEqual(error, .ensUnknown)
-            expect.fulfill()
-        })
-
-        waitForExpectations(timeout: 20)
-    }
-
-    func testGivenCustomRegistry_WhenInvalidENS_ThenErrorsRequest() {
-        let expect = expectation(description: "Get the ENS reverse lookup address")
-
-        let nameService = EthereumNameService(client: client!, registryAddress: EthereumAddress("0x7D7C04B7A05539a92541105806e0971E45969F85"))
-        nameService.resolve(ens: "**somegarbage)_!!", completion: { (error, ens) in
-            XCTAssertNil(ens)
-            XCTAssertEqual(error, .ensUnknown)
-            expect.fulfill()
-        })
-
-        waitForExpectations(timeout: 20)
-    }
-
-    func testGivenRopstenRegistry_ThenResolvesMultipleAddressesInOneCall() {
-        let expect = expectation(description: "Get the ENS reverse lookup address")
-
-        let nameService = EthereumNameService(client: client!)
-
-        var results: [EthereumNameService.ResolveOutput<String>]?
-
-        nameService.resolve(addresses: [
-            EthereumAddress("0xb0b874220ff95d62a676f58d186c832b3e6529c8"),
-            EthereumAddress("0x09b5bd82f3351a4c8437fc6d7772a9e6cd5d25a1"),
-            EthereumAddress("0x7e691d7ffb007abe91d8a24d7f22fc74307dab06")
-
-        ]) { result in
-            switch result {
-            case .success(let resolutions):
-                results = resolutions.map { $0.output }
-            case .failure:
-                break
-            }
-            expect.fulfill()
-        }
-
-        waitForExpectations(timeout: 5)
-
-        XCTAssertEqual(
-            results,
-            [
-                .resolved("julien.argent.test"),
-                .couldNotBeResolved(.ensUnknown),
-                .resolved("davidtests.argent.xyz")
-            ]
-        )
-    }
-
-    func testGivenRopstenRegistry_ThenResolvesMultipleNamesInOneCall() {
-        let expect = expectation(description: "Get the ENS reverse lookup address")
-
-        let nameService = EthereumNameService(client: client!)
-
-        var results: [EthereumNameService.ResolveOutput<EthereumAddress>]?
-
-        nameService.resolve(names: [
-            "julien.argent.test",
-            "davidtests.argent.xyz",
-            "somefakeens.argent.xyz"
-
-        ]) { result in
-            switch result {
-            case .success(let resolutions):
-                results = resolutions.map { $0.output }
-            case .failure:
-                break
-            }
-            expect.fulfill()
-        }
-
-        waitForExpectations(timeout: 5)
-
-        XCTAssertEqual(
-            results,
-            [
-                .resolved(EthereumAddress("0xb0b874220ff95d62a676f58d186c832b3e6529c8")),
-                .resolved(EthereumAddress("0x7e691d7ffb007abe91d8a24d7f22fc74307dab06")),
-                .couldNotBeResolved(.ensUnknown)
-            ]
-        )
-    }
-}
-
-
-#if compiler(>=5.5) && canImport(_Concurrency)
-
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-extension ENSTests {
-    func testGivenRopstenRegistry_WhenExistingDomainName_ResolvesOwnerAddressCorrectly_Async() async {
+    func testGivenRopstenRegistry_WhenExistingDomainName_ResolvesOwnerAddressCorrectly() async {
         do {
             let function = ENSContracts.ENSRegistryFunctions.owner(contract: ENSContracts.RopstenAddress, _node: EthereumNameService.nameHash(name: "test").web3.hexData ?? Data())
 
@@ -220,67 +43,85 @@ extension ENSTests {
         }
     }
 
-    func testGivenRopstenRegistry_WhenExistingAddress_ThenResolvesCorrectly_Async() async {
+    func testGivenRopstenRegistry_WhenExistingAddress_ThenResolvesCorrectly() async {
         do {
             let nameService = EthereumNameService(client: client!)
-            let ens = try await nameService.resolve(address: EthereumAddress("0xb0b874220ff95d62a676f58d186c832b3e6529c8"))
+            let ens = try await nameService.resolve(
+                address: EthereumAddress("0xb0b874220ff95d62a676f58d186c832b3e6529c8"),
+                mode: .onchain
+            )
             XCTAssertEqual("julien.argent.test", ens)
         } catch {
             XCTFail("Expected ens but failed \(error).")
         }
     }
 
-    func testGivenRopstenRegistry_WhenNotExistingAddress_ThenFailsCorrectly_Async() async {
+    func testGivenRopstenRegistry_WhenNotExistingAddress_ThenFailsCorrectly() async {
         do {
             let nameService = EthereumNameService(client: client!)
-            _ = try await nameService.resolve(address: EthereumAddress("0xb0b874220ff95d62a676f58d186c832b3e6529c9"))
+            _ = try await nameService.resolve(
+                address: EthereumAddress("0xb0b874220ff95d62a676f58d186c832b3e6529c9"),
+                mode: .onchain
+            )
             XCTFail("Expected to throw while awaiting, but succeeded")
         } catch {
             XCTAssertEqual(error as? EthereumNameServiceError, .ensUnknown)
         }
     }
 
-    func testGivenCustomRegistry_WhenNotExistingAddress_ThenResolvesFailsCorrectly_Async() async {
+    func testGivenCustomRegistry_WhenNotExistingAddress_ThenResolvesFailsCorrectly() async {
         do {
             let nameService = EthereumNameService(client: client!, registryAddress: EthereumAddress("0x7D7C04B7A05539a92541105806e0971E45969F85"))
-            _ = try await nameService.resolve(address: EthereumAddress("0xb0b874220ff95d62a676f58d186c832b3e6529c9"))
+            _ = try await nameService.resolve(
+                address: EthereumAddress("0xb0b874220ff95d62a676f58d186c832b3e6529c9"),
+                mode: .onchain
+            )
             XCTFail("Expected to throw while awaiting, but succeeded")
         } catch {
             XCTAssertEqual(error as? EthereumNameServiceError, .ensUnknown)
         }
     }
 
-    func testGivenRopstenRegistry_WhenExistingENS_ThenResolvesAddressCorrectly_Async() async {
+    func testGivenRopstenRegistry_WhenExistingENS_ThenResolvesAddressCorrectly() async {
         do {
             let nameService = EthereumNameService(client: client!)
-            let ens = try await nameService.resolve(ens: "julien.argent.test")
+            let ens = try await nameService.resolve(
+                ens: "julien.argent.test",
+                mode: .onchain
+            )
             XCTAssertEqual(EthereumAddress("0xb0b874220ff95d62a676f58d186c832b3e6529c8"), ens)
         } catch {
             XCTFail("Expected ens but failed \(error).")
         }
     }
 
-    func testGivenRopstenRegistry_WhenInvalidENS_ThenErrorsRequest_Async() async {
+    func testGivenRopstenRegistry_WhenInvalidENS_ThenErrorsRequest() async {
         do {
             let nameService = EthereumNameService(client: client!)
-            _ = try await nameService.resolve(ens: "**somegarbage)_!!")
+            _ = try await nameService.resolve(
+                ens: "**somegarbage)_!!",
+                mode: .onchain
+            )
             XCTFail("Expected to throw while awaiting, but succeeded")
         } catch {
             XCTAssertEqual(error as? EthereumNameServiceError, .ensUnknown)
         }
     }
 
-    func testGivenCustomRegistry_WhenInvalidENS_ThenErrorsRequest_Async() async {
+    func testGivenCustomRegistry_WhenInvalidENS_ThenErrorsRequest() async {
         do {
             let nameService = EthereumNameService(client: client!, registryAddress: EthereumAddress("0x7D7C04B7A05539a92541105806e0971E45969F85"))
-            _ = try await nameService.resolve(ens: "**somegarbage)_!!")
+            _ = try await nameService.resolve(
+                ens: "**somegarbage)_!!",
+                mode: .onchain
+            )
             XCTFail("Expected to throw while awaiting, but succeeded")
         } catch {
             XCTAssertEqual(error as? EthereumNameServiceError, .ensUnknown)
         }
     }
 
-    func testGivenRopstenRegistry_ThenResolvesMultipleAddressesInOneCall_Async() async {
+    func testGivenRopstenRegistry_ThenResolvesMultipleAddressesInOneCall() async {
         let nameService = EthereumNameService(client: client!)
 
         var results: [EthereumNameService.ResolveOutput<String>]?
@@ -308,7 +149,7 @@ extension ENSTests {
         )
     }
 
-    func testGivenRopstenRegistry_ThenResolvesMultipleNamesInOneCall_Async() async {
+    func testGivenRopstenRegistry_ThenResolvesMultipleNamesInOneCall() async {
         let nameService = EthereumNameService(client: client!)
 
         var results: [EthereumNameService.ResolveOutput<EthereumAddress>]?
@@ -337,4 +178,3 @@ extension ENSTests {
     }
 }
 
-#endif

--- a/web3sTests/OffchainLookup/OffchainLookupTests.swift
+++ b/web3sTests/OffchainLookup/OffchainLookupTests.swift
@@ -1,0 +1,334 @@
+//
+//  OffchainLookupTests.swift
+//  web3sTests
+//
+//  Created by Miguel on 12/05/2022.
+//  Copyright © 2022 Argent Labs Limited. All rights reserved.
+//
+
+@testable import web3
+import XCTest
+import BigInt
+
+struct DummyOffchainENSResolve: ABIFunction {
+    static var name: String = "resolver"
+    var gasPrice: BigUInt? = nil
+    var gasLimit: BigUInt? = nil
+
+    var contract = EthereumAddress("0x7A876E79a89b9B6dF935F2C1e832E15930FEf3f6")
+
+    var from: EthereumAddress? = nil
+    var node: Data
+
+    func encode(to encoder: ABIFunctionEncoder) throws {
+        try encoder.encode(node, staticSize: 32)
+    }
+}
+
+enum EthersTestContract {
+    struct TestGet: ABIFunction {
+        static var name: String = "testGet"
+        var gasPrice: BigUInt? = nil
+        var gasLimit: BigUInt? = nil
+
+        var contract = EthereumAddress("0xAe375B05A08204C809b3cA67C680765661998886")
+
+        var from: EthereumAddress? = nil
+        var data: Data
+
+        func encode(to encoder: ABIFunctionEncoder) throws {
+            try encoder.encode(data)
+        }
+    }
+
+    struct TestGetFail: ABIFunction {
+        static var name: String = "testGetFail"
+        var gasPrice: BigUInt? = nil
+        var gasLimit: BigUInt? = nil
+
+        var contract = EthereumAddress("0xAe375B05A08204C809b3cA67C680765661998886")
+
+        var from: EthereumAddress? = nil
+        var data: Data
+
+        func encode(to encoder: ABIFunctionEncoder) throws {
+            try encoder.encode(data)
+        }
+    }
+
+    struct TestGetSenderFail: ABIFunction {
+        static var name: String = "testGetSenderFail"
+        var gasPrice: BigUInt? = nil
+        var gasLimit: BigUInt? = nil
+
+        var contract = EthereumAddress("0xAe375B05A08204C809b3cA67C680765661998886")
+
+        var from: EthereumAddress? = nil
+        var data: Data
+
+        func encode(to encoder: ABIFunctionEncoder) throws {
+            try encoder.encode(data)
+        }
+    }
+
+    struct TestGetMissing: ABIFunction {
+        static var name: String = "testGetMissing"
+        var gasPrice: BigUInt? = nil
+        var gasLimit: BigUInt? = nil
+
+        var contract = EthereumAddress("0xAe375B05A08204C809b3cA67C680765661998886")
+
+        var from: EthereumAddress? = nil
+        var data: Data
+
+        func encode(to encoder: ABIFunctionEncoder) throws {
+            try encoder.encode(data)
+        }
+    }
+
+    struct TestGetFallback: ABIFunction {
+        static var name: String = "testGetFallback"
+        var gasPrice: BigUInt? = nil
+        var gasLimit: BigUInt? = nil
+
+        var contract = EthereumAddress("0xAe375B05A08204C809b3cA67C680765661998886")
+
+        var from: EthereumAddress? = nil
+        var data: Data
+
+        func encode(to encoder: ABIFunctionEncoder) throws {
+            try encoder.encode(data)
+        }
+    }
+
+    struct TestPost: ABIFunction {
+        static var name: String = "testPost"
+        var gasPrice: BigUInt? = nil
+        var gasLimit: BigUInt? = nil
+
+        var contract = EthereumAddress("0xAe375B05A08204C809b3cA67C680765661998886")
+
+        var from: EthereumAddress? = nil
+        var data: Data
+
+        func encode(to encoder: ABIFunctionEncoder) throws {
+            try encoder.encode(data)
+        }
+    }
+
+    struct BytesResponse: ABIResponse {
+        static var types: [ABIType.Type] {
+            [Data32.self]
+        }
+
+        let data: Data
+
+        init?(values: [ABIDecoder.DecodedValue]) throws {
+            data = try values[0].decoded()
+        }
+    }
+}
+
+extension EthereumClientError {
+    var executionError: JSONRPCErrorDetail? {
+        switch self {
+        case .executionError(let detail):
+            return detail
+        default:
+            return nil
+        }
+    }
+}
+
+class OffchainLookupTests: XCTestCase {
+    var client: EthereumClient!
+    var account: EthereumAccount!
+    var offchainLookup = OffchainLookup(address: .zero, urls: [], callData: Data(), callbackFunction: Data(), extraData: Data())
+
+    override func setUp() {
+        super.setUp()
+        self.client = EthereumClient(url: URL(string: TestConfig.clientUrl)!)
+        self.account = try? EthereumAccount(keyStorage: TestEthereumKeyStorage(privateKey: TestConfig.privateKey))
+        print("Public address: \(self.account?.address.value ?? "NONE")")
+    }
+
+    func test_GivenFunctionWithOffchainLookupError_ThenDecodesLookupParamsCorrectly() async throws {
+        let function =  DummyOffchainENSResolve(
+            node: EthereumNameService.nameHash(name: "hello.argent.xyz").web3.hexData!
+        )
+
+        let tx = try! function.transaction()
+
+        do {
+            let _ = try await client.eth_call(tx)
+            XCTFail("Expecting error, not return value")
+        } catch let error {
+            let error = (error as? EthereumClientError)?.executionError
+            let decoded = try? error?.decode(error: offchainLookup)
+
+
+            XCTAssertEqual(error?.code, JSONRPCErrorCode.contractExecution)
+            XCTAssertEqual(try? decoded?[0].decoded(), EthereumAddress("0x7a876e79a89b9b6df935f2c1e832e15930fef3f6"))
+            XCTAssertEqual(try? decoded?[1].decodedArray(), ["https://argent.xyz"])
+            XCTAssertEqual(try? decoded?[2].decoded(), Data(hex: "0x35b8485202b076a4e2d0173bf3d7e69546db3eb92389469473b2680c3cdb4427cafbcf2a")!)
+            XCTAssertEqual(try? decoded?[3].decoded(), Data(hex: "0xd2479f3e")!)
+            XCTAssertEqual(try? decoded?[4].decoded(), Data())
+        }
+    }
+
+    func test_GivenTestFunction_WhenLookupCorrect_ThenDecodesRetrievesValue() async throws {
+        let function =  EthersTestContract.TestGet(data: "0x1234".web3.hexData!)
+
+        do {
+            let response = try await function.call(
+                withClient: client,
+                responseType: EthersTestContract.BytesResponse.self,
+                resolution: .offchainAllowed(maxRedirects: 5)
+            )
+
+            XCTAssertEqual(
+                response.data.web3.hexString,
+                expectedResponse(
+                    sender: function.contract,
+                    data: "0x1234".web3.hexData!)
+            )
+        } catch let error {
+            XCTFail("Error \(error)")
+        }
+    }
+
+    func test_GivenTestFunction_WhenLookupDisabled_ThenFailsWithExecutionError() async throws {
+        let function =  EthersTestContract.TestGet(data: "0x1234".web3.hexData!)
+
+        do {
+            _ = try await function.call(
+                withClient: client,
+                responseType: EthersTestContract.BytesResponse.self,
+                resolution: .noOffchain(failOnExecutionError: true)
+            )
+            XCTFail("Expecting error")
+        } catch let error {
+            let error = (error as? EthereumClientError)?.executionError
+            XCTAssertEqual(error?.code, 3)
+        }
+    }
+
+    func test_GivenTestFunction_WhenGatewayFails_ThenFailsCall() async throws {
+        let function =  EthersTestContract.TestGetFail(data: "0x1234".web3.hexData!)
+
+        do {
+            _ = try await function.call(
+                withClient: client,
+                responseType: EthersTestContract.BytesResponse.self,
+                resolution: .offchainAllowed(maxRedirects: 5)
+            )
+            XCTFail("Expecting error")
+        } catch let error {
+            XCTAssertEqual(error as? EthereumClientError, EthereumClientError.noResultFound)
+        }
+    }
+
+    func test_GivenTestFunction_WhenSendersDoNotMatch_ThenFailsCall() async throws {
+        let function =  EthersTestContract.TestGetSenderFail(data: "0x1234".web3.hexData!)
+
+        do {
+            _ = try await function.call(
+                withClient: client,
+                responseType: EthersTestContract.BytesResponse.self,
+                resolution: .offchainAllowed(maxRedirects: 5)
+            )
+            XCTFail("Expecting error")
+        } catch _ {
+        }
+    }
+
+    func test_GivenTestFunction_WhenGatewayFailsWith4xx_ThenFailsCall() async throws {
+        let function =  EthersTestContract.TestGetMissing(data: "0x1234".web3.hexData!)
+
+        do {
+            _ = try await function.call(
+                withClient: client,
+                responseType: EthersTestContract.BytesResponse.self,
+                resolution: .offchainAllowed(maxRedirects: 5)
+            )
+            XCTFail("Expecting error")
+        } catch let error {
+            XCTAssertEqual(error as? EthereumClientError, EthereumClientError.noResultFound)
+        }
+    }
+
+    func test_GivenTestFunction_WhenLookupCorrectWithFallback_ThenDecodesRetrievesValue() async throws {
+        let function =  EthersTestContract.TestGetFallback(data: "0x1234".web3.hexData!)
+
+        do {
+            let response = try await function.call(
+                withClient: client,
+                responseType: EthersTestContract.BytesResponse.self,
+                resolution: .offchainAllowed(maxRedirects: 5)
+            )
+
+            XCTAssertEqual(
+                response.data.web3.hexString,
+                expectedResponse(
+                    sender: function.contract,
+                    data: "0x1234".web3.hexData!)
+            )
+        } catch let error {
+            XCTFail("Error \(error)")
+        }
+    }
+
+    func test_GivenTestFunction_WhenLookupCorrectWithFallbackAndNoRedirectsLeft_ThenFails() async throws {
+        let function =  EthersTestContract.TestGetFallback(data: "0x1234".web3.hexData!)
+
+        do {
+            let _ = try await function.call(
+                withClient: client,
+                responseType: EthersTestContract.BytesResponse.self,
+                resolution: .offchainAllowed(maxRedirects: 0)
+            )
+
+            XCTFail("Expecting error")
+        } catch let error {
+            XCTAssertEqual(error as? EthereumClientError, EthereumClientError.noResultFound)
+        }
+    }
+
+
+    func test_GivenTestFunction_WhenLookupCorrectWithPOSTData_ThenDecodesRetrievesValue() async throws {
+        let function =  EthersTestContract.TestPost(data: "0x1234".web3.hexData!)
+
+        do {
+            let response = try await function.call(
+                withClient: client,
+                responseType: EthersTestContract.BytesResponse.self,
+                resolution: .offchainAllowed(maxRedirects: 5)
+            )
+
+            XCTAssertEqual(
+                response.data.web3.hexString,
+                expectedResponse(
+                    sender: function.contract,
+                    data: "0x1234".web3.hexData!)
+            )
+        } catch let error {
+            XCTFail("Error \(error)")
+        }
+    }
+}
+
+// Expected hash of result, which is the same verification done in ethers contract
+fileprivate func expectedResponse(
+    sender: EthereumAddress,
+    data: Data
+) -> String {
+    let senderData = sender.value.web3.hexData!
+    return Data([
+        [UInt8(senderData.count)],
+        senderData.web3.bytes,
+        [UInt8(data.count)],
+        data.web3.bytes
+        ]
+        .flatMap { $0 }
+    ).web3.keccak256.web3.hexString
+}

--- a/web3swift/src/Client/JSONRPC.swift
+++ b/web3swift/src/Client/JSONRPC.swift
@@ -28,13 +28,16 @@ public struct JSONRPCResult<T: Decodable>: Decodable {
 public struct JSONRPCErrorDetail: Decodable, Equatable, CustomStringConvertible {
     public var code: Int
     public var message: String
+    public var data: String?
 
     public init(
         code: Int,
-        message: String
+        message: String,
+        data: String?
     ) {
         self.code = code
         self.message = message
+        self.data = data
     }
 
     public var description: String {
@@ -104,7 +107,6 @@ public class EthereumRPC {
                     let resultObjects = result.map{ return $0.result }
                     return completion(nil, resultObjects)
                 } else if let errorResult = try? JSONDecoder().decode(JSONRPCErrorResult.self, from: data) {
-                    print("Ethereum response error: \(errorResult.error)")
                     return completion(JSONRPCError.executionError(errorResult), nil)
                 } else if let response = response as? HTTPURLResponse, response.statusCode < 200 || response.statusCode > 299 {
                     return completion(JSONRPCError.requestRejected(data), nil)

--- a/web3swift/src/Contract/Statically Typed/ABIFunction.swift
+++ b/web3swift/src/Contract/Statically Typed/ABIFunction.swift
@@ -9,13 +9,11 @@
 import Foundation
 import BigInt
 
-public protocol ABIFunction {
-    static var name: String { get }
+public protocol ABIFunction: ABIFunctionEncodable {
     var gasPrice: BigUInt? { get }
     var gasLimit: BigUInt? { get }
     var contract: EthereumAddress { get }
     var from: EthereumAddress? { get }
-    func encode(to encoder: ABIFunctionEncoder) throws
 }
 
 public protocol ABIResponse: ABITupleDecodable {}

--- a/web3swift/src/Contract/Statically Typed/ABIFunctionEncodable.swift
+++ b/web3swift/src/Contract/Statically Typed/ABIFunctionEncodable.swift
@@ -1,0 +1,42 @@
+//
+//  ABIFunctionEncodable.swift
+//  web3swift
+//
+//  Created by Miguel on 12/05/2022.
+//  Copyright © 2022 Argent Labs Limited. All rights reserved.
+//
+
+import Foundation
+
+public protocol ABIFunctionEncodable {
+    static var name: String { get }
+    func encode(to encoder: ABIFunctionEncoder) throws
+}
+
+extension ABIFunctionEncodable {
+    public func decode(
+        _ data: Data,
+        expectedTypes: [ABIType.Type],
+        filteringEmptyEntries filterEmptyEntries: Bool = true
+    ) throws -> [ABIDecoder.DecodedValue] {
+        let encoder = ABIFunctionEncoder(Self.name)
+        try encode(to: encoder)
+        let rawTypes = encoder.types
+        let methodId = String(hexFromBytes: try ABIFunctionEncoder.methodId(name: Self.name, types: rawTypes))
+        var raw = data.web3.hexString
+
+        guard raw.hasPrefix(methodId) else {
+            throw ABIError.invalidSignature
+        }
+        raw = raw.replacingOccurrences(of: methodId, with: "")
+        let decoded = try ABIDecoder.decodeData(raw, types: expectedTypes)
+        let empty = decoded.flatMap { $0.entry.filter(\.isEmpty) }
+        guard
+            empty.count == 0 || !filterEmptyEntries,
+            decoded.count == expectedTypes.count else {
+            throw ABIError.invalidSignature
+        }
+
+        return decoded
+    }
+}

--- a/web3swift/src/Contract/Statically Typed/ABIFunctionEncoder.swift
+++ b/web3swift/src/Contract/Statically Typed/ABIFunctionEncoder.swift
@@ -9,30 +9,6 @@
 import Foundation
 import BigInt
 
-extension ABIFunction {
-    public func decode(_ data: Data, expectedTypes: [ABIType.Type]) throws -> [ABIDecoder.DecodedValue] {
-        let encoder = ABIFunctionEncoder(Self.name)
-        try encode(to: encoder)
-        let rawTypes = encoder.types
-        let methodId = String(hexFromBytes: try ABIFunctionEncoder.methodId(name: Self.name, types: rawTypes))
-        var raw = data.web3.hexString
-        
-        guard raw.hasPrefix(methodId) else {
-            throw ABIError.invalidSignature
-        }
-        raw = raw.replacingOccurrences(of: methodId, with: "")
-        let decoded = try ABIDecoder.decodeData(raw, types: expectedTypes)
-        let empty = decoded.flatMap { $0.entry.filter(\.isEmpty) }
-        guard
-            empty.count == 0,
-            decoded.count == expectedTypes.count else {
-            throw ABIError.invalidSignature
-        }
-        
-        return decoded
-    }
-}
-
 public class ABIFunctionEncoder {
     private let name: String
     private (set) var types: [ABIRawType] = []

--- a/web3swift/src/Contract/Statically Typed/ABIRevertError.swift
+++ b/web3swift/src/Contract/Statically Typed/ABIRevertError.swift
@@ -1,0 +1,30 @@
+//
+//  ABIRevertError.swift
+//  web3swift
+//
+//  Created by Miguel on 12/05/2022.
+//  Copyright © 2022 Argent Labs Limited. All rights reserved.
+//
+
+import Foundation
+
+// Technically an ABI error is the same as a function in the way it's encoded
+// But use different type to be more explicit, as some extensions
+// on ABIFunction don't matter for ABIError (i.e. to generate a transaction)
+public protocol ABIRevertError: ABIFunctionEncodable {
+    var expectedTypes: [ABIType.Type] { get }
+}
+
+extension JSONRPCErrorDetail {
+    public func decode<T: ABIRevertError>(error: T) throws -> [ABIDecoder.DecodedValue] {
+        guard let data = data?.web3.hexData else {
+            throw ABIError.invalidType
+        }
+
+        return try error.decode(
+            data,
+            expectedTypes: error.expectedTypes,
+            filteringEmptyEntries: false
+        )
+    }
+}

--- a/web3swift/src/ENS/ENSMultiResolver.swift
+++ b/web3swift/src/ENS/ENSMultiResolver.swift
@@ -111,7 +111,6 @@ extension EthereumNameService {
             resolveRegistry(
                 parameters: addresses.map(ENSRegistryResolverParameter.address),
                 handler: { index, parameter, result in
-                    // TODO: Temporary solution
                     guard let address = parameter.address else { return }
                     switch result {
                     case .success(let resolverAddress):
@@ -155,7 +154,6 @@ extension EthereumNameService {
             resolveRegistry(
                 parameters: names.map(ENSRegistryResolverParameter.name),
                 handler: { index, parameter, result in
-                    // TODO: Temporary solution
                     guard let name = parameter.name else { return }
                     switch result {
                     case .success(let resolverAddress):

--- a/web3swift/src/ENS/ENSResolver.swift
+++ b/web3swift/src/ENS/ENSResolver.swift
@@ -1,0 +1,110 @@
+//
+//  ENSResolver.swift
+//  web3swift
+//
+//  Created by Miguel on 17/05/2022.
+//  Copyright © 2022 Argent Labs Limited. All rights reserved.
+//
+
+import Foundation
+
+class ENSResolver {
+
+    let address: EthereumAddress
+    let callResolution: CallResolution
+    private (set) var supportsWildCard: Bool?
+    
+    private let client: EthereumClientProtocol
+
+    init(
+        address: EthereumAddress,
+        client: EthereumClientProtocol,
+        callResolution: CallResolution,
+        supportsWildCard: Bool? = nil
+    ) {
+        self.address = address
+        self.callResolution = callResolution
+        self.client = client
+        self.supportsWildCard = supportsWildCard
+    }
+
+    func resolve(
+        name: String
+    ) async throws -> EthereumAddress {
+        let wildcardResolution: Bool
+        if let supportsWildCard = self.supportsWildCard {
+            wildcardResolution = supportsWildCard
+        } else {
+            wildcardResolution = try await supportsWildcard()
+        }
+        self.supportsWildCard = wildcardResolution
+
+        if wildcardResolution && callResolution.allowsOffchain {
+            let response = try await ENSContracts.ENSOffchainResolverFunctions.resolve(
+                contract: address,
+                parameter: .name(name)
+            ).call(
+                withClient: client,
+                responseType: ENSContracts.AddressAsDataResponse.self,
+                resolution: callResolution
+            )
+            return response.value
+        } else {
+            let response = try await ENSContracts.ENSResolverFunctions.addr(
+                contract: address,
+                parameter: .name(name)
+            ).call(
+                withClient: client,
+                responseType: ENSContracts.AddressResponse.self,
+                resolution: callResolution
+            )
+            return response.value
+        }
+    }
+
+    func resolve(
+        address: EthereumAddress
+    ) async throws -> String {
+        let wildcardResolution: Bool
+        if let supportsWildCard = self.supportsWildCard {
+            wildcardResolution = supportsWildCard
+        } else {
+            wildcardResolution = try await supportsWildcard()
+        }
+        self.supportsWildCard = wildcardResolution
+
+        if wildcardResolution && callResolution.allowsOffchain {
+            let response = try await ENSContracts.ENSOffchainResolverFunctions.resolve(
+                contract: self.address,
+                parameter: .address(address)
+            ).call(
+                withClient: client,
+                responseType: ENSContracts.StringAsDataResponse.self,
+                resolution: callResolution
+            )
+            return response.value
+        } else {
+            let response = try await ENSContracts.ENSResolverFunctions.name(
+                contract: self.address,
+                parameter: .address(address)
+            ).call(
+                withClient: client,
+                responseType: ENSContracts.StringResponse.self,
+                resolution: callResolution
+            )
+
+            if response.value.isEmpty {
+                throw EthereumNameServiceError.ensUnknown
+            }
+
+            return response.value
+        }
+    }
+
+    private func supportsWildcard() async throws -> Bool {
+        try await ERC165(client: client).supportsInterface(
+            contract: address,
+            id: ENSContracts.ENSOffchainResolverFunctions.interfaceId
+        )
+    }
+}

--- a/web3swift/src/ERC165/ERC165.swift
+++ b/web3swift/src/ERC165/ERC165.swift
@@ -10,8 +10,8 @@ import Foundation
 import BigInt
 
 public class ERC165 {
-    public let client: EthereumClient
-    required public init(client: EthereumClient) {
+    public let client: EthereumClientProtocol
+    required public init(client: EthereumClientProtocol) {
         self.client = client
     }
 

--- a/web3swift/src/ERC20/ERC20.swift
+++ b/web3swift/src/ERC20/ERC20.swift
@@ -69,7 +69,7 @@ public class ERC20: ERC20Protocol {
         function.call(
             withClient: self.client,
             responseType: ERC20Responses.decimalsResponse.self,
-            failOnExecutionError: false
+            resolution: .noOffchain(failOnExecutionError: false)
         ) { (error, decimalsResponse) in
             return completion(error, decimalsResponse?.value)
         }

--- a/web3swift/src/ERC721/ERC721.swift
+++ b/web3swift/src/ERC721/ERC721.swift
@@ -195,12 +195,12 @@ public class ERC721Metadata: ERC721 {
 
     public let session: URLSession
 
-    public init(client: EthereumClient, metadataSession: URLSession) {
+    public init(client: EthereumClientProtocol, metadataSession: URLSession) {
         self.session = metadataSession
         super.init(client: client)
     }
 
-    required init(client: EthereumClient) {
+    required init(client: EthereumClientProtocol) {
         fatalError("init(client:) has not been implemented")
     }
 
@@ -350,7 +350,7 @@ public class ERC721Enumerable: ERC721 {
         function.call(
             withClient: client,
             responseType: ERC721EnumerableResponses.numberResponse.self,
-            failOnExecutionError: false
+            resolution: .noOffchain(failOnExecutionError: false)
         ) { error, response in
             return completion(error, response?.value)
         }

--- a/web3swift/src/OffchainLookup/OffchainLookup.swift
+++ b/web3swift/src/OffchainLookup/OffchainLookup.swift
@@ -1,0 +1,113 @@
+//
+//  OffchainLookup.swift
+//  web3swift
+//
+//  Created by Miguel on 12/05/2022.
+//  Copyright © 2022 Argent Labs Limited. All rights reserved.
+//
+
+import Foundation
+
+public struct OffchainLookup: ABIRevertError {
+    public var expectedTypes: [ABIType.Type] {
+        [
+            EthereumAddress.self,
+            ABIArray<String>.self,
+            Data.self,
+            Data4.self,
+            Data.self
+        ]
+    }
+    
+    public static var name: String = "OffchainLookup"
+
+    public var address: EthereumAddress
+    public var urls: [String]
+    public var callData: Data
+    public var callbackFunction: Data
+    public var extraData: Data
+
+    public func encode(to encoder: ABIFunctionEncoder) throws {
+        try encoder.encode(address)
+        try encoder.encode(urls)
+        try encoder.encode(callData)
+        try encoder.encode(callbackFunction, staticSize: 4)
+        try encoder.encode(extraData)
+    }
+
+    public init(
+        address: EthereumAddress,
+        urls: [String],
+        callData: Data,
+        callbackFunction: Data,
+        extraData: Data
+    ) {
+        self.address = address
+        self.urls = urls
+        self.callData = callData
+        self.callbackFunction = callbackFunction
+        self.extraData = extraData
+    }
+
+    init?(
+        decoded: [ABIDecoder.DecodedValue]
+    ) {
+        guard let sender = decoded.sender,
+              let urls = decoded.urls,
+              let callData = decoded.callData,
+              let callbackFunction = decoded.callbackFunction,
+              let extraData = decoded.extraData
+        else {
+            return nil
+        }
+        
+        self.init(
+            address: sender,
+            urls: urls,
+            callData: callData,
+            callbackFunction: callbackFunction,
+            extraData: extraData
+        )
+    }
+}
+
+extension JSONRPCErrorResult {
+    var offchainLookup: OffchainLookup? {
+        return (try? error.decode(error: expected)).flatMap(OffchainLookup.init(decoded:))
+    }
+}
+
+extension OffchainLookup {
+    func encodeCall(withResponse data: Data) -> Data {
+        let encodedCall = try? [data, extraData].map {
+            try ABIEncoder.encode($0)
+        }.encoded(isDynamic: false)
+        return callbackFunction + Data(encodedCall ?? [])
+    }
+}
+
+fileprivate let expected = OffchainLookup(
+    address: .zero,
+    urls: [],
+    callData: Data(),
+    callbackFunction: Data(),
+    extraData: Data()
+)
+
+fileprivate extension Array where Element == ABIDecoder.DecodedValue {
+    var sender: EthereumAddress? {
+        try? self[0].decoded()
+    }
+    var urls: [String]? {
+        try? self[1].decodedArray()
+    }
+    var callData: Data? {
+        try? self[2].decoded()
+    }
+    var callbackFunction: Data? {
+        try? self[3].decoded()
+    }
+    var extraData: Data? {
+        try? self[4].decoded()
+    }
+}

--- a/web3swift/src/Utils/PropertyWrappers.swift
+++ b/web3swift/src/Utils/PropertyWrappers.swift
@@ -1,0 +1,41 @@
+//
+//  PropertyWrappers.swift
+//  web3swift
+//
+//  Created by Miguel on 16/05/2022.
+//  Copyright © 2022 Argent Labs Limited. All rights reserved.
+//
+
+
+import Foundation
+
+@propertyWrapper
+struct DataStr: Codable, Equatable, Hashable {
+    private var value: Data
+
+    public init(wrappedValue: Data) {
+        self.value = wrappedValue
+    }
+
+    public init(_ value: Data) {
+        self.init(wrappedValue: value)
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let str = try container.decode(String.self)
+        guard let data = Data(hex: str) else { throw DecodingError.dataCorruptedError(in: container, debugDescription: "Data not in '0x' format") }
+        self.value = data
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(value.web3.hexString)
+    }
+
+    public var wrappedValue: Data {
+        get { value }
+        set { self.value = newValue }
+    }
+
+}


### PR DESCRIPTION
Add support for offchain read in `eth_call`, and more specifically add support for offchain ENS resolution.

An example to resolve is:
`offchainexample.eth` (both in ropsten and mainnet)

See
https://eips.ethereum.org/EIPS/eip-3668

There's another bit of related but not the same work, but will address this here : #205 