### PR TITLE
Support Custom Typed Array

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -56,7 +56,9 @@ let package = Package(
             path: "web3sTests",
             resources: [
                 .copy("Resources/rlptests.json"),
-                .copy("Account/cryptofights_712.json")
+                .copy("Account/cryptofights_712.json"),
+                .copy("Account/ethermail_signTypedDataV4.json"),
+                .copy("Account/real_word_opensea_signTypedDataV4.json"),
             ]
         )
     ]

--- a/web3sTests/Account/EthereumAccount+SignTypedTests.swift
+++ b/web3sTests/Account/EthereumAccount+SignTypedTests.swift
@@ -231,6 +231,18 @@ class EthereumAccount_SignTypedTests: XCTestCase {
         let typedData = try! decoder.decode(TypedData.self, from: data)
         XCTAssertEqual(try! typedData.signableHash().web3.hexString, "0xdb12328a6d193965801548e1174936c3aa7adbe1b54b3535a3c905bd4966467c")
     }
+    
+    func test_GivenCustomTypeArray_V4_ItHashesCorrectly() {
+        let simpleUrl = Bundle.module.url(forResource: "ethermail_signTypedDataV4", withExtension: "json")!
+        let simpleData = try! Data(contentsOf: simpleUrl)
+        let simpleTypedData = try! decoder.decode(TypedData.self, from: simpleData)
+        XCTAssertEqual(try! simpleTypedData.signableHash().web3.hexString, "0x8a2c45f690057d91a9738b313da3f65916327e1d5b9a1348b9fc1cff0dc4091e")
+        
+        let realWorldUrl = Bundle.module.url(forResource: "real_word_opensea_signTypedDataV4", withExtension: "json")!
+        let realWorldData = try! Data(contentsOf: realWorldUrl)
+        let realWorldTypedData = try! decoder.decode(TypedData.self, from: realWorldData)
+        XCTAssertEqual(try! realWorldTypedData.signableHash().web3.hexString, "0x76a61293096587b582305a07a60785f92b99ae6c8647c4bcf46d6651db0bd778")
+    }
 
     func test_givenExampleWithDynamicData_ItHashesCorrectly() {
         let typedData = try! decoder.decode(TypedData.self, from: example4)

--- a/web3sTests/Account/ethermail_signTypedDataV4.json
+++ b/web3sTests/Account/ethermail_signTypedDataV4.json
@@ -1,0 +1,70 @@
+{
+  "domain": {
+    "chainId": "137",
+    "name": "Etaher Mail",
+    "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC",
+    "version": "1"
+  },
+  "message": {
+    "contents": "Hello, Bob!",
+    "from": {
+      "name": "Cow",
+      "wallets": [
+        "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826",
+        "0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF"
+      ]
+    },
+    "to": [{
+      "name": "Cow",
+      "wallets": [
+        "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826",
+        "0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF"
+      ]
+    }]
+  },
+  "primaryType": "Mail",
+  "types": {
+    "EIP712Domain": [
+      {
+        "name": "name",
+        "type": "string"
+      },
+      {
+        "name": "version",
+        "type": "string"
+      },
+      {
+        "name": "chainId",
+        "type": "uint256"
+      },
+      {
+        "name": "verifyingContract",
+        "type": "address"
+      }
+    ],
+    "Mail": [
+      {
+        "name": "from",
+        "type": "Person"
+      },
+      {
+        "name": "to",
+        "type": "Person[]"
+      },
+      {
+        "name": "contents",
+        "type": "string"
+      }
+    ],
+    "Person": [
+      {
+        "name": "name",
+        "type": "string"
+      },
+      {
+        "name": "wallets",
+        "type": "address[]"
+      }
+    ]
+  }
+}

--- a/web3sTests/Account/real_word_opensea_signTypedDataV4.json
+++ b/web3sTests/Account/real_word_opensea_signTypedDataV4.json
@@ -1,0 +1,190 @@
+{
+  "types": {
+    "EIP712Domain": [
+      {
+        "name": "name",
+        "type": "string"
+      },
+      {
+        "name": "version",
+        "type": "string"
+      },
+      {
+        "name": "chainId",
+        "type": "uint256"
+      },
+      {
+        "name": "verifyingContract",
+        "type": "address"
+      }
+    ],
+    "OfferItem": [
+      {
+        "name": "itemType",
+        "type": "uint8"
+      },
+      {
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "name": "identifierOrCriteria",
+        "type": "uint256"
+      },
+      {
+        "name": "startAmount",
+        "type": "uint256"
+      },
+      {
+        "name": "endAmount",
+        "type": "uint256"
+      }
+    ],
+    "ConsiderationItem": [
+      {
+        "name": "itemType",
+        "type": "uint8"
+      },
+      {
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "name": "identifierOrCriteria",
+        "type": "uint256"
+      },
+      {
+        "name": "startAmount",
+        "type": "uint256"
+      },
+      {
+        "name": "endAmount",
+        "type": "uint256"
+      },
+      {
+        "name": "recipient",
+        "type": "address"
+      }
+    ],
+    "OrderComponents": [
+      {
+        "name": "offerer",
+        "type": "address"
+      },
+      {
+        "name": "zone",
+        "type": "address"
+      },
+      {
+        "name": "offer",
+        "type": "OfferItem[]"
+      },
+      {
+        "name": "consideration",
+        "type": "ConsiderationItem[]"
+      },
+      {
+        "name": "offertest",
+        "type": "OfferItem[]"
+      },
+      {
+        "name": "orderType",
+        "type": "uint8"
+      },
+      {
+        "name": "startTime",
+        "type": "uint256"
+      },
+      {
+        "name": "endTime",
+        "type": "uint256"
+      },
+      {
+        "name": "zoneHash",
+        "type": "bytes32"
+      },
+      {
+        "name": "salt",
+        "type": "uint256"
+      },
+      {
+        "name": "conduitKey",
+        "type": "bytes32"
+      },
+      {
+        "name": "counter",
+        "type": "uint256"
+      }
+    ],
+    
+  },
+  "primaryType": "OrderComponents",
+  "domain": {
+    "name": "Seaport",
+    "version": "1.1",
+    "chainId": "137",
+    "verifyingContract": "0x00000000006c3852cbEf3e08E8dF289169EdE581"
+  },
+  "message": {
+    "offerer": "0x1fB4b0D6EB80142a6d4893D20d541b235c314f0A",
+    "offer": [
+      {
+        "itemType": "1",
+        "token": "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",
+        "identifierOrCriteria": "0",
+        "startAmount": "900000000000000",
+        "endAmount": "900000000000000"
+      },
+      {
+        "itemType": "1",
+        "token": "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",
+        "identifierOrCriteria": "0",
+        "startAmount": "900000000000000",
+        "endAmount": "900000000000000"
+      }
+    ],
+    "offertest": [
+      {
+        "itemType": "1",
+        "token": "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",
+        "identifierOrCriteria": "0",
+        "startAmount": "900000000000000",
+        "endAmount": "900000000000000"
+      },
+      {
+        "itemType": "1",
+        "token": "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",
+        "identifierOrCriteria": "0",
+        "startAmount": "900000000000000",
+        "endAmount": "900000000000000"
+      }
+    ],
+    "consideration": [
+      {
+        "itemType": "2",
+        "token": "0xa9a6A3626993D487d2Dbda3173cf58cA1a9D9e9f",
+        "identifierOrCriteria": "59091204723763704856388986543321552591754523831551465717007213448841304074849",
+        "startAmount": "1",
+        "endAmount": "1",
+        "recipient": "0x1fB4b0D6EB80142a6d4893D20d541b235c314f0A"
+      },
+      {
+        "itemType": "1",
+        "token": "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",
+        "identifierOrCriteria": "0",
+        "startAmount": "22500000000000",
+        "endAmount": "22500000000000",
+        "recipient": "0x0000a26b00c1F0DF003000390027140000fAa719"
+      }
+    ],
+    "startTime": "1668033203",
+    "endTime": "1668292398",
+    "orderType": "0",
+    "zone": "0x0000000000000000000000000000000000000000",
+    "zoneHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "salt": "24446860302761739304752683030156737591518664810215442929813510023260621276899",
+    "conduitKey": "0x0000007b02230091a7ed01230072f7006a004d60a8d4e71d599b8104250f0000",
+    "totalOriginalConsiderationItems": "2",
+    "counter": "0"
+  }
+}

--- a/web3swift/src/Account/TypedData.swift
+++ b/web3swift/src/Account/TypedData.swift
@@ -71,6 +71,7 @@ extension TypedData {
             let param = types[type]!.map { "\($0.type) \($0.name)" }.joined(separator: ",")
             return "\(type)(\(param))"
         }.joined()
+        
         return encoded.data(using: .utf8) ?? Data()
     }
 
