### PR TITLE
[CHANGE] EthereumAddress: Deprecate `value`. Compare by converting to number

### DIFF
--- a/web3sTests/Account/EthereumAccountTests.swift
+++ b/web3sTests/Account/EthereumAccountTests.swift
@@ -17,13 +17,13 @@ class EthereumAccountTests: XCTestCase {
     
     func testLoadAccountAndAddress() {
         let account = try! EthereumAccount(keyStorage: TestEthereumKeyStorage(privateKey: TestConfig.privateKey))
-        XCTAssertEqual(account.address.value.lowercased(), TestConfig.publicKey.lowercased(), "Failed to load private key. Ensure key is valid in TestConfig.swift")
+        XCTAssertEqual(account.address, EthereumAddress(TestConfig.publicKey), "Failed to load private key. Ensure key is valid in TestConfig.swift")
     }
 
     func testLoadAccountAndAddressMultiple() {
         let storage = TestEthereumMultipleKeyStorage(privateKey: TestConfig.privateKey)
         let account = try! EthereumAccount(addressString: TestConfig.publicKey, keyStorage: storage)
-        XCTAssertEqual(account.address.value.lowercased(), TestConfig.publicKey.lowercased(), "Failed to load private key. Ensure key is valid in TestConfig.swift")
+        XCTAssertEqual(account.address, EthereumAddress(TestConfig.publicKey), "Failed to load private key. Ensure key is valid in TestConfig.swift")
     }
 
     func testCreateAccount() {
@@ -42,14 +42,14 @@ class EthereumAccountTests: XCTestCase {
         let storage = EthereumKeyLocalStorage()
         let account = try! EthereumAccount.importAccount(replacing: storage, privateKey: "0x2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173", keystorePassword: "PASSWORD")
 
-        XCTAssertEqual(account.address.value, "0x675f5810feb3b09528e5cd175061b4eb8de69075")
+        XCTAssertEqual(account.address, "0x675f5810feb3b09528e5cd175061b4eb8de69075")
     }
     
     func testImportAccountMultiple() {
         let storage = EthereumKeyLocalStorage()
         let account = try! EthereumAccount.importAccount(addingTo: storage, privateKey: "0x2639f727ded571d584643895d43d02a7a190f8249748a2c32200cfc12dde7173", keystorePassword: "PASSWORD")
 
-        XCTAssertEqual(account.address.value, "0x675f5810feb3b09528e5cd175061b4eb8de69075")
+        XCTAssertEqual(account.address, "0x675f5810feb3b09528e5cd175061b4eb8de69075")
     }
     
     func testFetchAccounts() {

--- a/web3sTests/Client/EthereumClientTests.swift
+++ b/web3sTests/Client/EthereumClientTests.swift
@@ -37,7 +37,6 @@ class EthereumClientTests: XCTestCase {
         super.setUp()
         client = EthereumHttpClient(url: URL(string: TestConfig.clientUrl)!)
         account = try? EthereumAccount(keyStorage: TestEthereumKeyStorage(privateKey: TestConfig.privateKey))
-        print("Public address: \(account?.address.value ?? "NONE")")
     }
 
     func testEthGetTransactionCount() async {
@@ -208,8 +207,8 @@ class EthereumClientTests: XCTestCase {
     func testGivenMinedTransactionHash_ThenGetsTransactionByHash() async {
         do {
             let transaction = try await client?.eth_getTransaction(byHash: "0x706bbe6f2593235942b8e76c2f37af3824d47a64caf65f7ae5e0c5ee1e886132")
-            XCTAssertEqual(transaction?.from?.value, "0x64d0ea4fc60f27e74f1a70aa6f39d403bbe56793")
-            XCTAssertEqual(transaction?.to.value, "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984")
+            XCTAssertEqual(transaction?.from, "0x64d0ea4fc60f27e74f1a70aa6f39d403bbe56793")
+            XCTAssertEqual(transaction?.to, "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984")
             XCTAssertEqual(transaction?.gas, "85773")
             XCTAssertEqual(transaction?.gasPrice, BigUInt(14300000000))
             XCTAssertEqual(transaction?.nonce, 23)

--- a/web3sTests/ENS/ENSTests.swift
+++ b/web3sTests/ENS/ENSTests.swift
@@ -69,7 +69,7 @@ class ENSTests: XCTestCase {
     func testGivenRegistry_WhenAddressHasSubdomain_AndReverseRecordNotSet_ThenDoesNotResolveCorrectly() async {
         do {
             let nameService = EthereumNameService(client: client!)
-            let ens = try await nameService.resolve(
+            let _ = try await nameService.resolve(
                 address: "0x787411394Ccb38483a6F303FDee075f3EA67D65F",
                 mode: .onchain
             )

--- a/web3sTests/OffchainLookup/OffchainLookupTests.swift
+++ b/web3sTests/OffchainLookup/OffchainLookupTests.swift
@@ -147,7 +147,6 @@ class OffchainLookupTests: XCTestCase {
         super.setUp()
         client = EthereumHttpClient(url: URL(string: TestConfig.clientUrl)!)
         account = try? EthereumAccount(keyStorage: TestEthereumKeyStorage(privateKey: TestConfig.privateKey))
-        print("Public address: \(account?.address.value ?? "NONE")")
     }
 
     func test_GivenFunctionWithOffchainLookupError_ThenDecodesLookupParamsCorrectly() async throws {
@@ -318,7 +317,7 @@ private func expectedResponse(
     sender: EthereumAddress,
     data: Data
 ) -> String {
-    let senderData = sender.value.web3.hexData!
+    let senderData = sender.asData()!
     return Data([
         [UInt8(senderData.count)],
         senderData.web3.bytes,

--- a/web3sTests/Utils/KeyUtilTests.swift
+++ b/web3sTests/Utils/KeyUtilTests.swift
@@ -45,7 +45,7 @@ class KeyUtilTests: XCTestCase {
         let publicKey = try! KeyUtil.generatePublicKey(from: privateKey)
         let address = KeyUtil.generateAddress(from: publicKey)
 
-        XCTAssertEqual(address.value, "0x751e735a83a8142c1b9dc722ef559b898f1d77fa")
+        XCTAssertEqual(address, "0x751e735a83a8142c1b9dc722ef559b898f1d77fa")
     }
     
     func testRecoverPublicKey() {
@@ -54,7 +54,7 @@ class KeyUtilTests: XCTestCase {
 
         let address = try! KeyUtil.recoverPublicKey(message: "Hello message!".web3.keccak256, signature: signature)
 
-        XCTAssertEqual(address, account.address.value.lowercased())
+        XCTAssertEqual(address, account.address.asString().lowercased())
     }
     
     func testRecoverPublicKeyMultiple() {
@@ -64,6 +64,6 @@ class KeyUtilTests: XCTestCase {
 
         let address = try! KeyUtil.recoverPublicKey(message: "Hello message!".web3.keccak256, signature: signature)
 
-        XCTAssertEqual(address, account.address.value.lowercased())
+        XCTAssertEqual(address, account.address.asString().lowercased())
     }
 }

--- a/web3swift/src/Account/EthereumAccount.swift
+++ b/web3swift/src/Account/EthereumAccount.swift
@@ -89,8 +89,8 @@ public class EthereumAccount: EthereumAccountProtocol {
         do {
             try keyStorage.encryptAndStorePrivateKey(key: privateKey, keystorePassword: password)
             let publicKey = try KeyUtil.generatePublicKey(from: privateKey)
-            let address = KeyUtil.generateAddress(from: publicKey).value
-            return try self.init(addressString: address, keyStorage: keyStorage, keystorePassword: password)
+            let address = KeyUtil.generateAddress(from: publicKey)
+            return try self.init(addressString: address.asString(), keyStorage: keyStorage, keystorePassword: password)
         } catch {
             throw EthereumAccountError.createAccountError
         }
@@ -116,8 +116,8 @@ public class EthereumAccount: EthereumAccountProtocol {
         do {
             try keyStorage.encryptAndStorePrivateKey(key: privateKey, keystorePassword: password)
             let publicKey = try KeyUtil.generatePublicKey(from: privateKey)
-            let address = KeyUtil.generateAddress(from: publicKey).value
-            return try self.init(addressString: address, keyStorage: keyStorage, keystorePassword: password)
+            let address = KeyUtil.generateAddress(from: publicKey)
+            return try self.init(addressString: address.asString(), keyStorage: keyStorage, keystorePassword: password)
         } catch {
             throw EthereumAccountError.importAccountError
         }

--- a/web3swift/src/Account/EthereumKeyStorage.swift
+++ b/web3swift/src/Account/EthereumKeyStorage.swift
@@ -28,7 +28,7 @@ public enum EthereumKeyStorageError: Error {
 public class EthereumKeyLocalStorage: EthereumSingleKeyStorageProtocol {
     public init() {}
 
-    private var address: String?
+    private var address: EthereumAddress?
     private let localFileName = "ethereumkey"
 
     private var addressPath: String? {
@@ -36,7 +36,7 @@ public class EthereumKeyLocalStorage: EthereumSingleKeyStorageProtocol {
             return nil
         }
         if let url = folderPath {
-            return url.appendingPathComponent(address).path
+            return url.appendingPathComponent(address.asString()).path
         }
         return nil
     }
@@ -102,7 +102,7 @@ extension EthereumKeyLocalStorage: EthereumMultipleKeyStorageProtocol {
     }
 
     public func storePrivateKey(key: Data, with address: EthereumAddress) throws {
-        self.address = address.value
+        self.address = address
 
         defer {
             self.address = nil
@@ -120,7 +120,7 @@ extension EthereumKeyLocalStorage: EthereumMultipleKeyStorageProtocol {
     }
 
     public func loadPrivateKey(for address: EthereumAddress) throws -> Data {
-        self.address = address.value
+        self.address = address
 
         defer {
             self.address = nil
@@ -155,7 +155,7 @@ extension EthereumKeyLocalStorage: EthereumMultipleKeyStorageProtocol {
     public func deletePrivateKey(for address: EthereumAddress) throws {
         do {
             if let folderPath = folderPath {
-                let filePathName = folderPath.appendingPathComponent(address.value)
+                let filePathName = folderPath.appendingPathComponent(address.asString())
                 try fileManager.removeItem(at: filePathName)
             }
         } catch {

--- a/web3swift/src/Client/BaseEthereumClient.swift
+++ b/web3swift/src/Client/BaseEthereumClient.swift
@@ -93,7 +93,7 @@ public class BaseEthereumClient: EthereumClientProtocol {
 
     public func eth_getBalance(address: EthereumAddress, block: EthereumBlock) async throws -> BigUInt {
         do {
-            let data = try await networkProvider.send(method: "eth_getBalance", params: [address.value, block.stringValue], receive: String.self)
+            let data = try await networkProvider.send(method: "eth_getBalance", params: [address.asString(), block.stringValue], receive: String.self)
             if let resString = data as? String, let balanceInt = BigUInt(hex: resString.web3.noHexPrefix) {
                 return balanceInt
             } else {
@@ -106,7 +106,7 @@ public class BaseEthereumClient: EthereumClientProtocol {
 
     public func eth_getCode(address: EthereumAddress, block: EthereumBlock = .Latest) async throws -> String {
         do {
-            let data = try await networkProvider.send(method: "eth_getCode", params: [address.value, block.stringValue], receive: String.self)
+            let data = try await networkProvider.send(method: "eth_getCode", params: [address.asString(), block.stringValue], receive: String.self)
             if let resDataString = data as? String {
                 return resDataString
             } else {
@@ -160,8 +160,8 @@ public class BaseEthereumClient: EthereumClientProtocol {
         }
 
         let params = CallParams(
-            from: transaction.from?.value,
-            to: transaction.to.value,
+            from: transaction.from?.asString(),
+            to: transaction.to.asString(),
             value: value?.web3.hexStringNoLeadingZeroes,
             data: transaction.data?.web3.hexString
         )
@@ -207,7 +207,7 @@ public class BaseEthereumClient: EthereumClientProtocol {
 
     public func eth_getTransactionCount(address: EthereumAddress, block: EthereumBlock) async throws -> Int {
         do {
-            let data = try await networkProvider.send(method: "eth_getTransactionCount", params: [address.value, block.stringValue], receive: String.self)
+            let data = try await networkProvider.send(method: "eth_getTransactionCount", params: [address.asString(), block.stringValue], receive: String.self)
             if let resString = data as? String, let count = Int(hex: resString) {
                 return count
             } else {

--- a/web3swift/src/Client/EthereumClient+Call.swift
+++ b/web3swift/src/Client/EthereumClient+Call.swift
@@ -58,8 +58,8 @@ extension BaseEthereumClient {
         }
 
         let params = CallParams(
-            from: transaction.from?.value,
-            to: transaction.to.value,
+            from: transaction.from?.asString(),
+            to: transaction.to.asString(),
             data: transactionData.web3.hexString,
             block: block.stringValue
         )
@@ -150,7 +150,7 @@ extension BaseEthereumClient {
         let isGet = rawURL.contains("{data}")
 
         guard let url = URL(string: rawURL
-            .replacingOccurrences(of: "{sender}", with: sender.value.lowercased())
+            .replacingOccurrences(of: "{sender}", with: sender.asString().lowercased())
             .replacingOccurrences(of: "{data}", with: data.web3.hexString.lowercased())) else {
             throw OffchainReadError.invalidParams
         }

--- a/web3swift/src/Client/Models/EthereumAddress.swift
+++ b/web3swift/src/Client/Models/EthereumAddress.swift
@@ -4,37 +4,61 @@
 //
 
 import Foundation
+import BigInt
 
 public struct EthereumAddress: Codable, Hashable {
-    public let value: String
+    @available(*, deprecated, message: "Shouldn't rely on the actual String representation. Use asString() instead to get an unformatted representation")
+    public var value: String {
+        raw
+    }
+    private let raw: String
     public static let zero: Self = "0x0000000000000000000000000000000000000000"
 
     public init(_ value: String) {
-        self.value = value.lowercased()
+        self.raw = value.lowercased()
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        self.value = try container.decode(String.self).lowercased()
+        self.raw = try container.decode(String.self).lowercased()
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
-        try container.encode(value)
+        try container.encode(raw)
     }
 
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(value)
+        guard let data = asData() else {
+            return
+        }
+        hasher.combine(data)
     }
 
     public static func == (lhs: EthereumAddress, rhs: EthereumAddress) -> Bool {
-        lhs.value == rhs.value
+        guard let lhsInt = lhs.asNumber(), let rhsInt = rhs.asNumber() else {
+            return false
+        }
+        // Comparing Number representation avoids issues with lowercase and 0-padding
+        return lhsInt == rhsInt
     }
 }
 
 public extension EthereumAddress {
+    func asString() -> String {
+        raw
+    }
+
+    func asNumber() -> BigUInt? {
+        .init(hex: raw)
+    }
+
+    func asData() -> Data? {
+        raw.web3.hexData
+    }
+
     func toChecksumAddress() -> String {
-        let lowerCaseAddress = value.web3.noHexPrefix.lowercased()
+        let lowerCaseAddress = raw.web3.noHexPrefix.lowercased()
         let arr = Array(lowerCaseAddress)
         let keccaf = Array(lowerCaseAddress.web3.keccak256.web3.hexString.web3.noHexPrefix)
         var result = "0x"

--- a/web3swift/src/Client/Models/EthereumTransaction.swift
+++ b/web3swift/src/Client/Models/EthereumTransaction.swift
@@ -44,7 +44,7 @@ public struct EthereumTransaction: EthereumTransactionProtocol, Equatable, Codab
         self.chainId = chainId
         self.gas = nil
         self.blockNumber = nil
-        let txArray: [Any?] = [self.nonce, self.gasPrice, self.gasLimit, self.to.value.web3.noHexPrefix, self.value, self.data, self.chainId, 0, 0]
+        let txArray: [Any?] = [self.nonce, self.gasPrice, self.gasLimit, self.to, self.value, self.data, self.chainId, 0, 0]
         self.hash = RLP.encode(txArray)
         self.input = nil
     }
@@ -100,7 +100,7 @@ public struct EthereumTransaction: EthereumTransactionProtocol, Equatable, Codab
     }
 
     public var raw: Data? {
-        let txArray: [Any?] = [nonce, gasPrice, gasLimit, to.value.web3.noHexPrefix, value, data, chainId, 0, 0]
+        let txArray: [Any?] = [nonce, gasPrice, gasLimit, to, value, data, chainId, 0, 0]
 
         return RLP.encode(txArray)
     }
@@ -174,7 +174,7 @@ public struct SignedTransaction {
     }
 
     public var raw: Data? {
-        let txArray: [Any?] = [transaction.nonce, transaction.gasPrice, transaction.gasLimit, transaction.to.value.web3.noHexPrefix, transaction.value, transaction.data, v, r, s]
+        let txArray: [Any?] = [transaction.nonce, transaction.gasPrice, transaction.gasLimit, transaction.to, transaction.value, transaction.data, v, r, s]
 
         return RLP.encode(txArray)
     }

--- a/web3swift/src/Contract/Statically Typed/ABIDecoder+Static.swift
+++ b/web3swift/src/Contract/Statically Typed/ABIDecoder+Static.swift
@@ -83,12 +83,11 @@ extension ABIDecoder {
     }
 
     public static func decode(_ data: ParsedABIEntry, to: EthereumAddress.Type) throws -> EthereumAddress {
-        let address = EthereumAddress(data)
-        guard address.value.hasPrefix("0x") else {
+        guard data.hasPrefix("0x") else {
             throw ABIError.invalidValue
         }
 
-        return address
+        return EthereumAddress(data)
     }
 
     public static func decode(_ data: ParsedABIEntry, to: BigInt.Type) throws -> BigInt {

--- a/web3swift/src/Contract/Statically Typed/ABIEncoder+Static.swift
+++ b/web3swift/src/Contract/Statically Typed/ABIEncoder+Static.swift
@@ -19,7 +19,7 @@ extension ABIEncoder {
         case let value as Bool:
             return try ABIEncoder.encodeRaw(value ? "true" : "false", forType: type, padded: !packed)
         case let value as EthereumAddress:
-            return try ABIEncoder.encodeRaw(value.value, forType: type, padded: !packed)
+            return try ABIEncoder.encodeRaw(value.asString(), forType: type, padded: !packed)
         case let value as BigInt:
             return try ABIEncoder.encodeRaw(String(value), forType: type, padded: !packed)
         case let value as BigUInt:

--- a/web3swift/src/ENS/ENSContracts.swift
+++ b/web3swift/src/ENS/ENSContracts.swift
@@ -31,7 +31,7 @@ public enum ENSContracts {
             switch self {
             case let .address(address):
                 nameHash = ENSContracts.nameHash(
-                    name: address.value.web3.noHexPrefix + ".addr.reverse"
+                    name: address.asString().web3.noHexPrefix + ".addr.reverse"
                 )
             case let .name(ens):
                 nameHash = ENSContracts.nameHash(name: ens)
@@ -43,7 +43,7 @@ public enum ENSContracts {
             switch self {
             case let .address(address):
                 return ENSContracts.dnsEncode(
-                    name: address.value.web3.noHexPrefix + ".addr.reverse"
+                    name: address.asString().web3.noHexPrefix + ".addr.reverse"
                 )
             case let .name(name):
                 return ENSContracts.dnsEncode(name: name)

--- a/web3swift/src/Utils/RLP.swift
+++ b/web3swift/src/Utils/RLP.swift
@@ -21,6 +21,8 @@ struct RLP {
             return encodeBigUInt(buint)
         case let data as Data:
             return encodeData(data)
+        case let address as EthereumAddress:
+            return encodeAddress(address)
         default:
             return nil
         }
@@ -35,6 +37,10 @@ struct RLP {
             return nil
         }
         return encodeData(data)
+    }
+
+    static func encodeAddress(_ address: EthereumAddress) -> Data? {
+        return encodeString(address.asString())
     }
 
     static func encodeInt(_ int: Int) -> Data? {


### PR DESCRIPTION
This will avoid any string comparison issues. Also the string value
shouldn't be exposed so explicity, created different converison methods
in the type.