### PR TITLE
[FIX] Hashing of EthereumAddress

### DIFF
--- a/web3sTests/Address/EthereumAddressTests.swift
+++ b/web3sTests/Address/EthereumAddressTests.swift
@@ -1,0 +1,41 @@
+//
+//  web3.swift
+//  Copyright © 2023 Argent Labs Limited. All rights reserved.
+//
+
+import XCTest
+@testable import web3
+
+class EthereumAddressTests: XCTestCase {
+    private var values: Set<EthereumAddress>!
+    private let addr1 = EthereumAddress("0x162142f0508F557C02bEB7C473682D7C91Bcef41")
+    private let addr1Padded = EthereumAddress("0x0162142f0508F557C02bEB7C473682D7C91Bcef41")
+    private let addr2 = EthereumAddress("0x162142f0508F557C02bEB7C473682D7C91Bcef42")
+
+    func testGivenAddress_WhenComparingWithSameAddressString_AddressIsEqual() {
+        XCTAssertEqual(addr1, addr1)
+    }
+
+    func testGivenAddress_WhenHashingWithSameAddressString_AddressIsEqual() {
+        values = [addr1]
+        XCTAssertTrue(values.contains(addr1))
+    }
+
+    func testGivenAddress_WhenComparingWithDifferentAddressString_AddressIsEqual() {
+        XCTAssertNotEqual(addr1, addr2)
+    }
+
+    func testGivenAddress_WhenComparingWith0PaddedAddress_AddressIsEqual() {
+        XCTAssertEqual(addr1, addr1Padded)
+    }
+
+    func testGivenAddress_WhenHashingWith0PaddedAddress_AddressIsEqual() {
+        values = [addr1]
+        XCTAssertTrue(values.contains(addr1Padded))
+    }
+
+    func testGiven0PaddedAddress_WhenHashingWithNotPaddedAddress_AddressIsEqual() {
+        values = [addr1Padded]
+        XCTAssertTrue(values.contains(addr1))
+    }
+}

--- a/web3swift/src/Client/Models/EthereumAddress.swift
+++ b/web3swift/src/Client/Models/EthereumAddress.swift
@@ -3,14 +3,14 @@
 //  Copyright © 2022 Argent Labs Limited. All rights reserved.
 //
 
-import Foundation
 import BigInt
+import Foundation
 
 public struct EthereumAddress: Codable, Hashable {
-    @available(*, deprecated, message: "Shouldn't rely on the actual String representation. Use asString() instead to get an unformatted representation")
-    public var value: String {
+    @available(*, deprecated, message: "Shouldn't rely on the actual String representation. Use asString() instead to get an unformatted representation")  public var value: String {
         raw
     }
+
     private let raw: String
     public static let zero: Self = "0x0000000000000000000000000000000000000000"
 
@@ -54,7 +54,7 @@ public extension EthereumAddress {
     }
 
     func asData() -> Data? {
-        raw.web3.hexData
+        raw.web3.hexDataAddingPadding?.web3.strippingZeroesFromBytes
     }
 
     func toChecksumAddress() -> String {

--- a/web3swift/src/Extensions/HexExtensions.swift
+++ b/web3swift/src/Extensions/HexExtensions.swift
@@ -95,4 +95,13 @@ public extension Web3Extensions where Base == String {
 
         return nil
     }
+
+    var hexDataAddingPadding: Data? {
+        let noHexPrefix = self.noHexPrefix
+        if let bytes = try? HexUtil.byteArray(fromHex: noHexPrefix, addingPadding: true) {
+            return Data(bytes)
+        }
+
+        return nil
+    }
 }

--- a/web3swift/src/Utils/HexUtil.swift
+++ b/web3swift/src/Utils/HexUtil.swift
@@ -27,21 +27,26 @@ class HexUtil {
         }
     }
 
-    static func byteArray(fromHex string: String) throws -> [UInt8] {
+    static func byteArray(fromHex string: String, addingPadding addPadding: Bool = false) throws -> [UInt8] {
         var iterator = string.unicodeScalars.makeIterator()
         var byteArray: [UInt8] = []
 
         while let msn = iterator.next() {
-            if let lsn = iterator.next() {
-                do {
-                    let convertedMsn = try convert(hexDigit: msn)
-                    let convertedLsn = try convert(hexDigit: lsn)
-                    byteArray += [convertedMsn << 4 | convertedLsn]
-                } catch {
-                    throw error
-                }
-            } else {
+            var lsn = iterator.next()
+            if lsn == nil, addPadding == true {
+                lsn = "0"
+            }
+
+            guard let lsn else {
                 throw HexConversionError.stringNotEven
+            }
+
+            do {
+                let convertedMsn = try convert(hexDigit: msn)
+                let convertedLsn = try convert(hexDigit: lsn)
+                byteArray += [convertedMsn << 4 | convertedLsn]
+            } catch {
+                throw error
             }
         }
         return byteArray

--- a/web3swift/src/Utils/RLP.swift
+++ b/web3swift/src/Utils/RLP.swift
@@ -40,7 +40,7 @@ struct RLP {
     }
 
     static func encodeAddress(_ address: EthereumAddress) -> Data? {
-        return encodeString(address.asString())
+        encodeString(address.asString())
     }
 
     static func encodeInt(_ int: Int) -> Data? {


### PR DESCRIPTION
Currently an address like "0xabcd.." and "0x0abcd..." would not be hashed correctly, failing to match when including in collection types that require keys to be `Hashable`