@@ -83,10 +84,32 @@ extension TypedData {
         }
 
         let recursiveEncoded: [UInt8] = try valueTypes.flatMap { variable -> [UInt8] in
-            if types[variable.type] != nil {
+            
+            // Decomposit the type if it is array type
+            let components = variable.type.components(separatedBy: CharacterSet(charactersIn: "[]"))
+            let parsedType = components[0]
+            
+            // Check the type is a custom type
+            if types[parsedType] != nil {
                 guard let json = data[variable.name] else {
                     throw ABIError.invalidValue
                 }
+                
+                // If is custom type array, recursively encode the array
+                if components.count == 3 && components[1].isEmpty {
+                    let encoded = try json.arrayValue!.flatMap { try encodeData(data: $0, type: parsedType).web3.keccak256.web3.bytes }
+                    
+                    return Data(encoded).web3.keccak256.web3.bytes
+                } else if components.count == 3 && !components[1].isEmpty {
+                    let num = String(components[1].filter { "0"..."9" ~= $0 })
+                    guard let int = Int(num), int == json.arrayValue?.count ?? 0 else {
+                        throw ABIError.invalidValue
+                    }
+
+                    let encoded = try json.arrayValue!.flatMap { try encodeData(data: $0, type: parsedType) }
+                    return Data(encoded).web3.keccak256.web3.bytes
+                }
+                
                 return try encodeData(data: json, type: variable.type).web3.keccak256.web3.bytes
             } else if let json = data[variable.name] {
                 return try parseAtomicType(json, type: variable.type)
@@ -94,19 +117,30 @@ extension TypedData {
                 return []
             }
         }
-
+        
         encoded.append(contentsOf: recursiveEncoded)
 
         return Data(encoded)
     }
 
+    private func getParsedType(primaryType: String) -> String {
+        // Decomposit the type if it is an array type
+        let components = primaryType.components(separatedBy: CharacterSet(charactersIn: "[]"))
+        let parsedType = components[0]
+        
+        return parsedType
+    }
+    
     private func findDependencies(primaryType: String, dependencies: Set<String> = Set<String>()) -> Set<String> {
         var found = dependencies
-        guard !found.contains(primaryType),
-            let primaryTypes = types[primaryType] else {
+        
+        let parsedType = getParsedType(primaryType: primaryType)
+        
+        guard !found.contains(parsedType),
+            let primaryTypes = types[parsedType] else {
                 return found
         }
-        found.insert(primaryType)
+        found.insert(parsedType)
         for type in primaryTypes {
             findDependencies(primaryType: type.type, dependencies: found)
                 .forEach { found.insert($0) }
@@ -155,6 +189,7 @@ extension TypedData {
             }
 
             let encoded = try value.flatMap { try parseAtomicType($0, type: nested.rawValue) }
+            
             return Data(encoded).web3.keccak256.web3.bytes
         case .FixedArray(let nested, let count):
             guard let value = data.arrayValue else {


### PR DESCRIPTION
Context: https://github.com/argentlabs/web3.swift/issues/277

Adding support of custom typed array in `signableHash`. Cross verified new unit test cases with [@metamask/eth-sig-util](https://github.com/MetaMask/eth-sig-util).

**Tests:**
1. All unit tests in `EthereumAccount_SignTypedTests`