### PR TITLE
fix: secp256k1 error

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -30,11 +30,11 @@
       },
       {
         "package": "secp256k1",
-        "repositoryURL": "https://github.com/Boilertalk/secp256k1.swift",
+        "repositoryURL": "https://github.com/GigaBitcoin/secp256k1.swift.git",
         "state": {
           "branch": null,
-          "revision": "823281fe9def21b384099b72a9a53ca988317b20",
-          "version": "0.1.4"
+          "revision": "1a796f738bdcd84b41d05f92593188b23163e60b",
+          "version": "0.7.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     dependencies: [
         .package(name: "BigInt", url: "https://github.com/attaswift/BigInt", from: "5.0.0"),
         .package(name: "GenericJSON", url: "https://github.com/zoul/generic-json-swift", from: "2.0.0"),
-        .package(name: "secp256k1", url: "https://github.com/Boilertalk/secp256k1.swift", from: "0.1.0"),
+        .package(url: "https://github.com/GigaBitcoin/secp256k1.swift.git", .upToNextMajor(from: "0.6.0")),
         .package(url: "https://github.com/OpenCombine/OpenCombine.git", from: "0.13.0")
     ],
     targets: [
@@ -24,11 +24,11 @@ let package = Package(
                     .target(name: "keccaktiny"),
                     .target(name: "aes"),
                     .target(name: "Internal_CryptoSwift_PBDKF2"),
-                    "BigInt",
+                    .product(name: "BigInt", package: "BigInt"),
                     "GenericJSON",
-                    "secp256k1",
                     "OpenCombine",
                     .product(name: "OpenCombineFoundation", package: "OpenCombine"),
+                    .product(name: "secp256k1", package: "secp256k1.swift")
                 ],
             path: "web3swift/src"
         ),

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Use Xcode to add to the project (**File -> Swift Packages**) or add this to your `Package.swift` file:
 ```swift
-.package(url: "https://github.com/argentlabs/web3.swift", from: "0.9.3")
+.package(url: "https://github.com/argentlabs/web3.swift", from: "1.1.0")
 ```
 ### CocoaPods
 

--- a/web3.swift.podspec
+++ b/web3.swift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'web3.swift'
-  s.version = '1.0.0'
+  s.version = '1.1.0'
   s.license = 'MIT'
   s.summary = 'Ethereum API for Swift'
   s.homepage = 'https://github.com/argentlabs/web3.swift'


### PR DESCRIPTION
Change secp256k1 package to a[ maintained package.](https://github.com/GigaBitcoin/secp256k1.swift)

Original `secp256k1` will throw error like below
<img width="271" alt="Screen Shot 2022-06-15 at 2 43 50 AM" src="https://user-images.githubusercontent.com/32106111/173665458-e4daa67c-3701-4a9b-919d-409fbae27cb8.png">
