### PR TITLE
[FIX] Remove explicit queue priorities

### DIFF
--- a/web3swift/src/Client/EthereumClient.swift
+++ b/web3swift/src/Client/EthereumClient.swift
@@ -120,13 +120,11 @@ public class EthereumClient: EthereumClientProtocol {
         self.url = url
         let networkQueue = OperationQueue()
         networkQueue.name = "web3swift.client.networkQueue"
-        networkQueue.qualityOfService = .background
         networkQueue.maxConcurrentOperationCount = 4
         self.networkQueue = networkQueue
 
         let txQueue = OperationQueue()
         txQueue.name = "web3swift.client.rawTxQueue"
-        txQueue.qualityOfService = .background
         txQueue.maxConcurrentOperationCount = 1
         self.concurrentQueue = txQueue
 


### PR DESCRIPTION
Currently the queue priorities are set to `.background`, and this is a problem when web3 methods are called from high priority tasks (eg in the Argent app). In Xcode 14 you get thread performance checker warnings about potential priority inversions, which is what happens when a high priority task is waiting on a low priority (.background) task, it effectively demotes the high priority task to low priority.

Here you see a high priority task in Argent being held up waiting on the low priority (background) task in web3:

<img width="660" alt="image" src="https://user-images.githubusercontent.com/4175766/197991660-48f2cd01-fcb5-4736-93ed-d483457a618f.png">

By removing the explicit QoS / Priority the OS decides what priority to give the tasks. This gets rid of the warnings in Xcode and you no longer get these priority inversions.