### PR TITLE
Remove unused account in eth_estimateGas

### DIFF
--- a/web3sTests/Client/EthereumClientTests.swift
+++ b/web3sTests/Client/EthereumClientTests.swift
@@ -344,7 +344,7 @@ class EthereumClientTests: XCTestCase {
                                          gasPrice: nil,
                                          gasLimit: nil)
 
-            let value = try await client!.eth_estimateGas(try! function.transaction(), withAccount: account!)
+            let value = try await client!.eth_estimateGas(try! function.transaction())
             XCTAssert(value != 0)
         } catch {
             XCTFail("Expected value but failed \(error).")

--- a/web3swift/src/Client/EthereumClient.swift
+++ b/web3swift/src/Client/EthereumClient.swift
@@ -28,7 +28,7 @@ public protocol EthereumClientProtocol: AnyObject {
     func eth_blockNumber(completionHandler: @escaping(Result<Int, EthereumClientError>) -> Void)
     func eth_getBalance(address: EthereumAddress, block: EthereumBlock, completionHandler: @escaping(Result<BigUInt, EthereumClientError>) -> Void)
     func eth_getCode(address: EthereumAddress, block: EthereumBlock, completionHandler: @escaping(Result<String, EthereumClientError>) -> Void)
-    func eth_estimateGas(_ transaction: EthereumTransaction, withAccount account: EthereumAccountProtocol, completionHandler: @escaping(Result<BigUInt, EthereumClientError>) -> Void)
+    func eth_estimateGas(_ transaction: EthereumTransaction, completionHandler: @escaping(Result<BigUInt, EthereumClientError>) -> Void)
     func eth_sendRawTransaction(_ transaction: EthereumTransaction, withAccount account: EthereumAccountProtocol, completionHandler: @escaping(Result<String, EthereumClientError>) -> Void)
     func eth_getTransactionCount(address: EthereumAddress, block: EthereumBlock, completionHandler: @escaping(Result<Int, EthereumClientError>) -> Void)
     func eth_getTransaction(byHash txHash: String, completionHandler: @escaping(Result<EthereumTransaction, EthereumClientError>) -> Void)
@@ -48,7 +48,7 @@ public protocol EthereumClientProtocol: AnyObject {
     func eth_blockNumber() async throws -> Int
     func eth_getBalance(address: EthereumAddress, block: EthereumBlock) async throws -> BigUInt
     func eth_getCode(address: EthereumAddress, block: EthereumBlock) async throws -> String
-    func eth_estimateGas(_ transaction: EthereumTransaction, withAccount account: EthereumAccountProtocol) async throws -> BigUInt
+    func eth_estimateGas(_ transaction: EthereumTransaction) async throws -> BigUInt
     func eth_sendRawTransaction(_ transaction: EthereumTransaction, withAccount account: EthereumAccountProtocol) async throws -> String
     func eth_getTransactionCount(address: EthereumAddress, block: EthereumBlock) async throws -> Int
     func eth_getTransaction(byHash txHash: String) async throws -> EthereumTransaction
@@ -236,7 +236,7 @@ public class EthereumClient: EthereumClientProtocol {
         }
     }
 
-    public func eth_estimateGas(_ transaction: EthereumTransaction, withAccount account: EthereumAccountProtocol, completionHandler: @escaping (Result<BigUInt, EthereumClientError>) -> Void) {
+    public func eth_estimateGas(_ transaction: EthereumTransaction, completionHandler: @escaping (Result<BigUInt, EthereumClientError>) -> Void) {
         struct CallParams: Encodable {
             let from: String?
             let to: String
@@ -502,9 +502,9 @@ extension EthereumClient {
         }
     }
 
-    public func eth_estimateGas(_ transaction: EthereumTransaction, withAccount account: EthereumAccountProtocol) async throws -> BigUInt {
+    public func eth_estimateGas(_ transaction: EthereumTransaction) async throws -> BigUInt {
         return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<BigUInt, Error>) in
-            eth_estimateGas(transaction, withAccount: account, completionHandler: continuation.resume)
+            eth_estimateGas(transaction, completionHandler: continuation.resume)
         }
     }
 
@@ -613,9 +613,9 @@ extension EthereumClient {
         }
     }
 
-    @available(*, deprecated, renamed: "eth_estimateGas(_:withAccount:completionHandler:)")
+    @available(*, deprecated, renamed: "eth_estimateGas(_:completionHandler:)")
     public func eth_estimateGas(_ transaction: EthereumTransaction, withAccount account: EthereumAccountProtocol, completion: @escaping((EthereumClientError?, BigUInt?) -> Void)) {
-        eth_estimateGas(transaction, withAccount: account) { result in
+        eth_estimateGas(transaction) { result in
             switch result {
             case .success(let data):
                 completion(nil, data)


### PR DESCRIPTION
Good afternoon team, I'm using your library to build an app with web3. Thank you for your work, it has been really helpful. I would like to propose a small improvement.

While building my model I have found that [EthereumClient](https://github.com/argentlabs/web3.swift/blob/master/web3swift/src/Client/EthereumClient.swift) function [eth_estimateGas](https://github.com/argentlabs/web3.swift/blob/master/web3swift/src/Client/EthereumClient.swift#L31) does not use the account parameter and would be good to remove it.

I have a model Token where I inject contract address and `EthereumClient` for the read functions. For the write functions I want the model to return a transaction with `GasPrice` and `GasLimit` calculated. Having the account as a parameter of `eth_estimateGas`, forces me to inject the account which is not used and is coupled to it.

I have maintained signature of the deprecated method.