### PR TITLE
Private key on-demand

### DIFF
--- a/web3sTests/Account/EthereumAccount+SignTransactionTests.swift
+++ b/web3sTests/Account/EthereumAccount+SignTransactionTests.swift
@@ -17,7 +17,7 @@ class EthereumAccount_SignTransactionTests: XCTestCase {
         super.tearDown()
     }
 
-    func testTransaction2Sign() {
+    func testTransaction2Sign() async {
         //https://medium.com/@codetractio/walkthrough-of-an-ethereum-improvement-proposal-eip-6fda3966d171
 
         let nonce = 9
@@ -32,7 +32,7 @@ class EthereumAccount_SignTransactionTests: XCTestCase {
         let privateKey = "0x4646464646464646464646464646464646464646464646464646464646464646"
         let address = "0x9d8a62f656a8d1615c1294fd71e9cfb3e4855a4f"
         let account = EthereumAccount.init(address: .init(address), keyStorage: TestEthereumKeyStorage(privateKey: privateKey))
-        let signed = try! account.sign(transaction: tx)
+        let signed = try! await account.sign(transaction: tx)
 
         let v = signed.v.web3.hexString
         let r = signed.r.web3.hexString

--- a/web3sTests/Account/EthereumAccount+SignTransactionTests.swift
+++ b/web3sTests/Account/EthereumAccount+SignTransactionTests.swift
@@ -29,7 +29,9 @@ class EthereumAccount_SignTransactionTests: XCTestCase {
 
         let tx = EthereumTransaction(from: nil, to: to, value: value, data: nil, nonce: nonce, gasPrice: gasPrice, gasLimit: gasLimit, chainId: chainID)
 
-        let account = try! EthereumAccount.init(keyStorage: TestEthereumKeyStorage(privateKey: "0x4646464646464646464646464646464646464646464646464646464646464646"))
+        let privateKey = "0x4646464646464646464646464646464646464646464646464646464646464646"
+        let address = "0x9d8a62f656a8d1615c1294fd71e9cfb3e4855a4f"
+        let account = try! EthereumAccount.init(addressString: address, keyStorage: TestEthereumKeyStorage(privateKey: privateKey))
         let signed = try! account.sign(transaction: tx)
 
         let v = signed.v.web3.hexString

--- a/web3sTests/Account/EthereumAccount+SignTransactionTests.swift
+++ b/web3sTests/Account/EthereumAccount+SignTransactionTests.swift
@@ -31,7 +31,7 @@ class EthereumAccount_SignTransactionTests: XCTestCase {
 
         let privateKey = "0x4646464646464646464646464646464646464646464646464646464646464646"
         let address = "0x9d8a62f656a8d1615c1294fd71e9cfb3e4855a4f"
-        let account = try! EthereumAccount.init(addressString: address, keyStorage: TestEthereumKeyStorage(privateKey: privateKey))
+        let account = EthereumAccount.init(address: .init(address), keyStorage: TestEthereumKeyStorage(privateKey: privateKey))
         let signed = try! account.sign(transaction: tx)
 
         let v = signed.v.web3.hexString

--- a/web3sTests/Account/EthereumAccount+SignTypedTests.swift
+++ b/web3sTests/Account/EthereumAccount+SignTypedTests.swift
@@ -164,7 +164,7 @@ class EthereumAccount_SignTypedTests: XCTestCase {
         let privateKey = "cow".web3.keccak256
         let address = "0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826"
         try! keyStorage.storePrivateKey(key: privateKey, with: .init(address))
-        account = try! EthereumAccount(addressString: address, keyStorage: keyStorage)
+        account = EthereumAccount(address: .init(address), keyStorage: keyStorage)
     }
 
     func test_GivenExample_TypeHashIsCorrect() {

--- a/web3sTests/Account/EthereumAccount+SignTypedTests.swift
+++ b/web3sTests/Account/EthereumAccount+SignTypedTests.swift
@@ -161,8 +161,10 @@ class EthereumAccount_SignTypedTests: XCTestCase {
 
     override func setUp() {
         let keyStorage = EthereumKeyLocalStorage()
-        try! keyStorage.storePrivateKey(key: "cow".web3.keccak256)
-        account = try! EthereumAccount(keyStorage: keyStorage)
+        let privateKey = "cow".web3.keccak256
+        let address = "0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826"
+        try! keyStorage.storePrivateKey(key: privateKey, with: .init(address))
+        account = try! EthereumAccount(addressString: address, keyStorage: keyStorage)
     }
 
     func test_GivenExample_TypeHashIsCorrect() {

--- a/web3sTests/Account/EthereumAccount+SignTypedTests.swift
+++ b/web3sTests/Account/EthereumAccount+SignTypedTests.swift
@@ -159,11 +159,11 @@ class EthereumAccount_SignTypedTests: XCTestCase {
 
     let decoder = JSONDecoder()
 
-    override func setUp() {
+    override func setUp() async throws {
         let keyStorage = EthereumKeyLocalStorage()
         let privateKey = "cow".web3.keccak256
         let address = "0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826"
-        try! keyStorage.storePrivateKey(key: privateKey, with: .init(address))
+        try await keyStorage.storePrivateKey(key: privateKey, with: .init(address))
         account = EthereumAccount(address: .init(address), keyStorage: keyStorage)
     }
 
@@ -253,9 +253,9 @@ class EthereumAccount_SignTypedTests: XCTestCase {
 
     }
 
-    func test_givenExample_ItSignsCorrectly() {
+    func test_givenExample_ItSignsCorrectly() async {
         let typedData = try! decoder.decode(TypedData.self, from: example1)
-        let signed = try? account.signMessage(message: typedData)
+        let signed = try? await account.signMessage(message: typedData)
         XCTAssertEqual(signed, "0x4355c47d63924e8a72e509b65029052eb6c299d53a04e167c5775fd466751c9d07299936d304c153f6443dfa05f40ff007d72911b6f72307f996231605b915621c")
     }
 }

--- a/web3sTests/Account/EthereumAccountTests.swift
+++ b/web3sTests/Account/EthereumAccountTests.swift
@@ -16,7 +16,7 @@ class EthereumAccountTests: XCTestCase {
     }
     
     func testLoadAccountAndAddress() {
-        let account = try! EthereumAccount(keyStorage: TestEthereumKeyStorage(privateKey: TestConfig.privateKey))
+        let account = try! EthereumAccount(addressString: TestConfig.publicKey, keyStorage: TestEthereumKeyStorage(privateKey: TestConfig.privateKey))
         XCTAssertEqual(account.address.value.lowercased(), TestConfig.publicKey.lowercased(), "Failed to load private key. Ensure key is valid in TestConfig.swift")
     }
 
@@ -69,7 +69,9 @@ class EthereumAccountTests: XCTestCase {
     }
     
     func testSignMessage() {
-        let account = try! EthereumAccount(keyStorage: TestEthereumKeyStorage(privateKey: "0x2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173"))
+        let privateKey = "0x2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173"
+        let address = "0x675f5810feb3b09528e5cd175061b4eb8de69075"
+        let account = try! EthereumAccount(addressString: address, keyStorage: TestEthereumKeyStorage(privateKey: privateKey))
         let signature = try! account.sign(message: "Hello message!")
 
         let expectedSignature = "7f89b86ee3ca79d32324b9c2ede02385b5a32ecd7c0caf5d7ceb0b34cf7c90697627d1cb3435c16bb72866273eb14bd9f387d74591382add29d4e39b8c11167300"
@@ -78,7 +80,9 @@ class EthereumAccountTests: XCTestCase {
     }
     
     func testSignData() {
-        let account = try! EthereumAccount(keyStorage: TestEthereumKeyStorage(privateKey: "0x2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173"))
+        let privateKey = "0x2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173"
+        let address = "0x675f5810feb3b09528e5cd175061b4eb8de69075"
+        let account = try! EthereumAccount(addressString: address, keyStorage: TestEthereumKeyStorage(privateKey: privateKey))
         let signature = try! account.sign(data: "Hello message!".data(using: .utf8)!)
 
         let expectedSignature = "7f89b86ee3ca79d32324b9c2ede02385b5a32ecd7c0caf5d7ceb0b34cf7c90697627d1cb3435c16bb72866273eb14bd9f387d74591382add29d4e39b8c11167300"
@@ -87,7 +91,9 @@ class EthereumAccountTests: XCTestCase {
     }
     
     func testSignHash() {
-        let account = try! EthereumAccount(keyStorage: TestEthereumKeyStorage(privateKey: "774681694ad86635346b6e9b92fa8aa4806265336dc6766623029a6264a162c1"))
+        let privateKey = "774681694ad86635346b6e9b92fa8aa4806265336dc6766623029a6264a162c1"
+        let address = "0x7e7cbf2e3f7611f860d41411a8287cc86cc789f3"
+        let account = try! EthereumAccount(addressString: address, keyStorage: TestEthereumKeyStorage(privateKey: privateKey))
         let signature = try! account.sign(hash: "0x9dd2c369a187b4e6b9c402f030e50743e619301ea62aa4c0737d4ef7e10a3d49")
 
         let expectedSignature = "16f89ddb9bf9ec08ff696bc766e675da7cfcb4f0b10bc8ce7c1a87a414a65a4f19c05c207e1b59f2e1cd18053cb8406fb7c6d22cec5e348d6217febbff8fc19801"
@@ -96,7 +102,9 @@ class EthereumAccountTests: XCTestCase {
     }
     
     func testSignHex() {
-        let account = try! EthereumAccount(keyStorage: TestEthereumKeyStorage(privateKey: "2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173"))
+        let privateKey = "2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173"
+        let address = "0x675f5810feb3b09528e5cd175061b4eb8de69075"
+        let account = try! EthereumAccount(addressString: address, keyStorage: TestEthereumKeyStorage(privateKey: privateKey))
         let signature = try! account.sign(hex: "0xe5808504a817c80082520894f59fc5a335e75060ff18beed2d6c8fbbbdab0dc2843b9aca0080")
 
         let expectedSignature = "8152ada8bece83905602d6b9a8a0f137dace41cd6a2da9d3fb26baa9fb79e2080e871937b634213a0e4cd7dee00c119567fa53096532e88ddf0fb183097bb4d701"
@@ -105,7 +113,9 @@ class EthereumAccountTests: XCTestCase {
     }
 
     func testSignTxHash() {
-        let account = try! EthereumAccount(keyStorage: TestEthereumKeyStorage(privateKey: "0x4646464646464646464646464646464646464646464646464646464646464646"))
+        let privateKey = "0x4646464646464646464646464646464646464646464646464646464646464646"
+        let address = "0x9d8a62f656a8d1615c1294fd71e9cfb3e4855a4f"
+        let account = try! EthereumAccount(addressString: address, keyStorage: TestEthereumKeyStorage(privateKey: privateKey))
         let signature = try! account.sign(hash: "0xdaf5a779ae972f972197303d7b574746c7ef83eadac0f2791ad23db92e4c8e53")
         let expectedSignature = "28ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa63627667cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d8300"
 

--- a/web3sTests/Account/EthereumAccountTests.swift
+++ b/web3sTests/Account/EthereumAccountTests.swift
@@ -16,13 +16,13 @@ class EthereumAccountTests: XCTestCase {
     }
     
     func testLoadAccountAndAddress() {
-        let account = try! EthereumAccount(addressString: TestConfig.publicKey, keyStorage: TestEthereumKeyStorage(privateKey: TestConfig.privateKey))
+        let account = EthereumAccount(address: .init(TestConfig.publicKey), keyStorage: TestEthereumKeyStorage(privateKey: TestConfig.privateKey))
         XCTAssertEqual(account.address.value.lowercased(), TestConfig.publicKey.lowercased(), "Failed to load private key. Ensure key is valid in TestConfig.swift")
     }
 
     func testLoadAccountAndAddressMultiple() {
         let storage = TestEthereumMultipleKeyStorage(privateKey: TestConfig.privateKey)
-        let account = try! EthereumAccount(addressString: TestConfig.publicKey, keyStorage: storage)
+        let account = EthereumAccount(address: .init(TestConfig.publicKey), keyStorage: storage)
         XCTAssertEqual(account.address.value.lowercased(), TestConfig.publicKey.lowercased(), "Failed to load private key. Ensure key is valid in TestConfig.swift")
     }
 
@@ -58,7 +58,7 @@ class EthereumAccountTests: XCTestCase {
     func testSignMessage() {
         let privateKey = "0x2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173"
         let address = "0x675f5810feb3b09528e5cd175061b4eb8de69075"
-        let account = try! EthereumAccount(addressString: address, keyStorage: TestEthereumKeyStorage(privateKey: privateKey))
+        let account = EthereumAccount(address: .init(address), keyStorage: TestEthereumKeyStorage(privateKey: privateKey))
         let signature = try! account.sign(message: "Hello message!")
 
         let expectedSignature = "7f89b86ee3ca79d32324b9c2ede02385b5a32ecd7c0caf5d7ceb0b34cf7c90697627d1cb3435c16bb72866273eb14bd9f387d74591382add29d4e39b8c11167300"
@@ -69,7 +69,7 @@ class EthereumAccountTests: XCTestCase {
     func testSignData() {
         let privateKey = "0x2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173"
         let address = "0x675f5810feb3b09528e5cd175061b4eb8de69075"
-        let account = try! EthereumAccount(addressString: address, keyStorage: TestEthereumKeyStorage(privateKey: privateKey))
+        let account = EthereumAccount(address: .init(address), keyStorage: TestEthereumKeyStorage(privateKey: privateKey))
         let signature = try! account.sign(data: "Hello message!".data(using: .utf8)!)
 
         let expectedSignature = "7f89b86ee3ca79d32324b9c2ede02385b5a32ecd7c0caf5d7ceb0b34cf7c90697627d1cb3435c16bb72866273eb14bd9f387d74591382add29d4e39b8c11167300"
@@ -80,7 +80,7 @@ class EthereumAccountTests: XCTestCase {
     func testSignHash() {
         let privateKey = "774681694ad86635346b6e9b92fa8aa4806265336dc6766623029a6264a162c1"
         let address = "0x7e7cbf2e3f7611f860d41411a8287cc86cc789f3"
-        let account = try! EthereumAccount(addressString: address, keyStorage: TestEthereumKeyStorage(privateKey: privateKey))
+        let account = EthereumAccount(address: .init(address), keyStorage: TestEthereumKeyStorage(privateKey: privateKey))
         let signature = try! account.sign(hash: "0x9dd2c369a187b4e6b9c402f030e50743e619301ea62aa4c0737d4ef7e10a3d49")
 
         let expectedSignature = "16f89ddb9bf9ec08ff696bc766e675da7cfcb4f0b10bc8ce7c1a87a414a65a4f19c05c207e1b59f2e1cd18053cb8406fb7c6d22cec5e348d6217febbff8fc19801"
@@ -91,7 +91,7 @@ class EthereumAccountTests: XCTestCase {
     func testSignHex() {
         let privateKey = "2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173"
         let address = "0x675f5810feb3b09528e5cd175061b4eb8de69075"
-        let account = try! EthereumAccount(addressString: address, keyStorage: TestEthereumKeyStorage(privateKey: privateKey))
+        let account = EthereumAccount(address: .init(address), keyStorage: TestEthereumKeyStorage(privateKey: privateKey))
         let signature = try! account.sign(hex: "0xe5808504a817c80082520894f59fc5a335e75060ff18beed2d6c8fbbbdab0dc2843b9aca0080")
 
         let expectedSignature = "8152ada8bece83905602d6b9a8a0f137dace41cd6a2da9d3fb26baa9fb79e2080e871937b634213a0e4cd7dee00c119567fa53096532e88ddf0fb183097bb4d701"
@@ -102,7 +102,7 @@ class EthereumAccountTests: XCTestCase {
     func testSignTxHash() {
         let privateKey = "0x4646464646464646464646464646464646464646464646464646464646464646"
         let address = "0x9d8a62f656a8d1615c1294fd71e9cfb3e4855a4f"
-        let account = try! EthereumAccount(addressString: address, keyStorage: TestEthereumKeyStorage(privateKey: privateKey))
+        let account = EthereumAccount(address: .init(address), keyStorage: TestEthereumKeyStorage(privateKey: privateKey))
         let signature = try! account.sign(hash: "0xdaf5a779ae972f972197303d7b574746c7ef83eadac0f2791ad23db92e4c8e53")
         let expectedSignature = "28ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa63627667cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d8300"
 

--- a/web3sTests/Account/EthereumAccountTests.swift
+++ b/web3sTests/Account/EthereumAccountTests.swift
@@ -26,84 +26,84 @@ class EthereumAccountTests: XCTestCase {
         XCTAssertEqual(account.address.value.lowercased(), TestConfig.publicKey.lowercased(), "Failed to load private key. Ensure key is valid in TestConfig.swift")
     }
 
-    func testCreateAccount() {
+    func testCreateAccount() async {
         let storage = EthereumKeyLocalStorage()
-        let account = try? EthereumAccount.create(settingTo: storage)
+        let account = try? await EthereumAccount.create(settingTo: storage)
         XCTAssertNotNil(account, "Failed to create account. Ensure key is valid in TestConfig.swift")
     }
 
-    func testImportAccount() {
+    func testImportAccount() async {
         let storage = EthereumKeyLocalStorage()
-        let account = try! EthereumAccount.importAccount(settingTo: storage, privateKey: "0x2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173")
+        let account = try! await EthereumAccount.importAccount(settingTo: storage, privateKey: "0x2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173")
 
         XCTAssertEqual(account.address.value, "0x675f5810feb3b09528e5cd175061b4eb8de69075")
     }
     
-    func testFetchAccounts() {
+    func testFetchAccounts() async {
         let storage = EthereumKeyLocalStorage()
-        let account = try! EthereumAccount.importAccount(settingTo: storage, privateKey: "0x2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173")
-        let accounts = try! storage.fetchAccounts()
+        let account = try! await EthereumAccount.importAccount(settingTo: storage, privateKey: "0x2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173")
+        let accounts = try! await storage.fetchAccounts()
         XCTAssertTrue(accounts.contains(account.address))
     }
     
-    func testDeleteAccount() {
+    func testDeleteAccount() async {
         let storage = EthereumKeyLocalStorage()
-        let account = try! EthereumAccount.importAccount(settingTo: storage, privateKey: "0x2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173")
+        let account = try! await EthereumAccount.importAccount(settingTo: storage, privateKey: "0x2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173")
         let ethereumAddress = EthereumAddress("0x675f5810feb3b09528e5cd175061b4eb8de69075")
-        try! storage.deletePrivateKey(for: ethereumAddress)
-        let accounts = try! storage.fetchAccounts()
+        try! await storage.deletePrivateKey(for: ethereumAddress)
+        let accounts = try! await storage.fetchAccounts()
         XCTAssertTrue(!accounts.contains(account.address))
     }
     
-    func testSignMessage() {
+    func testSignMessage() async {
         let privateKey = "0x2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173"
         let address = "0x675f5810feb3b09528e5cd175061b4eb8de69075"
         let account = EthereumAccount(address: .init(address), keyStorage: TestEthereumKeyStorage(privateKey: privateKey))
-        let signature = try! account.sign(message: "Hello message!")
+        let signature = try! await account.sign(message: "Hello message!")
 
         let expectedSignature = "7f89b86ee3ca79d32324b9c2ede02385b5a32ecd7c0caf5d7ceb0b34cf7c90697627d1cb3435c16bb72866273eb14bd9f387d74591382add29d4e39b8c11167300"
 
         XCTAssertEqual(signature.web3.hexString.web3.noHexPrefix, expectedSignature)
     }
     
-    func testSignData() {
+    func testSignData() async {
         let privateKey = "0x2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173"
         let address = "0x675f5810feb3b09528e5cd175061b4eb8de69075"
         let account = EthereumAccount(address: .init(address), keyStorage: TestEthereumKeyStorage(privateKey: privateKey))
-        let signature = try! account.sign(data: "Hello message!".data(using: .utf8)!)
+        let signature = try! await account.sign(data: "Hello message!".data(using: .utf8)!)
 
         let expectedSignature = "7f89b86ee3ca79d32324b9c2ede02385b5a32ecd7c0caf5d7ceb0b34cf7c90697627d1cb3435c16bb72866273eb14bd9f387d74591382add29d4e39b8c11167300"
 
         XCTAssertEqual(signature.web3.hexString.web3.noHexPrefix, expectedSignature)
     }
     
-    func testSignHash() {
+    func testSignHash() async {
         let privateKey = "774681694ad86635346b6e9b92fa8aa4806265336dc6766623029a6264a162c1"
         let address = "0x7e7cbf2e3f7611f860d41411a8287cc86cc789f3"
         let account = EthereumAccount(address: .init(address), keyStorage: TestEthereumKeyStorage(privateKey: privateKey))
-        let signature = try! account.sign(hash: "0x9dd2c369a187b4e6b9c402f030e50743e619301ea62aa4c0737d4ef7e10a3d49")
+        let signature = try! await account.sign(hash: "0x9dd2c369a187b4e6b9c402f030e50743e619301ea62aa4c0737d4ef7e10a3d49")
 
         let expectedSignature = "16f89ddb9bf9ec08ff696bc766e675da7cfcb4f0b10bc8ce7c1a87a414a65a4f19c05c207e1b59f2e1cd18053cb8406fb7c6d22cec5e348d6217febbff8fc19801"
 
         XCTAssertEqual(signature.web3.hexString.web3.noHexPrefix, expectedSignature)
     }
     
-    func testSignHex() {
+    func testSignHex() async {
         let privateKey = "2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173"
         let address = "0x675f5810feb3b09528e5cd175061b4eb8de69075"
         let account = EthereumAccount(address: .init(address), keyStorage: TestEthereumKeyStorage(privateKey: privateKey))
-        let signature = try! account.sign(hex: "0xe5808504a817c80082520894f59fc5a335e75060ff18beed2d6c8fbbbdab0dc2843b9aca0080")
+        let signature = try! await account.sign(hex: "0xe5808504a817c80082520894f59fc5a335e75060ff18beed2d6c8fbbbdab0dc2843b9aca0080")
 
         let expectedSignature = "8152ada8bece83905602d6b9a8a0f137dace41cd6a2da9d3fb26baa9fb79e2080e871937b634213a0e4cd7dee00c119567fa53096532e88ddf0fb183097bb4d701"
 
         XCTAssertEqual(signature.web3.hexString.web3.noHexPrefix, expectedSignature)
     }
 
-    func testSignTxHash() {
+    func testSignTxHash() async {
         let privateKey = "0x4646464646464646464646464646464646464646464646464646464646464646"
         let address = "0x9d8a62f656a8d1615c1294fd71e9cfb3e4855a4f"
         let account = EthereumAccount(address: .init(address), keyStorage: TestEthereumKeyStorage(privateKey: privateKey))
-        let signature = try! account.sign(hash: "0xdaf5a779ae972f972197303d7b574746c7ef83eadac0f2791ad23db92e4c8e53")
+        let signature = try! await account.sign(hash: "0xdaf5a779ae972f972197303d7b574746c7ef83eadac0f2791ad23db92e4c8e53")
         let expectedSignature = "28ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa63627667cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d8300"
 
         XCTAssertEqual(signature.web3.hexString.web3.noHexPrefix, expectedSignature)

--- a/web3sTests/Account/EthereumAccountTests.swift
+++ b/web3sTests/Account/EthereumAccountTests.swift
@@ -28,40 +28,27 @@ class EthereumAccountTests: XCTestCase {
 
     func testCreateAccount() {
         let storage = EthereumKeyLocalStorage()
-        let account = try? EthereumAccount.create(replacing: storage, keystorePassword: "PASSWORD")
-        XCTAssertNotNil(account, "Failed to create account. Ensure key is valid in TestConfig.swift")
-    }
-    
-    func testCreateAccountMultiple() {
-        let storage = EthereumKeyLocalStorage()
-        let account = try? EthereumAccount.create(addingTo: storage, keystorePassword: "PASSWORD")
+        let account = try? EthereumAccount.create(settingTo: storage)
         XCTAssertNotNil(account, "Failed to create account. Ensure key is valid in TestConfig.swift")
     }
 
     func testImportAccount() {
         let storage = EthereumKeyLocalStorage()
-        let account = try! EthereumAccount.importAccount(replacing: storage, privateKey: "0x2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173", keystorePassword: "PASSWORD")
-
-        XCTAssertEqual(account.address.value, "0x675f5810feb3b09528e5cd175061b4eb8de69075")
-    }
-    
-    func testImportAccountMultiple() {
-        let storage = EthereumKeyLocalStorage()
-        let account = try! EthereumAccount.importAccount(addingTo: storage, privateKey: "0x2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173", keystorePassword: "PASSWORD")
+        let account = try! EthereumAccount.importAccount(settingTo: storage, privateKey: "0x2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173")
 
         XCTAssertEqual(account.address.value, "0x675f5810feb3b09528e5cd175061b4eb8de69075")
     }
     
     func testFetchAccounts() {
         let storage = EthereumKeyLocalStorage()
-        let account = try! EthereumAccount.importAccount(addingTo: storage, privateKey: "0x2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173", keystorePassword: "PASSWORD")
+        let account = try! EthereumAccount.importAccount(settingTo: storage, privateKey: "0x2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173")
         let accounts = try! storage.fetchAccounts()
         XCTAssertTrue(accounts.contains(account.address))
     }
     
     func testDeleteAccount() {
         let storage = EthereumKeyLocalStorage()
-        let account = try! EthereumAccount.importAccount(addingTo: storage, privateKey: "0x2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173", keystorePassword: "PASSWORD")
+        let account = try! EthereumAccount.importAccount(settingTo: storage, privateKey: "0x2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173")
         let ethereumAddress = EthereumAddress("0x675f5810feb3b09528e5cd175061b4eb8de69075")
         try! storage.deletePrivateKey(for: ethereumAddress)
         let accounts = try! storage.fetchAccounts()

--- a/web3sTests/Account/EthereumCryptingStorageTests.swift
+++ b/web3sTests/Account/EthereumCryptingStorageTests.swift
@@ -11,13 +11,11 @@ final class EthereumCryptingStorageTests: XCTestCase {
     private let addressStub = EthereumAddress("0x675f5810feb3b09528e5cd175061b4eb8de69075")
     private let passwordStub = "PASSWORD"
     private var storageSpy = EthereumKeyStorageSpy()
-    private lazy var sut = EthereumCryptingStorage(backingStorage: storageSpy)
+    private lazy var sut = EthereumCryptingStorage(backingStorage: storageSpy, passwordProvider: { [unowned self] in passwordStub })
 
     func test_givenKeyAndAddressAndOTPPassword_whenStoreCalled_thenStoreDataCalled() throws {
         // given
-        let password = "PASSWORD"
         let key = try XCTUnwrap(Data(hex: "2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173"))
-        sut.setOneTimePassword(password)
 
         // when
         try sut.storePrivateKey(key: key, with: addressStub)
@@ -28,23 +26,8 @@ final class EthereumCryptingStorageTests: XCTestCase {
         XCTAssertNotEqual(storageSpy.storePrivateKeyRecordedData.first?.key, key)
     }
 
-    func test_givenKeyAndAddress_whenStoreCalled_thenThrowsError() throws {
-        // given
-        let key = try XCTUnwrap(Data(hex: "2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173"))
-
-        // when
-        // then
-        XCTAssertThrowsError(try sut.storePrivateKey(key: key, with: addressStub)) { error in
-            let error = error as?  EthereumCryptingStorage<EthereumKeyStorageSpy>.StorageError
-            XCTAssertNotNil(error)
-            XCTAssertEqual(error, .unableToGetDataBecauseOfPasswordNotFound)
-        }
-    }
-
     func test_givenKeyAndAddressAndOTPPassword_whenLoadCalled_thenLoadDataCalled() throws {
         // given
-        let password = "PASSWORD"
-        sut.setOneTimePassword(password)
         storageSpy.loadPrivateKeyReturnValue = try XCTUnwrap(Data(hex: "7b2261646472657373223a22307836373566353831306665623362303935323865356364313735303631623465623864653639303735222c2276657273696f6e223a332c2263727970746f223a7b2263697068657274657874223a2263616338396633333134653337313730623336313364313734616161366663353239303465386363326335393766663030306564383565376132306535333363222c22636970686572706172616d73223a7b226976223a223266653166356538323535666638356531373565663136636665313664376230227d2c226b6466223a2270626b646632222c226b6466706172616d73223a7b22707266223a22686d61632d736861323536222c2263223a3236323134342c22646b6c656e223a33322c2273616c74223a226437383630316335666634623434333733663761353536663862343735646233227d2c226d6163223a2230333736363237363436346536356333613366373064313661643164383232353230623762633735306238353463343439386132633163356166363563663133222c22636970686572223a226165732d3132382d637472227d7d"))
 
         // when
@@ -53,17 +36,6 @@ final class EthereumCryptingStorageTests: XCTestCase {
         // then
         XCTAssertEqual(storageSpy.loadPrivateKeyCallsCount, 1)
         XCTAssertEqual(storageSpy.loadPrivateKeyRecordedData.first, addressStub)
-    }
-
-    func test_givenKeyAndAddress_whenLoadCalled_thenThrowsError() throws {
-        // given
-        // when
-        // then
-        XCTAssertThrowsError(try sut.loadPrivateKey(for: addressStub)) { error in
-            let error = error as?  EthereumCryptingStorage<EthereumKeyStorageSpy>.StorageError
-            XCTAssertNotNil(error)
-            XCTAssertEqual(error, .unableToGetDataBecauseOfPasswordNotFound)
-        }
     }
 }
 

--- a/web3sTests/Account/EthereumCryptingStorageTests.swift
+++ b/web3sTests/Account/EthereumCryptingStorageTests.swift
@@ -37,6 +37,37 @@ final class EthereumCryptingStorageTests: XCTestCase {
         XCTAssertEqual(storageSpy.loadPrivateKeyCallsCount, 1)
         XCTAssertEqual(storageSpy.loadPrivateKeyRecordedData.first, addressStub)
     }
+
+    func test_whenDeleteAllKeysCalled_thenDeleteAllKeysCalled() throws {
+        // when
+        try sut.deleteAllKeys()
+
+        // then
+        XCTAssertEqual(storageSpy.deleteAllKeysCallsCount, 1)
+    }
+
+    func test_givenAddress_whenDeletePrivateKeyCalled_thenDeletePrivateKeyCalled() throws {
+        // given
+        // when
+        try sut.deletePrivateKey(for: addressStub)
+
+        // then
+        XCTAssertEqual(storageSpy.deletePrivateKeyCallsCount, 1)
+        XCTAssertEqual(storageSpy.deletePrivateKeyRecordedData.first, addressStub)
+    }
+
+    func test_givenAddresses_whenFetchAccountsCalled_thenReturnsExpectedAccounts() throws {
+        // given
+        let expected = [addressStub]
+        storageSpy.fetchAccountsReturnValue = expected
+
+        // when
+        let result = try sut.fetchAccounts()
+
+        // then
+        XCTAssertEqual(storageSpy.fetchAccountsCallsCount, 1)
+        XCTAssertEqual(result, expected)
+    }
 }
 
 extension EthereumCryptingStorageTests {

--- a/web3sTests/Account/EthereumCryptingStorageTests.swift
+++ b/web3sTests/Account/EthereumCryptingStorageTests.swift
@@ -11,7 +11,7 @@ final class EthereumCryptingStorageTests: XCTestCase {
     private let addressStub = EthereumAddress("0x675f5810feb3b09528e5cd175061b4eb8de69075")
     private let passwordStub = "PASSWORD"
     private var storageSpy = EthereumKeyStorageSpy()
-    private lazy var sut = EthereumCryptingStorage(backingStorage: storageSpy, passwordProvider: { [unowned self] in passwordStub })
+    private lazy var sut = EthereumCryptingStorage(backingStorage: storageSpy, passwordProvider: { [unowned self] _ in passwordStub })
 
     func test_givenKeyAndAddressAndOTPPassword_whenStoreCalled_thenStoreDataCalled() async throws {
         // given

--- a/web3sTests/Account/EthereumCryptingStorageTests.swift
+++ b/web3sTests/Account/EthereumCryptingStorageTests.swift
@@ -1,0 +1,76 @@
+//
+//  web3.swift
+//  Copyright © 2022 Argent Labs Limited. All rights reserved.
+//
+
+import XCTest
+@testable import web3
+
+final class EthereumCryptingStorageTests: XCTestCase {
+
+    private let addressStub = EthereumAddress("0x675f5810feb3b09528e5cd175061b4eb8de69075")
+    private let passwordStub = "PASSWORD"
+    private var storageSpy = EthereumKeyStorageSpy()
+    private lazy var sut = EthereumCryptingStorage(backingStorage: storageSpy)
+
+    func test_givenKeyAndAddressAndOTPPassword_whenStoreCalled_thenStoreDataCalled() throws {
+        // given
+        let password = "PASSWORD"
+        let key = try XCTUnwrap(Data(hex: "2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173"))
+        sut.setOneTimePassword(password)
+
+        // when
+        try sut.storePrivateKey(key: key, with: addressStub)
+
+        // then
+        XCTAssertEqual(storageSpy.storePrivateKeyCallsCount, 1)
+        XCTAssertEqual(storageSpy.storePrivateKeyRecordedData.first?.address, addressStub)
+        XCTAssertNotEqual(storageSpy.storePrivateKeyRecordedData.first?.key, key)
+    }
+
+    func test_givenKeyAndAddress_whenStoreCalled_thenThrowsError() throws {
+        // given
+        let key = try XCTUnwrap(Data(hex: "2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173"))
+
+        // when
+        // then
+        XCTAssertThrowsError(try sut.storePrivateKey(key: key, with: addressStub)) { error in
+            let error = error as?  EthereumCryptingStorage<EthereumKeyStorageSpy>.StorageError
+            XCTAssertNotNil(error)
+            XCTAssertEqual(error, .unableToGetDataBecauseOfPasswordNotFound)
+        }
+    }
+
+    func test_givenKeyAndAddressAndOTPPassword_whenLoadCalled_thenLoadDataCalled() throws {
+        // given
+        let password = "PASSWORD"
+        sut.setOneTimePassword(password)
+        storageSpy.loadPrivateKeyReturnValue = try XCTUnwrap(Data(hex: "7b2261646472657373223a22307836373566353831306665623362303935323865356364313735303631623465623864653639303735222c2276657273696f6e223a332c2263727970746f223a7b2263697068657274657874223a2263616338396633333134653337313730623336313364313734616161366663353239303465386363326335393766663030306564383565376132306535333363222c22636970686572706172616d73223a7b226976223a223266653166356538323535666638356531373565663136636665313664376230227d2c226b6466223a2270626b646632222c226b6466706172616d73223a7b22707266223a22686d61632d736861323536222c2263223a3236323134342c22646b6c656e223a33322c2273616c74223a226437383630316335666634623434333733663761353536663862343735646233227d2c226d6163223a2230333736363237363436346536356333613366373064313661643164383232353230623762633735306238353463343439386132633163356166363563663133222c22636970686572223a226165732d3132382d637472227d7d"))
+
+        // when
+        _ = try sut.loadPrivateKey(for: addressStub)
+
+        // then
+        XCTAssertEqual(storageSpy.loadPrivateKeyCallsCount, 1)
+        XCTAssertEqual(storageSpy.loadPrivateKeyRecordedData.first, addressStub)
+    }
+
+    func test_givenKeyAndAddress_whenLoadCalled_thenThrowsError() throws {
+        // given
+        // when
+        // then
+        XCTAssertThrowsError(try sut.loadPrivateKey(for: addressStub)) { error in
+            let error = error as?  EthereumCryptingStorage<EthereumKeyStorageSpy>.StorageError
+            XCTAssertNotNil(error)
+            XCTAssertEqual(error, .unableToGetDataBecauseOfPasswordNotFound)
+        }
+    }
+}
+
+extension EthereumCryptingStorageTests {
+
+    static func hexString(data: Data?) -> String? {
+        guard let data else { return nil }
+        return data.map { String(format: "%02x", $0) }.reduce("", +)
+    }
+}

--- a/web3sTests/Account/EthereumCryptingStorageTests.swift
+++ b/web3sTests/Account/EthereumCryptingStorageTests.swift
@@ -13,12 +13,12 @@ final class EthereumCryptingStorageTests: XCTestCase {
     private var storageSpy = EthereumKeyStorageSpy()
     private lazy var sut = EthereumCryptingStorage(backingStorage: storageSpy, passwordProvider: { [unowned self] in passwordStub })
 
-    func test_givenKeyAndAddressAndOTPPassword_whenStoreCalled_thenStoreDataCalled() throws {
+    func test_givenKeyAndAddressAndOTPPassword_whenStoreCalled_thenStoreDataCalled() async throws {
         // given
         let key = try XCTUnwrap(Data(hex: "2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173"))
 
         // when
-        try sut.storePrivateKey(key: key, with: addressStub)
+        try await sut.storePrivateKey(key: key, with: addressStub)
 
         // then
         XCTAssertEqual(storageSpy.storePrivateKeyCallsCount, 1)
@@ -26,43 +26,43 @@ final class EthereumCryptingStorageTests: XCTestCase {
         XCTAssertNotEqual(storageSpy.storePrivateKeyRecordedData.first?.key, key)
     }
 
-    func test_givenKeyAndAddressAndOTPPassword_whenLoadCalled_thenLoadDataCalled() throws {
+    func test_givenKeyAndAddressAndOTPPassword_whenLoadCalled_thenLoadDataCalled() async throws {
         // given
         storageSpy.loadPrivateKeyReturnValue = try XCTUnwrap(Data(hex: "7b2261646472657373223a22307836373566353831306665623362303935323865356364313735303631623465623864653639303735222c2276657273696f6e223a332c2263727970746f223a7b2263697068657274657874223a2263616338396633333134653337313730623336313364313734616161366663353239303465386363326335393766663030306564383565376132306535333363222c22636970686572706172616d73223a7b226976223a223266653166356538323535666638356531373565663136636665313664376230227d2c226b6466223a2270626b646632222c226b6466706172616d73223a7b22707266223a22686d61632d736861323536222c2263223a3236323134342c22646b6c656e223a33322c2273616c74223a226437383630316335666634623434333733663761353536663862343735646233227d2c226d6163223a2230333736363237363436346536356333613366373064313661643164383232353230623762633735306238353463343439386132633163356166363563663133222c22636970686572223a226165732d3132382d637472227d7d"))
 
         // when
-        _ = try sut.loadPrivateKey(for: addressStub)
+        _ = try await sut.loadPrivateKey(for: addressStub)
 
         // then
         XCTAssertEqual(storageSpy.loadPrivateKeyCallsCount, 1)
         XCTAssertEqual(storageSpy.loadPrivateKeyRecordedData.first, addressStub)
     }
 
-    func test_whenDeleteAllKeysCalled_thenDeleteAllKeysCalled() throws {
+    func test_whenDeleteAllKeysCalled_thenDeleteAllKeysCalled() async throws {
         // when
-        try sut.deleteAllKeys()
+        try await sut.deleteAllKeys()
 
         // then
         XCTAssertEqual(storageSpy.deleteAllKeysCallsCount, 1)
     }
 
-    func test_givenAddress_whenDeletePrivateKeyCalled_thenDeletePrivateKeyCalled() throws {
+    func test_givenAddress_whenDeletePrivateKeyCalled_thenDeletePrivateKeyCalled() async throws {
         // given
         // when
-        try sut.deletePrivateKey(for: addressStub)
+        try await sut.deletePrivateKey(for: addressStub)
 
         // then
         XCTAssertEqual(storageSpy.deletePrivateKeyCallsCount, 1)
         XCTAssertEqual(storageSpy.deletePrivateKeyRecordedData.first, addressStub)
     }
 
-    func test_givenAddresses_whenFetchAccountsCalled_thenReturnsExpectedAccounts() throws {
+    func test_givenAddresses_whenFetchAccountsCalled_thenReturnsExpectedAccounts() async throws {
         // given
         let expected = [addressStub]
         storageSpy.fetchAccountsReturnValue = expected
 
         // when
-        let result = try sut.fetchAccounts()
+        let result = try await sut.fetchAccounts()
 
         // then
         XCTAssertEqual(storageSpy.fetchAccountsCallsCount, 1)

--- a/web3sTests/Account/EthereumKeyStorageTests.swift
+++ b/web3sTests/Account/EthereumKeyStorageTests.swift
@@ -16,72 +16,72 @@ class EthereumKeyStorageTests: XCTestCase {
         super.tearDown()
     }
 
-    func testStoreLocalPrivateKey() {
+    func testStoreLocalPrivateKey() async {
         let randomData = Data.randomOfLength(256)!
         let keyStorage = EthereumKeyLocalStorage()
 
         do {
             let ethereumAddress = EthereumAddress(TestConfig.publicKey)
-            try keyStorage.storePrivateKey(key: randomData, with: ethereumAddress)
+            try await keyStorage.storePrivateKey(key: randomData, with: ethereumAddress)
         } catch {
             XCTFail("Failed to save private key. Ensure key is valid in TestConfig.swift")
         }
     }
 
-    func testStoreAndLoadLocalPrivateKey() {
+    func testStoreAndLoadLocalPrivateKey() async {
         let randomData = Data.randomOfLength(256)!
         let keyStorage = EthereumKeyLocalStorage()
         let ethereumAddress = EthereumAddress(TestConfig.publicKey)
         do {
-            try keyStorage.storePrivateKey(key: randomData, with: ethereumAddress)
-            let storedData = try keyStorage.loadPrivateKey(for: ethereumAddress)
+            try await keyStorage.storePrivateKey(key: randomData, with: ethereumAddress)
+            let storedData = try await keyStorage.loadPrivateKey(for: ethereumAddress)
             XCTAssertEqual(randomData, storedData)
         } catch {
             XCTFail("Failed to save private key. Ensure key is valid in TestConfig.swift")
         }
     }
     
-    func testEncryptAndStorePrivateKey() {
+    func testEncryptAndStorePrivateKey() async {
         let randomData = Data.randomOfLength(256)!
         let keyStorage = EthereumKeyLocalStorage() as EthereumKeyStorageProtocol
         let password = "myP4ssw0rD"
 
         do {
-            try keyStorage.encryptAndStorePrivateKey(key: randomData, keystorePassword: password)
+            try await keyStorage.encryptAndStorePrivateKey(key: randomData, keystorePassword: password)
             let publicKey = try KeyUtil.generatePublicKey(from: randomData)
             let address = KeyUtil.generateAddress(from: publicKey)
-            let decrypted = try keyStorage.loadAndDecryptPrivateKey(for: address, keystorePassword: password)
+            let decrypted = try await keyStorage.loadAndDecryptPrivateKey(for: address, keystorePassword: password)
             XCTAssertEqual(decrypted, randomData)
         } catch let error {
             XCTFail("Failed to encrypt and store private key with error: \(error)")
         }
     }
 
-    func testEncryptAndStorePrivateKeyMultiple() {
+    func testEncryptAndStorePrivateKeyMultiple() async {
         let randomData = Data.randomOfLength(256)!
         let keyStorage = EthereumKeyLocalStorage() as EthereumMultipleKeyStorageProtocol
         let password = "myP4ssw0rD"
 
         do {
             _ = KeyUtil.generateAddress(from: randomData)
-            try keyStorage.encryptAndStorePrivateKey(key: randomData, keystorePassword: password)
+            try await keyStorage.encryptAndStorePrivateKey(key: randomData, keystorePassword: password)
             let publicKey = try KeyUtil.generatePublicKey(from: randomData)
             let address = KeyUtil.generateAddress(from: publicKey)
-            let decrypted = try keyStorage.loadAndDecryptPrivateKey(for: address, keystorePassword: password)
+            let decrypted = try await keyStorage.loadAndDecryptPrivateKey(for: address, keystorePassword: password)
             XCTAssertEqual(decrypted, randomData)
         } catch let error {
             XCTFail("Failed to encrypt and store private key with error: \(error)")
         }
     }
     
-    func testDeleteAllPrivateKeys() {
+    func testDeleteAllPrivateKeys() async {
         let keyStorage = EthereumKeyLocalStorage()
         do {
-            _ = try EthereumAccount.create(settingTo: keyStorage)
-            _ = try EthereumAccount.create(settingTo: keyStorage)
-            _ = try EthereumAccount.create(settingTo: keyStorage)
-            try keyStorage.deleteAllKeys()
-            let countAfterDeleting = try keyStorage.fetchAccounts()
+            _ = try await EthereumAccount.create(settingTo: keyStorage)
+            _ = try await EthereumAccount.create(settingTo: keyStorage)
+            _ = try await EthereumAccount.create(settingTo: keyStorage)
+            try await keyStorage.deleteAllKeys()
+            let countAfterDeleting = try await keyStorage.fetchAccounts()
             XCTAssertEqual(countAfterDeleting.count, 0)
         } catch let error {
             XCTFail("Failed to delete all private keys: \(error)")

--- a/web3sTests/Account/EthereumKeyStorageTests.swift
+++ b/web3sTests/Account/EthereumKeyStorageTests.swift
@@ -77,9 +77,9 @@ class EthereumKeyStorageTests: XCTestCase {
     func testDeleteAllPrivateKeys() {
         let keyStorage = EthereumKeyLocalStorage()
         do {
-            _ = try EthereumAccount.create(addingTo: keyStorage, keystorePassword: "PASSWORD")
-            _ = try EthereumAccount.create(addingTo: keyStorage, keystorePassword: "PASSWORD")
-            _ = try EthereumAccount.create(addingTo: keyStorage, keystorePassword: "PASSWORD")
+            _ = try EthereumAccount.create(settingTo: keyStorage)
+            _ = try EthereumAccount.create(settingTo: keyStorage)
+            _ = try EthereumAccount.create(settingTo: keyStorage)
             try keyStorage.deleteAllKeys()
             let countAfterDeleting = try keyStorage.fetchAccounts()
             XCTAssertEqual(countAfterDeleting.count, 0)

--- a/web3sTests/Account/EthereumKeyStorageTests.swift
+++ b/web3sTests/Account/EthereumKeyStorageTests.swift
@@ -43,7 +43,7 @@ class EthereumKeyStorageTests: XCTestCase {
     
     func testEncryptAndStorePrivateKey() {
         let randomData = Data.randomOfLength(256)!
-        let keyStorage = EthereumKeyLocalStorage() as EthereumSingleKeyStorageProtocol
+        let keyStorage = EthereumKeyLocalStorage() as EthereumKeyStorageProtocol
         let password = "myP4ssw0rD"
 
         do {

--- a/web3sTests/Account/EthereumKeyStorageTests.swift
+++ b/web3sTests/Account/EthereumKeyStorageTests.swift
@@ -48,7 +48,9 @@ class EthereumKeyStorageTests: XCTestCase {
 
         do {
             try keyStorage.encryptAndStorePrivateKey(key: randomData, keystorePassword: password)
-            let decrypted = try keyStorage.loadAndDecryptPrivateKey(keystorePassword: password)
+            let publicKey = try KeyUtil.generatePublicKey(from: randomData)
+            let address = KeyUtil.generateAddress(from: publicKey)
+            let decrypted = try keyStorage.loadAndDecryptPrivateKey(for: address, keystorePassword: password)
             XCTAssertEqual(decrypted, randomData)
         } catch let error {
             XCTFail("Failed to encrypt and store private key with error: \(error)")

--- a/web3sTests/Client/EthereumClientTests.swift
+++ b/web3sTests/Client/EthereumClientTests.swift
@@ -36,7 +36,7 @@ class EthereumClientTests: XCTestCase {
     override func setUp() {
         super.setUp()
         client = EthereumHttpClient(url: URL(string: TestConfig.clientUrl)!)
-        account = try? EthereumAccount(keyStorage: TestEthereumKeyStorage(privateKey: TestConfig.privateKey))
+        account = try? EthereumAccount(addressString: TestConfig.publicKey, keyStorage: TestEthereumKeyStorage(privateKey: TestConfig.privateKey))
         print("Public address: \(account?.address.value ?? "NONE")")
     }
 

--- a/web3sTests/Client/EthereumClientTests.swift
+++ b/web3sTests/Client/EthereumClientTests.swift
@@ -36,7 +36,7 @@ class EthereumClientTests: XCTestCase {
     override func setUp() {
         super.setUp()
         client = EthereumHttpClient(url: URL(string: TestConfig.clientUrl)!)
-        account = try? EthereumAccount(addressString: TestConfig.publicKey, keyStorage: TestEthereumKeyStorage(privateKey: TestConfig.privateKey))
+        account = EthereumAccount(address: .init(TestConfig.publicKey), keyStorage: TestEthereumKeyStorage(privateKey: TestConfig.privateKey))
         print("Public address: \(account?.address.value ?? "NONE")")
     }
 

--- a/web3sTests/Mocks/EthereumKeyStorageSpy.swift
+++ b/web3sTests/Mocks/EthereumKeyStorageSpy.swift
@@ -1,0 +1,26 @@
+//
+//  web3.swift
+//  Copyright © 2022 Argent Labs Limited. All rights reserved.
+//
+
+import Foundation
+import web3
+
+class EthereumKeyStorageSpy: EthereumKeyStorageProtocol {
+
+    var storePrivateKeyCallsCount: Int { storePrivateKeyRecordedData.count }
+    private(set) var storePrivateKeyRecordedData = [(key: Data, address: EthereumAddress)]()
+
+    func storePrivateKey(key: Data, with address: EthereumAddress) throws {
+        storePrivateKeyRecordedData.append((key, address))
+    }
+
+    var loadPrivateKeyReturnValue = Data()
+    var loadPrivateKeyCallsCount: Int { loadPrivateKeyRecordedData.count }
+    private(set) var loadPrivateKeyRecordedData = [EthereumAddress]()
+
+    func loadPrivateKey(for address: EthereumAddress) throws -> Data {
+        loadPrivateKeyRecordedData.append(address)
+        return loadPrivateKeyReturnValue
+    }
+}

--- a/web3sTests/Mocks/EthereumKeyStorageSpy.swift
+++ b/web3sTests/Mocks/EthereumKeyStorageSpy.swift
@@ -6,7 +6,7 @@
 import Foundation
 import web3
 
-class EthereumKeyStorageSpy: EthereumKeyStorageProtocol {
+class EthereumKeyStorageSpy: EthereumMultipleKeyStorageProtocol {
 
     var storePrivateKeyCallsCount: Int { storePrivateKeyRecordedData.count }
     private(set) var storePrivateKeyRecordedData = [(key: Data, address: EthereumAddress)]()
@@ -22,5 +22,26 @@ class EthereumKeyStorageSpy: EthereumKeyStorageProtocol {
     func loadPrivateKey(for address: EthereumAddress) throws -> Data {
         loadPrivateKeyRecordedData.append(address)
         return loadPrivateKeyReturnValue
+    }
+
+    private(set) var deleteAllKeysCallsCount = 0
+
+    func deleteAllKeys() throws {
+        deleteAllKeysCallsCount += 1
+    }
+
+    var deletePrivateKeyCallsCount: Int { deletePrivateKeyRecordedData.count }
+    private(set) var deletePrivateKeyRecordedData = [EthereumAddress]()
+
+    func deletePrivateKey(for address: EthereumAddress) throws {
+        deletePrivateKeyRecordedData.append(address)
+    }
+
+    var fetchAccountsReturnValue = [EthereumAddress]()
+    private(set) var fetchAccountsCallsCount = 0
+
+    func fetchAccounts() throws -> [EthereumAddress] {
+        fetchAccountsCallsCount += 1
+        return fetchAccountsReturnValue
     }
 }

--- a/web3sTests/Mocks/TestEthereumKeyStorage.swift
+++ b/web3sTests/Mocks/TestEthereumKeyStorage.swift
@@ -6,7 +6,7 @@
 import Foundation
 @testable import web3
 
-class TestEthereumKeyStorage: EthereumSingleKeyStorageProtocol {
+class TestEthereumKeyStorage: EthereumKeyStorageProtocol {
     
     private var privateKey: String
 

--- a/web3sTests/Mocks/TestEthereumKeyStorage.swift
+++ b/web3sTests/Mocks/TestEthereumKeyStorage.swift
@@ -14,10 +14,10 @@ class TestEthereumKeyStorage: EthereumSingleKeyStorageProtocol {
         self.privateKey = privateKey
     }
 
-    func storePrivateKey(key: Data) throws {
+    func storePrivateKey(key: Data, with address: EthereumAddress) throws {
     }
 
-    func loadPrivateKey() throws -> Data {
+    func loadPrivateKey(for address: EthereumAddress) throws -> Data {
         return privateKey.web3.hexData!
     }
 }
@@ -28,13 +28,6 @@ class TestEthereumMultipleKeyStorage: EthereumMultipleKeyStorageProtocol {
     
     init(privateKey: String) {
         self.privateKey = privateKey
-    }
-    
-    func storePrivateKey(key: Data) throws -> Void {
-    }
-
-    func loadPrivateKey() throws -> Data {
-        return privateKey.web3.hexData!
     }
     
     func fetchAccounts() throws -> [EthereumAddress] {

--- a/web3sTests/OffchainLookup/OffchainLookupTests.swift
+++ b/web3sTests/OffchainLookup/OffchainLookupTests.swift
@@ -146,7 +146,7 @@ class OffchainLookupTests: XCTestCase {
     override func setUp() {
         super.setUp()
         client = EthereumHttpClient(url: URL(string: TestConfig.clientUrl)!)
-        account = try? EthereumAccount(addressString: TestConfig.publicKey, keyStorage: TestEthereumKeyStorage(privateKey: TestConfig.privateKey))
+        account = EthereumAccount(address: .init(TestConfig.publicKey), keyStorage: TestEthereumKeyStorage(privateKey: TestConfig.privateKey))
         print("Public address: \(account?.address.value ?? "NONE")")
     }
 

--- a/web3sTests/OffchainLookup/OffchainLookupTests.swift
+++ b/web3sTests/OffchainLookup/OffchainLookupTests.swift
@@ -146,7 +146,7 @@ class OffchainLookupTests: XCTestCase {
     override func setUp() {
         super.setUp()
         client = EthereumHttpClient(url: URL(string: TestConfig.clientUrl)!)
-        account = try? EthereumAccount(keyStorage: TestEthereumKeyStorage(privateKey: TestConfig.privateKey))
+        account = try? EthereumAccount(addressString: TestConfig.publicKey, keyStorage: TestEthereumKeyStorage(privateKey: TestConfig.privateKey))
         print("Public address: \(account?.address.value ?? "NONE")")
     }
 

--- a/web3sTests/SIWE/SIWETests.swift
+++ b/web3sTests/SIWE/SIWETests.swift
@@ -20,7 +20,9 @@ class SIWETests: XCTestCase {
     }
 
     func testEndToEnd() async {
-        let account = try! EthereumAccount.init(keyStorage: TestEthereumKeyStorage(privateKey: "0x4646464646464646464646464646464646464646464646464646464646464646"))
+        let privateKey = "0x4646464646464646464646464646464646464646464646464646464646464646"
+        let address = "0x9d8a62f656a8d1615c1294fd71e9cfb3e4855a4f"
+        let account = try! EthereumAccount.init(addressString: address, keyStorage: TestEthereumKeyStorage(privateKey: privateKey))
         let message = try! SiweMessage(
             """
             login.xyz wants you to sign in with your Ethereum account:

--- a/web3sTests/SIWE/SIWETests.swift
+++ b/web3sTests/SIWE/SIWETests.swift
@@ -45,7 +45,12 @@ class SIWETests: XCTestCase {
         )
 
         var signature: String = ""
-        XCTAssertNoThrow(signature = try account.signSIWERequest(message))
+        do {
+            signature = try await account.signSIWERequest(message)
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+
         var isValid = false
         do {
             isValid = try await verifier.verify(message: message, against: signature)

--- a/web3sTests/SIWE/SIWETests.swift
+++ b/web3sTests/SIWE/SIWETests.swift
@@ -22,7 +22,7 @@ class SIWETests: XCTestCase {
     func testEndToEnd() async {
         let privateKey = "0x4646464646464646464646464646464646464646464646464646464646464646"
         let address = "0x9d8a62f656a8d1615c1294fd71e9cfb3e4855a4f"
-        let account = try! EthereumAccount.init(addressString: address, keyStorage: TestEthereumKeyStorage(privateKey: privateKey))
+        let account = EthereumAccount(address: .init(address), keyStorage: TestEthereumKeyStorage(privateKey: privateKey))
         let message = try! SiweMessage(
             """
             login.xyz wants you to sign in with your Ethereum account:

--- a/web3sTests/Utils/KeyUtilTests.swift
+++ b/web3sTests/Utils/KeyUtilTests.swift
@@ -60,7 +60,7 @@ class KeyUtilTests: XCTestCase {
     }
     
     func testRecoverPublicKeyMultiple() {
-        let storage = TestEthereumMultipleKeyStorage(privateKey: "0x2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173")
+        let storage = TestEthereumMultipleKeyStorage(privateKey: TestConfig.privateKey)
         let account = EthereumAccount(address: .init(TestConfig.publicKey), keyStorage: storage)
         let signature = try! account.sign(message: "Hello message!")
 

--- a/web3sTests/Utils/KeyUtilTests.swift
+++ b/web3sTests/Utils/KeyUtilTests.swift
@@ -48,21 +48,21 @@ class KeyUtilTests: XCTestCase {
         XCTAssertEqual(address.value, "0x751e735a83a8142c1b9dc722ef559b898f1d77fa")
     }
     
-    func testRecoverPublicKey() {
+    func testRecoverPublicKey() async {
         let privateKey = "0x2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173"
         let address = "0x675f5810feb3b09528e5cd175061b4eb8de69075"
         let account = EthereumAccount(address: .init(address), keyStorage: TestEthereumKeyStorage(privateKey: privateKey))
-        let signature = try! account.sign(message: "Hello message!")
+        let signature = try! await account.sign(message: "Hello message!")
 
         let recoveredAddress = try! KeyUtil.recoverPublicKey(message: "Hello message!".web3.keccak256, signature: signature)
 
         XCTAssertEqual(recoveredAddress, account.address.value.lowercased())
     }
     
-    func testRecoverPublicKeyMultiple() {
+    func testRecoverPublicKeyMultiple() async {
         let storage = TestEthereumMultipleKeyStorage(privateKey: TestConfig.privateKey)
         let account = EthereumAccount(address: .init(TestConfig.publicKey), keyStorage: storage)
-        let signature = try! account.sign(message: "Hello message!")
+        let signature = try! await account.sign(message: "Hello message!")
 
         let address = try! KeyUtil.recoverPublicKey(message: "Hello message!".web3.keccak256, signature: signature)
 

--- a/web3sTests/Utils/KeyUtilTests.swift
+++ b/web3sTests/Utils/KeyUtilTests.swift
@@ -49,12 +49,14 @@ class KeyUtilTests: XCTestCase {
     }
     
     func testRecoverPublicKey() {
-        let account = try! EthereumAccount(keyStorage: TestEthereumKeyStorage(privateKey: "0x2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173"))
+        let privateKey = "0x2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173"
+        let address = "0x675f5810feb3b09528e5cd175061b4eb8de69075"
+        let account = try! EthereumAccount(addressString: address, keyStorage: TestEthereumKeyStorage(privateKey: privateKey))
         let signature = try! account.sign(message: "Hello message!")
 
-        let address = try! KeyUtil.recoverPublicKey(message: "Hello message!".web3.keccak256, signature: signature)
+        let recoveredAddress = try! KeyUtil.recoverPublicKey(message: "Hello message!".web3.keccak256, signature: signature)
 
-        XCTAssertEqual(address, account.address.value.lowercased())
+        XCTAssertEqual(recoveredAddress, account.address.value.lowercased())
     }
     
     func testRecoverPublicKeyMultiple() {

--- a/web3sTests/Utils/KeyUtilTests.swift
+++ b/web3sTests/Utils/KeyUtilTests.swift
@@ -51,7 +51,7 @@ class KeyUtilTests: XCTestCase {
     func testRecoverPublicKey() {
         let privateKey = "0x2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173"
         let address = "0x675f5810feb3b09528e5cd175061b4eb8de69075"
-        let account = try! EthereumAccount(addressString: address, keyStorage: TestEthereumKeyStorage(privateKey: privateKey))
+        let account = EthereumAccount(address: .init(address), keyStorage: TestEthereumKeyStorage(privateKey: privateKey))
         let signature = try! account.sign(message: "Hello message!")
 
         let recoveredAddress = try! KeyUtil.recoverPublicKey(message: "Hello message!".web3.keccak256, signature: signature)
@@ -61,7 +61,7 @@ class KeyUtilTests: XCTestCase {
     
     func testRecoverPublicKeyMultiple() {
         let storage = TestEthereumMultipleKeyStorage(privateKey: "0x2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173")
-        let account = try! EthereumAccount(addressString: TestConfig.publicKey, keyStorage: storage)
+        let account = EthereumAccount(address: .init(TestConfig.publicKey), keyStorage: storage)
         let signature = try! account.sign(message: "Hello message!")
 
         let address = try! KeyUtil.recoverPublicKey(message: "Hello message!".web3.keccak256, signature: signature)

--- a/web3swift/src/Account/EthereumAccount+SignTransaction.swift
+++ b/web3swift/src/Account/EthereumAccount+SignTransaction.swift
@@ -11,20 +11,20 @@ enum EthereumSignerError: Error {
 }
 
 public extension EthereumAccount {
-    func signRaw(_ transaction: EthereumTransaction) throws -> Data {
-        let signed: SignedTransaction = try sign(transaction: transaction)
+    func signRaw(_ transaction: EthereumTransaction) async throws -> Data {
+        let signed: SignedTransaction = try await sign(transaction: transaction)
         guard let raw = signed.raw else {
             throw EthereumSignerError.unknownError
         }
         return raw
     }
 
-    func sign(transaction: EthereumTransaction) throws -> SignedTransaction {
+    func sign(transaction: EthereumTransaction) async throws -> SignedTransaction {
         guard let raw = transaction.raw else {
             throw EthereumSignerError.emptyRawTransaction
         }
 
-        guard let signature = try? sign(data: raw) else {
+        guard let signature = try? await sign(data: raw) else {
             throw EthereumSignerError.unknownError
         }
 

--- a/web3swift/src/Account/EthereumAccount.swift
+++ b/web3swift/src/Account/EthereumAccount.swift
@@ -26,7 +26,6 @@ public enum EthereumAccountError: Error {
 
 public class EthereumAccount: EthereumAccountProtocol {
     private let privateKeyData: Data
-    private let publicKeyData: Data
     private let logger: Logger
 
     public let publicKey: String
@@ -38,7 +37,7 @@ public class EthereumAccount: EthereumAccountProtocol {
             let address = EthereumAddress(addressString)
             let decodedKey = try keyStorage.loadAndDecryptPrivateKey(for: address, keystorePassword: password)
             self.privateKeyData = decodedKey
-            self.publicKeyData = try KeyUtil.generatePublicKey(from: decodedKey)
+            let publicKeyData = try KeyUtil.generatePublicKey(from: decodedKey)
             self.publicKey = publicKeyData.web3.hexString
             self.address = KeyUtil.generateAddress(from: publicKeyData)
         } catch {
@@ -53,7 +52,7 @@ public class EthereumAccount: EthereumAccountProtocol {
             let address = EthereumAddress(addressString)
             let data = try keyStorage.loadPrivateKey(for: address)
             self.privateKeyData = data
-            self.publicKeyData = try KeyUtil.generatePublicKey(from: data)
+            let publicKeyData = try KeyUtil.generatePublicKey(from: data)
             self.publicKey = publicKeyData.web3.hexString
             self.address = KeyUtil.generateAddress(from: publicKeyData)
         } catch {
@@ -67,7 +66,7 @@ public class EthereumAccount: EthereumAccountProtocol {
             let address = EthereumAddress(addressString)
             let decodedKey = try keyStorage.loadAndDecryptPrivateKey(for: address, keystorePassword: password)
             self.privateKeyData = decodedKey
-            self.publicKeyData = try KeyUtil.generatePublicKey(from: decodedKey)
+            let publicKeyData = try KeyUtil.generatePublicKey(from: decodedKey)
             self.publicKey = publicKeyData.web3.hexString
             self.address = KeyUtil.generateAddress(from: publicKeyData)
         } catch {
@@ -82,7 +81,7 @@ public class EthereumAccount: EthereumAccountProtocol {
             let address = EthereumAddress(addressString)
             let data = try keyStorage.loadPrivateKey(for: address)
             self.privateKeyData = data
-            self.publicKeyData = try KeyUtil.generatePublicKey(from: data)
+            let publicKeyData = try KeyUtil.generatePublicKey(from: data)
             self.publicKey = publicKeyData.web3.hexString
             self.address = KeyUtil.generateAddress(from: publicKeyData)
         } catch {

--- a/web3swift/src/Account/EthereumAccount.swift
+++ b/web3swift/src/Account/EthereumAccount.swift
@@ -32,7 +32,7 @@ public class EthereumAccount: EthereumAccountProtocol {
     public let publicKey: String
     public let address: EthereumAddress
 
-    required public init(addressString: String, keyStorage: EthereumSingleKeyStorageProtocol, keystorePassword password: String, logger: Logger? = nil) throws {
+    required public init(addressString: String, keyStorage: EthereumKeyStorageProtocol, keystorePassword password: String, logger: Logger? = nil) throws {
         self.logger = logger ?? Logger(label: "web3.swift.eth-account")
         do {
             let address = EthereumAddress(addressString)
@@ -47,7 +47,7 @@ public class EthereumAccount: EthereumAccountProtocol {
         }
     }
 
-    required public init(addressString: String, keyStorage: EthereumSingleKeyStorageProtocol, logger: Logger? = nil) throws {
+    required public init(addressString: String, keyStorage: EthereumKeyStorageProtocol, logger: Logger? = nil) throws {
         self.logger = logger ?? Logger(label: "web3.swift.eth-account")
         do {
             let address = EthereumAddress(addressString)
@@ -105,7 +105,7 @@ public class EthereumAccount: EthereumAccountProtocol {
         }
     }
 
-    public static func create(replacing keyStorage: EthereumSingleKeyStorageProtocol, keystorePassword password: String) throws -> EthereumAccount {
+    public static func create(replacing keyStorage: EthereumKeyStorageProtocol, keystorePassword password: String) throws -> EthereumAccount {
         guard let privateKey = KeyUtil.generatePrivateKeyData() else {
             throw EthereumAccountError.createAccountError
         }
@@ -134,7 +134,7 @@ public class EthereumAccount: EthereumAccountProtocol {
         }
     }
 
-    public static func importAccount(replacing keyStorage: EthereumSingleKeyStorageProtocol, privateKey: String, keystorePassword password: String) throws -> EthereumAccount {
+    public static func importAccount(replacing keyStorage: EthereumKeyStorageProtocol, privateKey: String, keystorePassword password: String) throws -> EthereumAccount {
         guard let privateKey = privateKey.web3.hexData else {
             throw EthereumAccountError.importAccountError
         }

--- a/web3swift/src/Account/EthereumAccount.swift
+++ b/web3swift/src/Account/EthereumAccount.swift
@@ -31,18 +31,11 @@ public class EthereumAccount: EthereumAccountProtocol {
     public let publicKey: String
     public let address: EthereumAddress
 
-    required public init(addressString: String, keyStorage: EthereumKeyStorageProtocol, logger: Logger? = nil) throws {
+    required public init(address: EthereumAddress, keyStorage: EthereumKeyStorageProtocol, logger: Logger? = nil) {
         self.keyStorage = keyStorage
         self.logger = logger ?? Logger(label: "web3.swift.eth-account")
-        do {
-            let address = EthereumAddress(addressString)
-            let data = try keyStorage.loadPrivateKey(for: address)
-            let publicKeyData = try KeyUtil.generatePublicKey(from: data)
-            self.publicKey = publicKeyData.web3.hexString
-            self.address = KeyUtil.generateAddress(from: publicKeyData)
-        } catch {
-            throw EthereumAccountError.loadAccountError
-        }
+        self.address = address
+        self.publicKey = address.value.web3.withHexPrefix
     }
 
     public static func create(settingTo keyStorage: EthereumKeyStorageProtocol) throws -> EthereumAccount {
@@ -54,7 +47,7 @@ public class EthereumAccount: EthereumAccountProtocol {
             let publicKey = try KeyUtil.generatePublicKey(from: privateKey)
             let address = KeyUtil.generateAddress(from: publicKey)
             try keyStorage.storePrivateKey(key: privateKey, with: address)
-            return try self.init(addressString: address.value, keyStorage: keyStorage)
+            return self.init(address: address, keyStorage: keyStorage)
         } catch {
             throw EthereumAccountError.createAccountError
         }
@@ -68,7 +61,7 @@ public class EthereumAccount: EthereumAccountProtocol {
             let publicKey = try KeyUtil.generatePublicKey(from: privateKey)
             let address = KeyUtil.generateAddress(from: publicKey)
             try keyStorage.storePrivateKey(key: privateKey, with: address)
-            return try self.init(addressString: address.value, keyStorage: keyStorage)
+            return self.init(address: address, keyStorage: keyStorage)
         } catch {
             throw EthereumAccountError.importAccountError
         }

--- a/web3swift/src/Account/EthereumAccount.swift
+++ b/web3swift/src/Account/EthereumAccount.swift
@@ -29,9 +29,8 @@ public class EthereumAccount: EthereumAccountProtocol {
     private let publicKeyData: Data
     private let logger: Logger
 
-    public lazy var publicKey: String = self.publicKeyData.web3.hexString
-
-    public lazy var address: EthereumAddress = KeyUtil.generateAddress(from: self.publicKeyData)
+    public let publicKey: String
+    public let address: EthereumAddress
 
     required public init(keyStorage: EthereumSingleKeyStorageProtocol, keystorePassword password: String, logger: Logger? = nil) throws {
         self.logger = logger ?? Logger(label: "web3.swift.eth-account")
@@ -39,6 +38,8 @@ public class EthereumAccount: EthereumAccountProtocol {
             let decodedKey = try keyStorage.loadAndDecryptPrivateKey(keystorePassword: password)
             self.privateKeyData = decodedKey
             self.publicKeyData = try KeyUtil.generatePublicKey(from: decodedKey)
+            self.publicKey = publicKeyData.web3.hexString
+            self.address = KeyUtil.generateAddress(from: publicKeyData)
         } catch {
             self.logger.warning("Error loading key data: \(error)")
             throw EthereumAccountError.loadAccountError
@@ -51,6 +52,8 @@ public class EthereumAccount: EthereumAccountProtocol {
             let data = try keyStorage.loadPrivateKey()
             self.privateKeyData = data
             self.publicKeyData = try KeyUtil.generatePublicKey(from: data)
+            self.publicKey = publicKeyData.web3.hexString
+            self.address = KeyUtil.generateAddress(from: publicKeyData)
         } catch {
             throw EthereumAccountError.loadAccountError
         }
@@ -63,6 +66,8 @@ public class EthereumAccount: EthereumAccountProtocol {
             let decodedKey = try keyStorage.loadAndDecryptPrivateKey(for: address, keystorePassword: password)
             self.privateKeyData = decodedKey
             self.publicKeyData = try KeyUtil.generatePublicKey(from: decodedKey)
+            self.publicKey = publicKeyData.web3.hexString
+            self.address = KeyUtil.generateAddress(from: publicKeyData)
         } catch {
             self.logger.warning("Error loading key data: \(error)")
             throw EthereumAccountError.loadAccountError
@@ -76,6 +81,8 @@ public class EthereumAccount: EthereumAccountProtocol {
             let data = try keyStorage.loadPrivateKey(for: address)
             self.privateKeyData = data
             self.publicKeyData = try KeyUtil.generatePublicKey(from: data)
+            self.publicKey = publicKeyData.web3.hexString
+            self.address = KeyUtil.generateAddress(from: publicKeyData)
         } catch {
             throw EthereumAccountError.loadAccountError
         }

--- a/web3swift/src/Account/EthereumCryptingStorage.swift
+++ b/web3swift/src/Account/EthereumCryptingStorage.swift
@@ -1,0 +1,53 @@
+//
+//  web3.swift
+//  Copyright © 2022 Argent Labs Limited. All rights reserved.
+//
+
+import Foundation
+
+public class EthereumCryptingStorage<Wrapped>: EthereumKeyStorageProtocol where Wrapped: EthereumKeyStorageProtocol {
+
+    private let backingStorage: Wrapped
+    private var password: String?
+
+    public init(backingStorage: Wrapped) {
+        self.backingStorage = backingStorage
+    }
+
+    public func setOneTimePassword(_ password: String) {
+        self.password = password
+    }
+
+    public func storePrivateKey(key: Data, with address: EthereumAddress) throws {
+        guard let password else { throw StorageError.unableToGetDataBecauseOfPasswordNotFound }
+        defer { self.password = nil }
+        try backingStorage.encryptAndStorePrivateKey(key: key, keystorePassword: password)
+    }
+
+    public func loadPrivateKey(for address: EthereumAddress) throws -> Data {
+        guard let password else { throw StorageError.unableToGetDataBecauseOfPasswordNotFound }
+        defer { self.password = nil }
+        return try backingStorage.loadAndDecryptPrivateKey(for: address, keystorePassword: password)
+    }
+}
+
+extension EthereumCryptingStorage: EthereumMultipleKeyStorageProtocol where Wrapped: EthereumMultipleKeyStorageProtocol {
+    public func deleteAllKeys() throws {
+        try backingStorage.deleteAllKeys()
+    }
+
+    public func deletePrivateKey(for address: EthereumAddress) throws {
+        try backingStorage.deletePrivateKey(for: address)
+    }
+
+    public func fetchAccounts() throws -> [EthereumAddress] {
+        try backingStorage.fetchAccounts()
+    }
+}
+
+extension EthereumCryptingStorage {
+
+    public enum StorageError: Error {
+        case unableToGetDataBecauseOfPasswordNotFound
+    }
+}

--- a/web3swift/src/Account/EthereumCryptingStorage.swift
+++ b/web3swift/src/Account/EthereumCryptingStorage.swift
@@ -17,26 +17,26 @@ public class EthereumCryptingStorage<Wrapped>: EthereumKeyStorageProtocol where 
         self.passwordProvider = passwordProvider
     }
 
-    public func storePrivateKey(key: Data, with address: EthereumAddress) throws {
-        try backingStorage.encryptAndStorePrivateKey(key: key, keystorePassword: passwordProvider())
+    public func storePrivateKey(key: Data, with address: EthereumAddress) async throws {
+        try await backingStorage.encryptAndStorePrivateKey(key: key, keystorePassword: passwordProvider())
     }
 
-    public func loadPrivateKey(for address: EthereumAddress) throws -> Data {
-        try backingStorage.loadAndDecryptPrivateKey(for: address, keystorePassword: passwordProvider())
+    public func loadPrivateKey(for address: EthereumAddress) async throws -> Data {
+        try await backingStorage.loadAndDecryptPrivateKey(for: address, keystorePassword: passwordProvider())
     }
 }
 
 extension EthereumCryptingStorage: EthereumMultipleKeyStorageProtocol where Wrapped: EthereumMultipleKeyStorageProtocol {
-    public func deleteAllKeys() throws {
-        try backingStorage.deleteAllKeys()
+    public func deleteAllKeys() async throws {
+        try await backingStorage.deleteAllKeys()
     }
 
-    public func deletePrivateKey(for address: EthereumAddress) throws {
-        try backingStorage.deletePrivateKey(for: address)
+    public func deletePrivateKey(for address: EthereumAddress) async throws {
+        try await backingStorage.deletePrivateKey(for: address)
     }
 
-    public func fetchAccounts() throws -> [EthereumAddress] {
-        try backingStorage.fetchAccounts()
+    public func fetchAccounts() async throws -> [EthereumAddress] {
+        try await backingStorage.fetchAccounts()
     }
 }
 

--- a/web3swift/src/Account/EthereumCryptingStorage.swift
+++ b/web3swift/src/Account/EthereumCryptingStorage.swift
@@ -7,7 +7,7 @@ import Foundation
 
 public class EthereumCryptingStorage<Wrapped>: EthereumKeyStorageProtocol where Wrapped: EthereumKeyStorageProtocol {
 
-    public typealias PasswordProvider = () -> String
+    public typealias PasswordProvider = (_ address: EthereumAddress) async throws -> String
 
     private let backingStorage: Wrapped
     private var passwordProvider: PasswordProvider
@@ -18,11 +18,13 @@ public class EthereumCryptingStorage<Wrapped>: EthereumKeyStorageProtocol where 
     }
 
     public func storePrivateKey(key: Data, with address: EthereumAddress) async throws {
-        try await backingStorage.encryptAndStorePrivateKey(key: key, keystorePassword: passwordProvider())
+        let password = try await passwordProvider(address)
+        try await backingStorage.encryptAndStorePrivateKey(key: key, keystorePassword: password)
     }
 
     public func loadPrivateKey(for address: EthereumAddress) async throws -> Data {
-        try await backingStorage.loadAndDecryptPrivateKey(for: address, keystorePassword: passwordProvider())
+        let password = try await passwordProvider(address)
+        return try await backingStorage.loadAndDecryptPrivateKey(for: address, keystorePassword: password)
     }
 }
 

--- a/web3swift/src/Account/EthereumKeyStorage+Password.swift
+++ b/web3swift/src/Account/EthereumKeyStorage+Password.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public extension EthereumSingleKeyStorageProtocol {
+public extension EthereumKeyStorageProtocol {
     func encryptAndStorePrivateKey(key: Data, keystorePassword: String) throws {
         let encodedKey = try KeystoreUtil.encode(privateKey: key, password: keystorePassword)
         let publicKey = try KeyUtil.generatePublicKey(from: key)

--- a/web3swift/src/Account/EthereumKeyStorage+Password.swift
+++ b/web3swift/src/Account/EthereumKeyStorage+Password.swift
@@ -8,18 +8,6 @@ import Foundation
 public extension EthereumSingleKeyStorageProtocol {
     func encryptAndStorePrivateKey(key: Data, keystorePassword: String) throws {
         let encodedKey = try KeystoreUtil.encode(privateKey: key, password: keystorePassword)
-        try storePrivateKey(key: encodedKey)
-    }
-
-    func loadAndDecryptPrivateKey(keystorePassword: String) throws -> Data {
-        let encryptedKey = try loadPrivateKey()
-        return try KeystoreUtil.decode(data: encryptedKey, password: keystorePassword)
-    }
-}
-
-public extension EthereumMultipleKeyStorageProtocol {
-    func encryptAndStorePrivateKey(key: Data, keystorePassword: String) throws {
-        let encodedKey = try KeystoreUtil.encode(privateKey: key, password: keystorePassword)
         let publicKey = try KeyUtil.generatePublicKey(from: key)
         let address = KeyUtil.generateAddress(from: publicKey)
         try storePrivateKey(key: encodedKey, with: address)

--- a/web3swift/src/Account/EthereumKeyStorage+Password.swift
+++ b/web3swift/src/Account/EthereumKeyStorage+Password.swift
@@ -6,15 +6,15 @@
 import Foundation
 
 public extension EthereumKeyStorageProtocol {
-    func encryptAndStorePrivateKey(key: Data, keystorePassword: String) throws {
+    func encryptAndStorePrivateKey(key: Data, keystorePassword: String) async throws {
         let encodedKey = try KeystoreUtil.encode(privateKey: key, password: keystorePassword)
         let publicKey = try KeyUtil.generatePublicKey(from: key)
         let address = KeyUtil.generateAddress(from: publicKey)
-        try storePrivateKey(key: encodedKey, with: address)
+        try await storePrivateKey(key: encodedKey, with: address)
     }
 
-    func loadAndDecryptPrivateKey(for address: EthereumAddress, keystorePassword: String) throws -> Data {
-        let encryptedKey = try loadPrivateKey(for: address)
+    func loadAndDecryptPrivateKey(for address: EthereumAddress, keystorePassword: String) async throws -> Data {
+        let encryptedKey = try await loadPrivateKey(for: address)
         return try KeystoreUtil.decode(data: encryptedKey, password: keystorePassword)
     }
 }

--- a/web3swift/src/Account/EthereumKeyStorage.swift
+++ b/web3swift/src/Account/EthereumKeyStorage.swift
@@ -6,14 +6,14 @@
 import Foundation
 
 public protocol EthereumKeyStorageProtocol {
-    func storePrivateKey(key: Data, with address: EthereumAddress) throws
-    func loadPrivateKey(for address: EthereumAddress) throws -> Data
+    func storePrivateKey(key: Data, with address: EthereumAddress) async throws
+    func loadPrivateKey(for address: EthereumAddress) async throws -> Data
 }
 
 public protocol EthereumMultipleKeyStorageProtocol: EthereumKeyStorageProtocol {
-    func deleteAllKeys() throws
-    func deletePrivateKey(for address: EthereumAddress) throws
-    func fetchAccounts() throws -> [EthereumAddress]
+    func deleteAllKeys() async throws
+    func deletePrivateKey(for address: EthereumAddress) async throws
+    func fetchAccounts() async throws -> [EthereumAddress]
 }
 
 public enum EthereumKeyStorageError: Error {
@@ -55,7 +55,7 @@ public class EthereumKeyLocalStorage: EthereumKeyStorageProtocol {
 
     private let fileManager = FileManager.default
 
-    public func storePrivateKey(key: Data) throws {
+    public func storePrivateKey(key: Data) async throws {
         guard let localPath = localPath else {
             throw EthereumKeyStorageError.failedToSave
         }
@@ -67,7 +67,7 @@ public class EthereumKeyLocalStorage: EthereumKeyStorageProtocol {
         }
     }
 
-    public func loadPrivateKey() throws -> Data {
+    public func loadPrivateKey() async throws -> Data {
         guard let localPath = localPath else {
             throw EthereumKeyStorageError.failedToLoad
         }
@@ -81,7 +81,7 @@ public class EthereumKeyLocalStorage: EthereumKeyStorageProtocol {
 }
 
 extension EthereumKeyLocalStorage: EthereumMultipleKeyStorageProtocol {
-    public func fetchAccounts() throws -> [EthereumAddress] {
+    public func fetchAccounts() async throws -> [EthereumAddress] {
         guard let folderPath = folderPath else {
             throw EthereumKeyStorageError.failedToLoad
         }
@@ -99,7 +99,7 @@ extension EthereumKeyLocalStorage: EthereumMultipleKeyStorageProtocol {
         }
     }
 
-    public func storePrivateKey(key: Data, with address: EthereumAddress) throws {
+    public func storePrivateKey(key: Data, with address: EthereumAddress) async throws {
         self.address = address.value
 
         defer {
@@ -117,7 +117,7 @@ extension EthereumKeyLocalStorage: EthereumMultipleKeyStorageProtocol {
         }
     }
 
-    public func loadPrivateKey(for address: EthereumAddress) throws -> Data {
+    public func loadPrivateKey(for address: EthereumAddress) async throws -> Data {
         self.address = address.value
 
         defer {
@@ -135,13 +135,13 @@ extension EthereumKeyLocalStorage: EthereumMultipleKeyStorageProtocol {
         return data
     }
 
-    public func deleteAllKeys() throws {
+    public func deleteAllKeys() async throws {
         do {
             if let folderPath = folderPath {
                 let directoryContents = try fileManager.contentsOfDirectory(atPath: folderPath.path)
                 let addresses = directoryContents.filter({ $0.web3.isAddress || $0 == localFileName })
                 for address in addresses {
-                    try deletePrivateKey(for: EthereumAddress(address))
+                    try await deletePrivateKey(for: EthereumAddress(address))
                 }
             }
         } catch {
@@ -150,7 +150,7 @@ extension EthereumKeyLocalStorage: EthereumMultipleKeyStorageProtocol {
         }
     }
 
-    public func deletePrivateKey(for address: EthereumAddress) throws {
+    public func deletePrivateKey(for address: EthereumAddress) async throws {
         do {
             if let folderPath = folderPath {
                 let filePathName = folderPath.appendingPathComponent(address.value)

--- a/web3swift/src/Account/EthereumKeyStorage.swift
+++ b/web3swift/src/Account/EthereumKeyStorage.swift
@@ -6,16 +6,14 @@
 import Foundation
 
 public protocol EthereumSingleKeyStorageProtocol {
-    func storePrivateKey(key: Data) throws
-    func loadPrivateKey() throws -> Data
+    func storePrivateKey(key: Data, with address: EthereumAddress) throws
+    func loadPrivateKey(for address: EthereumAddress) throws -> Data
 }
 
-public protocol EthereumMultipleKeyStorageProtocol {
+public protocol EthereumMultipleKeyStorageProtocol: EthereumSingleKeyStorageProtocol {
     func deleteAllKeys() throws
     func deletePrivateKey(for address: EthereumAddress) throws
     func fetchAccounts() throws -> [EthereumAddress]
-    func loadPrivateKey(for address: EthereumAddress) throws -> Data
-    func storePrivateKey(key: Data, with address: EthereumAddress) throws
 }
 
 public enum EthereumKeyStorageError: Error {

--- a/web3swift/src/Account/EthereumKeyStorage.swift
+++ b/web3swift/src/Account/EthereumKeyStorage.swift
@@ -5,12 +5,12 @@
 
 import Foundation
 
-public protocol EthereumSingleKeyStorageProtocol {
+public protocol EthereumKeyStorageProtocol {
     func storePrivateKey(key: Data, with address: EthereumAddress) throws
     func loadPrivateKey(for address: EthereumAddress) throws -> Data
 }
 
-public protocol EthereumMultipleKeyStorageProtocol: EthereumSingleKeyStorageProtocol {
+public protocol EthereumMultipleKeyStorageProtocol: EthereumKeyStorageProtocol {
     func deleteAllKeys() throws
     func deletePrivateKey(for address: EthereumAddress) throws
     func fetchAccounts() throws -> [EthereumAddress]
@@ -23,7 +23,7 @@ public enum EthereumKeyStorageError: Error {
     case failedToDelete
 }
 
-public class EthereumKeyLocalStorage: EthereumSingleKeyStorageProtocol {
+public class EthereumKeyLocalStorage: EthereumKeyStorageProtocol {
     public init() {}
 
     private var address: String?

--- a/web3swift/src/Client/BaseEthereumClient.swift
+++ b/web3swift/src/Client/BaseEthereumClient.swift
@@ -190,7 +190,7 @@ public class BaseEthereumClient: EthereumClientProtocol {
                 transaction.chainId = network.intValue
             }
 
-            guard let _ = transaction.chainId, let signedTx = (try? account.sign(transaction: transaction)), let transactionHex = signedTx.raw?.web3.hexString else {
+            guard let _ = transaction.chainId, let signedTx = (try? await account.sign(transaction: transaction)), let transactionHex = signedTx.raw?.web3.hexString else {
                 throw EthereumClientError.encodeIssue
             }
 

--- a/web3swift/src/Client/Models/EthereumAddress.swift
+++ b/web3swift/src/Client/Models/EthereumAddress.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public struct EthereumAddress: Codable, Hashable {
+public struct EthereumAddress: Codable, Hashable, Sendable {
     public let value: String
     public static let zero: Self = "0x0000000000000000000000000000000000000000"
 

--- a/web3swift/src/SIWE/EthereumAccount+SignSIWERequest.swift
+++ b/web3swift/src/SIWE/EthereumAccount+SignSIWERequest.swift
@@ -6,15 +6,15 @@
 import Foundation
 
 extension EthereumAccount {
-    func signSIWERequest(_ message: String) throws -> String {
+    func signSIWERequest(_ message: String) async throws -> String {
         let message = try SiweMessage(message)
-        return try signSIWERequest(message)
+        return try await signSIWERequest(message)
     }
 
-    func signSIWERequest(_ message: SiweMessage) throws -> String {
+    func signSIWERequest(_ message: SiweMessage) async throws -> String {
         guard let data = "\(message)".data(using: .utf8) else {
             throw EthereumAccountError.signError
         }
-        return try signMessage(message: data)
+        return try await signMessage(message: data)
     }
 }


### PR DESCRIPTION
Hello all!

This is my first contribution here, so I would like to thank you guys for such an amazing library.
If I violated any style guide rule or commit policy, please let me know.

All the details you may find below.

I hope this concept finds you well :)

Thank you! :)

## Introduction
The proposed change removes holding private key in property in `EthereumAccount` instance and moves that responsibility to the key storage.
Key storage provides private key "on-demand" i.e. while signing.
It has unified methods for storing and loading private key and gives developer more flexibility in case of creating a storage. The change simplifies `EthereumAccount` API.

## Motivation
The reason for change was to meet [OWASP MASVS MSTG-STORAGE-10](https://mobile-security.gitbook.io/masvs/security-requirements/0x07-v2-data_storage_and_privacy_requirements) security requirement.
Previous implementation holds `privateKeyData` in `EthereumAccount`'s property so it lives in memory as long as `EthereumAccount` instance.

Having private key "on-demand" would allow to wrap it e.g. with keychain which allows to have a behavior similar to banking apps, where operation has to be authorized either by biometry or PIN. The API design now allows to force such an approach.

Developers could use the previous behavior as well, where asking for private key was done only once, but it would be theirs discretion, based on key storage implementation (which may have private key caching).

## Detailed design
Instead of having `privateKeyData` property, `EthereumAccount` now stores `keyStorage` and calls `loadPrivateKey(for: address)` when private key is needed:
```swift
public func sign(data: Data) throws -> Data {
    let privateKeyData = try keyStorage.loadPrivateKey(for: address)
    try validate(address: address, withPrivateKey: privateKeyData)
    return try KeyUtil.sign(message: data, with: privateKeyData, hashing: true)
}
```
As previous implementation has two separate key storages it was not possible to easily keep it as property, so it was required to find similarities between `EthereumSingleKeyStorageProtocol` and `EthereumMultipleKeyStorageProtocol` and unify API. The result is `EthereumKeyStorageProtocol`:
```swift
public protocol EthereumKeyStorageProtocol {
    func storePrivateKey(key: Data, with address: EthereumAddress) throws
    func loadPrivateKey(for address: EthereumAddress) throws -> Data
}
```
Having `address` passed through method may allow to perform additional operations based on it (e.g. salt creation).
Having responsibility moved to keyStorages allows to simplify `EthereumAccount` API. It was possible to remove `keystoragePassword` in favor to `EthereumCryptingStorage`

Because of the constructor change, I have created additional check in case of addresses discrepancy:
```
private func validate(address: EthereumAddress, withPrivateKey key: Data) throws {
    let retrievedAddress = try KeyUtil.generateAddress(from: KeyUtil.generatePublicKey(from: key))
    guard address == retrievedAddress else { throw EthereumAccountError.addressesDoesNotMatch }
}
```

## Source compatibility
This change breaks the current API for `EthereumAccount`. 

It unifies ethereum key storages with same methods for setting and loading private key, so because of that, the behavior of `EthereumKeyLocalStorage` is slightly different (it uses implementation from multiple key storage, but for single key)

## Backward compatibility
To match previous behavior with `keystoragePassword` I have added a storage wrapper called `EthereumCryptingStorage`.
It wraps previous logic with `keystoragePassword` as follows:

Before:
```swift
let keyStorage = EthereumKeyLocalStorage()
let account = EthereumAccount.create(replacing: keyStorage, keystorePassword: "PASSWORD")
```

After:
```swift
let keyStorage = EthereumKeyLocalStorage()
let wrapperStorage = EthereumCryptingStorage(backingStorage: keyStorage, passwordProvider: { "PASSWORD" })
let account = EthereumAccount.create(settingTo: wrapperStorage)
```
