### PR TITLE
[FIX] ENS wildcard resolution caching

### DIFF
--- a/web3sTests/ENS/ENSOffchainTests.swift
+++ b/web3sTests/ENS/ENSOffchainTests.swift
@@ -83,5 +83,69 @@ class ENSOffchainTests: XCTestCase {
             XCTFail("Expected ens but failed \(error).")
         }
     }
+    
+    func testGivenRopstenRegistry_WhenWildcardNOTSupported_AndAddressHasSubdomain_ThenFailsResolving() async {
+        do {
+            let nameService = EthereumNameService(client: client!)
+
+            _ = try await nameService.resolve(
+                ens: "1.resolver.eth",
+                mode: .allowOffchainLookup
+            )
+
+            XCTFail("Expected error")
+        } catch {
+            XCTAssertEqual(error as? EthereumNameServiceError, .ensUnknown)
+        }
+    }
+    
+    func testGivenRopstenRegistry_WhenTwoRequestsWithAndWithoutSubdomain_ThenBothResolveCorrectly() async {
+        let nameService = EthereumNameService(client: client!)
+        
+        do {
+            let ens = try await nameService.resolve(
+                ens: "resolver.eth",
+                mode: .allowOffchainLookup
+            )
+            XCTAssertEqual(EthereumAddress("0x42d63ae25990889e35f215bc95884039ba354115"), ens)
+        } catch {
+            XCTFail("Expected ens but failed \(error).")
+        }
+        do {
+            _ = try await nameService.resolve(
+                ens: "1.resolver.eth",
+                mode: .allowOffchainLookup
+            )
+
+            XCTFail("Expected error")
+        } catch {
+            XCTAssertEqual(error as? EthereumNameServiceError, .ensUnknown)
+        }
+    }
+    
+    func testGivenRopstenRegistry_WhenTwoRequestsWithoutAndWithSubdomain_ThenBothResolveCorrectly() async {
+        let nameService = EthereumNameService(client: client!)
+        
+        do {
+            _ = try await nameService.resolve(
+                ens: "1.resolver.eth",
+                mode: .allowOffchainLookup
+            )
+
+            XCTFail("Expected error")
+        } catch {
+            XCTAssertEqual(error as? EthereumNameServiceError, .ensUnknown)
+        }
+        
+        do {
+            let ens = try await nameService.resolve(
+                ens: "resolver.eth",
+                mode: .allowOffchainLookup
+            )
+            XCTAssertEqual(EthereumAddress("0x42d63ae25990889e35f215bc95884039ba354115"), ens)
+        } catch {
+            XCTFail("Expected ens but failed \(error).")
+        }
+    }
 }
 

--- a/web3swift/src/ENS/ENSResolver.swift
+++ b/web3swift/src/ENS/ENSResolver.swift
@@ -13,7 +13,6 @@ class ENSResolver {
     let address: EthereumAddress
     let callResolution: CallResolution
     private (set) var supportsWildCard: Bool?
-    private let mustSupportWilcard: Bool
     
     private let client: EthereumClientProtocol
 
@@ -21,18 +20,17 @@ class ENSResolver {
         address: EthereumAddress,
         client: EthereumClientProtocol,
         callResolution: CallResolution,
-        supportsWildCard: Bool? = nil,
-        mustSupportWildcard: Bool = false
+        supportsWildCard: Bool? = nil
     ) {
         self.address = address
         self.callResolution = callResolution
         self.client = client
         self.supportsWildCard = supportsWildCard
-        self.mustSupportWilcard = mustSupportWildcard
     }
 
     func resolve(
-        name: String
+        name: String,
+        supportingWildcard mustSupportWildCard: Bool
     ) async throws -> EthereumAddress {
         let wildcardResolution: Bool
         if let supportsWildCard = self.supportsWildCard {
@@ -42,7 +40,7 @@ class ENSResolver {
         }
         self.supportsWildCard = wildcardResolution
 
-        if mustSupportWilcard && !wildcardResolution {
+        if mustSupportWildCard && !wildcardResolution {
             // Wildcard name resolution (ENSIP-10)
             throw EthereumNameServiceError.ensUnknown
         }


### PR DESCRIPTION
Resolving ENS without wildcard, **then** ENS with wildcard on same resolver. Also added test for inverse order.