### PR TITLE
Decreasing minimum macOS version

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/GigaBitcoin/secp256k1.swift.git",
         "state": {
           "branch": null,
-          "revision": "847f56717138cb3ae53896f1912b1f38a274d2fe",
-          "version": "0.9.1"
+          "revision": "1a796f738bdcd84b41d05f92593188b23163e60b",
+          "version": "0.7.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 import PackageDescription
 
 let package = Package(
     name: "web3.swift",
     platforms: [
         .iOS(SupportedPlatform.IOSVersion.v13),
-        .macOS(SupportedPlatform.MacOSVersion.v11)
+        .macOS(SupportedPlatform.MacOSVersion.v10_15)
     ],
     products: [
         .library(name: "web3.swift", targets: ["web3"])


### PR DESCRIPTION
Since Xcode 13.2, support for async/await has been back ported down to macOS 10.15, so we can safely reduce minimum target deployment on macOS. Notice however that Concurrency framework is only available for Xcode 13.2 (Swift 5.5) upwards, so we need to increase swift-tools-version as well