### PR TITLE
[FIX] Remove potential deadlock when using async-await. Provide network at client initialization instead

### DIFF
--- a/web3sTests/Client/EthereumClientTests.swift
+++ b/web3sTests/Client/EthereumClientTests.swift
@@ -35,7 +35,7 @@ class EthereumClientTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        client = EthereumHttpClient(url: URL(string: TestConfig.clientUrl)!)
+        client = EthereumHttpClient(url: URL(string: TestConfig.clientUrl)!, network: TestConfig.network)
         account = try? EthereumAccount(keyStorage: TestEthereumKeyStorage(privateKey: TestConfig.privateKey))
     }
 
@@ -435,14 +435,14 @@ class EthereumWebSocketClientTests: EthereumClientTests {
 
     override func setUp() {
         super.setUp()
-        client = EthereumWebSocketClient(url: URL(string: TestConfig.wssUrl)!, configuration: TestConfig.webSocketConfig)
+        client = EthereumWebSocketClient(url: URL(string: TestConfig.wssUrl)!, configuration: TestConfig.webSocketConfig, network: TestConfig.network)
 
     }
 #if os(Linux)
 // On Linux some tests are fail. Need investigation
 #else
     func testWebSocketNoAutomaticOpen() {
-        self.client = EthereumWebSocketClient(url: URL(string: TestConfig.wssUrl)!, configuration: .init(automaticOpen: false))
+        self.client = EthereumWebSocketClient(url: URL(string: TestConfig.wssUrl)!, configuration: .init(automaticOpen: false), network: TestConfig.network)
 
         guard let client = client as? EthereumWebSocketClient else {
             XCTFail("Expected client to be EthereumWebSocketClient")
@@ -453,7 +453,7 @@ class EthereumWebSocketClientTests: EthereumClientTests {
     }
 
     func testWebSocketConnect() {
-        self.client = EthereumWebSocketClient(url: URL(string: TestConfig.wssUrl)!, configuration: .init(automaticOpen: false))
+        self.client = EthereumWebSocketClient(url: URL(string: TestConfig.wssUrl)!, configuration: .init(automaticOpen: false), network: TestConfig.network)
 
         guard let client = client as? EthereumWebSocketClient else {
             XCTFail("Expected client to be EthereumWebSocketClient")

--- a/web3sTests/Contract/ABIEventTests.swift
+++ b/web3sTests/Contract/ABIEventTests.swift
@@ -12,7 +12,7 @@ class ABIEventTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        client = EthereumHttpClient(url: URL(string: TestConfig.clientUrl)!)
+        client = EthereumHttpClient(url: URL(string: TestConfig.clientUrl)!, network: TestConfig.network)
     }
     
     func test_givenEventWithData4_ItParsesCorrectly() async {
@@ -60,7 +60,7 @@ class ABIEventTests: XCTestCase {
 class ABIEventWebSocketTests: ABIEventTests {
     override func setUp() {
         super.setUp()
-        client = EthereumWebSocketClient(url: URL(string: TestConfig.wssUrl)!, configuration: TestConfig.webSocketConfig)
+        client = EthereumWebSocketClient(url: URL(string: TestConfig.wssUrl)!, configuration: TestConfig.webSocketConfig, network: TestConfig.network)
     }
 }
 

--- a/web3sTests/ENS/ENSOffchainTests.swift
+++ b/web3sTests/ENS/ENSOffchainTests.swift
@@ -12,7 +12,7 @@ class ENSOffchainTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        client = EthereumHttpClient(url: URL(string: TestConfig.clientUrl)!)
+        client = EthereumHttpClient(url: URL(string: TestConfig.clientUrl)!, network: TestConfig.network)
     }
 
     func testDNSEncode() {
@@ -149,6 +149,6 @@ class ENSOffchainTests: XCTestCase {
 class ENSOffchainWebSocketTests: ENSOffchainTests {
     override func setUp() {
         super.setUp()
-        client = EthereumWebSocketClient(url: URL(string: TestConfig.wssUrl)!, configuration: TestConfig.webSocketConfig)
+        client = EthereumWebSocketClient(url: URL(string: TestConfig.wssUrl)!, configuration: TestConfig.webSocketConfig, network: TestConfig.network)
     }
 }

--- a/web3sTests/ENS/ENSTests.swift
+++ b/web3sTests/ENS/ENSTests.swift
@@ -363,7 +363,7 @@ class ENSTests: XCTestCase {
 class ENSWebSocketTests: ENSTests {
     override func setUp() {
         super.setUp()
-        client = EthereumWebSocketClient(url: URL(string: TestConfig.wssUrl)!, configuration: TestConfig.webSocketConfig)
-        mainnetClient = EthereumWebSocketClient(url: URL(string: TestConfig.wssMainnetUrl)!, configuration: TestConfig.webSocketConfig)
+        client = EthereumWebSocketClient(url: URL(string: TestConfig.wssUrl)!, configuration: TestConfig.webSocketConfig, network: TestConfig.network)
+        mainnetClient = EthereumWebSocketClient(url: URL(string: TestConfig.wssMainnetUrl)!, configuration: TestConfig.webSocketConfig, network: .mainnet)
     }
 }

--- a/web3sTests/ERC1271/ERC1271Tests.swift
+++ b/web3sTests/ERC1271/ERC1271Tests.swift
@@ -13,7 +13,7 @@ class ERC1271Tests: XCTestCase {
     override func setUp() {
         super.setUp()
         if self.client == nil {
-            self.client = EthereumHttpClient(url: URL(string: TestConfig.clientUrl)!)
+            self.client = EthereumHttpClient(url: URL(string: TestConfig.clientUrl)!, network: TestConfig.network)
         }
         self.erc1271 = ERC1271(client: self.client)
     }
@@ -105,7 +105,7 @@ final class ERC1271WebSocketTests: ERC1271Tests {
 
     override func setUp() {
         if self.client == nil {
-            self.client = EthereumWebSocketClient(url: URL(string: TestConfig.wssUrl)!)
+            self.client = EthereumWebSocketClient(url: URL(string: TestConfig.wssUrl)!, network: TestConfig.network)
         }
         super.setUp()
     }

--- a/web3sTests/ERC165/ERC165Tests.swift
+++ b/web3sTests/ERC165/ERC165Tests.swift
@@ -15,7 +15,7 @@ class ERC165Tests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        client = EthereumHttpClient(url: URL(string: TestConfig.clientUrl)!)
+        client = EthereumHttpClient(url: URL(string: TestConfig.clientUrl)!, network: TestConfig.network)
         erc165 = ERC165(client: client)
     }
 
@@ -54,6 +54,6 @@ class ERC165Tests: XCTestCase {
 class ERC165WebSocketTests: ERC165Tests {
     override func setUp() {
         super.setUp()
-        client = EthereumWebSocketClient(url: URL(string: TestConfig.wssUrl)!, configuration: TestConfig.webSocketConfig)
+        client = EthereumWebSocketClient(url: URL(string: TestConfig.wssUrl)!, configuration: TestConfig.webSocketConfig, network: TestConfig.network)
     }
 }

--- a/web3sTests/ERC20/ERC20Tests.swift
+++ b/web3sTests/ERC20/ERC20Tests.swift
@@ -14,7 +14,7 @@ class ERC20Tests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        client = EthereumHttpClient(url: URL(string: TestConfig.clientUrl)!)
+        client = EthereumHttpClient(url: URL(string: TestConfig.clientUrl)!, network: TestConfig.network)
         erc20 = ERC20(client: client!)
     }
 
@@ -114,6 +114,6 @@ class ERC20Tests: XCTestCase {
 class ERC20WebSocketTests: ERC20Tests {
     override func setUp() {
         super.setUp()
-        client = EthereumWebSocketClient(url: URL(string: TestConfig.wssUrl)!, configuration: TestConfig.webSocketConfig)
+        client = EthereumWebSocketClient(url: URL(string: TestConfig.wssUrl)!, configuration: TestConfig.webSocketConfig, network: TestConfig.network)
     }
 }

--- a/web3sTests/ERC721/ERC721Tests.swift
+++ b/web3sTests/ERC721/ERC721Tests.swift
@@ -24,7 +24,7 @@ class ERC721Tests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        client = EthereumHttpClient(url: URL(string: TestConfig.clientUrl)!)
+        client = EthereumHttpClient(url: URL(string: TestConfig.clientUrl)!, network: TestConfig.network)
         erc721 = ERC721(client: client)
     }
 
@@ -111,7 +111,7 @@ class ERC721MetadataTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        client = EthereumHttpClient(url: URL(string: TestConfig.clientUrl)!)
+        client = EthereumHttpClient(url: URL(string: TestConfig.clientUrl)!, network: TestConfig.network)
         erc721 = ERC721Metadata(client: client, metadataSession: URLSession.shared)
     }
 
@@ -163,7 +163,7 @@ class ERC721EnumerableTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        client = EthereumHttpClient(url: URL(string: TestConfig.clientUrl)!)
+        client = EthereumHttpClient(url: URL(string: TestConfig.clientUrl)!, network: TestConfig.network)
         erc721 = ERC721Enumerable(client: client)
     }
 
@@ -211,20 +211,20 @@ class ERC721EnumerableTests: XCTestCase {
 class ERC721WebSocketTests: ERC721Tests {
     override func setUp() {
         super.setUp()
-        client = EthereumWebSocketClient(url: URL(string: TestConfig.wssUrl)!, configuration: TestConfig.webSocketConfig)
+        client = EthereumWebSocketClient(url: URL(string: TestConfig.wssUrl)!, configuration: TestConfig.webSocketConfig, network: TestConfig.network)
     }
 }
 
 class ERC721MetadataWebSocketTests: ERC721MetadataTests {
     override func setUp() {
         super.setUp()
-        client = EthereumWebSocketClient(url: URL(string: TestConfig.wssUrl)!, configuration: TestConfig.webSocketConfig)
+        client = EthereumWebSocketClient(url: URL(string: TestConfig.wssUrl)!, configuration: TestConfig.webSocketConfig, network: TestConfig.network)
     }
 }
 
 class ERC721EnumerableWebSocketTests: ERC721EnumerableTests {
     override func setUp() {
         super.setUp()
-        client = EthereumWebSocketClient(url: URL(string: TestConfig.wssUrl)!, configuration: TestConfig.webSocketConfig)
+        client = EthereumWebSocketClient(url: URL(string: TestConfig.wssUrl)!, configuration: TestConfig.webSocketConfig, network: TestConfig.network)
     }
 }

--- a/web3sTests/Multicall/MulticallTests.swift
+++ b/web3sTests/Multicall/MulticallTests.swift
@@ -13,7 +13,7 @@ class MulticallTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        client = EthereumHttpClient(url: URL(string: TestConfig.clientUrl)!)
+        client = EthereumHttpClient(url: URL(string: TestConfig.clientUrl)!, network: TestConfig.network)
         multicall = Multicall(client: client!)
     }
 
@@ -83,6 +83,6 @@ class MulticallTests: XCTestCase {
 class MulticallWebSocketTests: MulticallTests {
     override func setUp() {
         super.setUp()
-        client = EthereumWebSocketClient(url: URL(string: TestConfig.wssUrl)!, configuration: TestConfig.webSocketConfig)
+        client = EthereumWebSocketClient(url: URL(string: TestConfig.wssUrl)!, configuration: TestConfig.webSocketConfig, network: TestConfig.network)
     }
 }

--- a/web3sTests/OffchainLookup/OffchainLookupTests.swift
+++ b/web3sTests/OffchainLookup/OffchainLookupTests.swift
@@ -145,7 +145,7 @@ class OffchainLookupTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        client = EthereumHttpClient(url: URL(string: TestConfig.clientUrl)!)
+        client = EthereumHttpClient(url: URL(string: TestConfig.clientUrl)!, network: TestConfig.network)
         account = try? EthereumAccount(keyStorage: TestEthereumKeyStorage(privateKey: TestConfig.privateKey))
     }
 
@@ -331,6 +331,6 @@ private func expectedResponse(
 class OffchainLookupWebSocketTests: OffchainLookupTests {
     override func setUp() {
         super.setUp()
-        client = EthereumWebSocketClient(url: URL(string: TestConfig.wssUrl)!, configuration: TestConfig.webSocketConfig)
+        client = EthereumWebSocketClient(url: URL(string: TestConfig.wssUrl)!, configuration: TestConfig.webSocketConfig, network: TestConfig.network)
     }
 }

--- a/web3sTests/SIWE/SIWETests.swift
+++ b/web3sTests/SIWE/SIWETests.swift
@@ -14,7 +14,7 @@ class SIWETests: XCTestCase {
     override func setUp() {
         super.setUp()
         if self.client == nil {
-            self.client = EthereumHttpClient(url: URL(string: TestConfig.clientUrl)!)
+            self.client = EthereumHttpClient(url: URL(string: TestConfig.clientUrl)!, network: TestConfig.network)
         }
         self.verifier = SiweVerifier(client: self.client)
     }
@@ -58,7 +58,7 @@ final class SIWEWebSocketTests: SIWETests {
 
     override func setUp() {
         if self.client == nil {
-            self.client = EthereumWebSocketClient(url: URL(string: TestConfig.wssUrl)!)
+            self.client = EthereumWebSocketClient(url: URL(string: TestConfig.wssUrl)!, network: TestConfig.network)
         }
         super.setUp()
     }

--- a/web3sTests/SIWE/SiweVerifierTests.swift
+++ b/web3sTests/SIWE/SiweVerifierTests.swift
@@ -226,7 +226,7 @@ final class SiweVerifierWebSocketTests: SiweVerifierTests {
 
     override func setUp() {
         if self.client == nil {
-            self.client = EthereumWebSocketClient(url: URL(string: TestConfig.wssUrl)!)
+            self.client = EthereumWebSocketClient(url: URL(string: TestConfig.wssUrl)!, network: TestConfig.network)
         }
         super.setUp()
     }

--- a/web3sTests/TestConfig.swift
+++ b/web3sTests/TestConfig.swift
@@ -32,9 +32,12 @@ struct TestConfig {
 
     static let webSocketConfig = WebSocketConfiguration(maxFrameSize: 1_000_000)
 
+    static let network = EthereumNetwork.goerli
+
      enum ZKSync {
-        static let chainId = 280
-        static let clientURL = URL(string: "https://zksync2-testnet.zksync.dev")!
+         static let chainId = 280
+         static let network = EthereumNetwork.custom("\(280)")
+         static let clientURL = URL(string: "https://zksync2-testnet.zksync.dev")!
     }
 }
 

--- a/web3sTests/ZKSync/EthereumClient+ZKSyncTests.swift
+++ b/web3sTests/ZKSync/EthereumClient+ZKSyncTests.swift
@@ -12,7 +12,7 @@ import BigInt
 
 final class EthereumClientZKSyncTests: XCTestCase {
     let eoaAccount = try! EthereumAccount(keyStorage: TestEthereumKeyStorage(privateKey: TestConfig.privateKey))
-    let client = ZKSyncClient(url: TestConfig.ZKSync.clientURL)
+    let client = ZKSyncClient(url: TestConfig.ZKSync.clientURL, network: TestConfig.ZKSync.network)
     var eoaEthTransfer = ZKSyncTransaction(
         from: .init(TestConfig.publicKey),
         to: .init("0x64d0eA4FC60f27E74f1a70Aa6f39D403bBe56793"),

--- a/web3swift/src/Client/BaseEthereumClient.swift
+++ b/web3swift/src/Client/BaseEthereumClient.swift
@@ -18,37 +18,18 @@ open class BaseEthereumClient: EthereumClientProtocol {
 
     private let logger: Logger
 
-    public var network: EthereumNetwork?
+    public var network: EthereumNetwork
 
     public init(
         networkProvider: NetworkProviderProtocol,
         url: URL,
         logger: Logger? = nil,
-        network: EthereumNetwork?
+        network: EthereumNetwork
     ) {
         self.url = url
         self.networkProvider = networkProvider
         self.logger = logger ?? Logger(label: "web3.swift.eth-client")
         self.network = network
-
-        if network == nil {
-            let semaphore = DispatchSemaphore(value: 0)
-            Task {
-                self.network = await fetchNetwork()
-                semaphore.signal()
-            }
-            semaphore.wait()
-        }
-    }
-
-    private func fetchNetwork() async -> EthereumNetwork? {
-        do {
-            return try await net_version()
-        } catch {
-            logger.warning("Client has no network: \(error.localizedDescription)")
-        }
-
-        return nil
     }
 
     func failureHandler(_ error: Error) -> EthereumClientError {

--- a/web3swift/src/Client/HTTP/EthereumHttpClient.swift
+++ b/web3swift/src/Client/HTTP/EthereumHttpClient.swift
@@ -17,7 +17,7 @@ public class EthereumHttpClient: BaseEthereumClient {
         url: URL,
         sessionConfig: URLSessionConfiguration = URLSession.shared.configuration,
         logger: Logger? = nil,
-        network: EthereumNetwork? = nil
+        network: EthereumNetwork
     ) {
         let networkQueue = OperationQueue()
         networkQueue.name = "web3swift.client.networkQueue"

--- a/web3swift/src/Client/Protocols/EthereumClientProtocol.swift
+++ b/web3swift/src/Client/Protocols/EthereumClientProtocol.swift
@@ -14,8 +14,6 @@ public enum CallResolution {
 //  MARK: EthereumClient (HTTP or Websocket)
 
 public protocol EthereumClientProtocol: EthereumRPCProtocol, AnyObject {
-    var network: EthereumNetwork? { get }
-
     // Legacy result-based API
     func net_version(completionHandler: @escaping (Result<EthereumNetwork, EthereumClientError>) -> Void)
     func eth_gasPrice(completionHandler: @escaping (Result<BigUInt, EthereumClientError>) -> Void)

--- a/web3swift/src/Client/Protocols/EthereumProvider.swift
+++ b/web3swift/src/Client/Protocols/EthereumProvider.swift
@@ -28,7 +28,7 @@ public enum EthereumClientError: Error, Equatable {
 
 public protocol EthereumRPCProtocol: AnyObject {
     var networkProvider: NetworkProviderProtocol { get }
-    var network: EthereumNetwork? { get }
+    var network: EthereumNetwork { get }
 
     func eth_getTransactionCount(address: EthereumAddress, block: EthereumBlock) async throws -> Int
     func net_version() async throws -> EthereumNetwork
@@ -179,7 +179,7 @@ extension EthereumRPCProtocol {
             var transaction = transaction
             transaction.nonce = nonce
 
-            if transaction.chainId == nil, let network = network {
+            if transaction.chainId == nil {
                 transaction.chainId = network.intValue
             }
 

--- a/web3swift/src/Client/WSS/EthereumWebSocketClient.swift
+++ b/web3swift/src/Client/WSS/EthereumWebSocketClient.swift
@@ -56,7 +56,7 @@
             configuration: WebSocketConfiguration = .init(),
             sessionConfig: URLSessionConfiguration = URLSession.shared.configuration,
             logger: Logger? = nil,
-            network: EthereumNetwork? = nil
+            network: EthereumNetwork
         ) {
             let networkQueue = OperationQueue()
             networkQueue.name = "web3swift.client.networkQueue"

--- a/web3swift/src/ENS/ENSMultiResolver.swift
+++ b/web3swift/src/ENS/ENSMultiResolver.swift
@@ -93,6 +93,10 @@ extension EthereumNameService {
             self.multicall = Multicall(client: client)
         }
 
+        private var network: EthereumNetwork {
+            client.network
+        }
+
         func resolve(addresses: [EthereumAddress]) async throws -> [AddressResolveOutput] {
             let output = RegistryOutput<AddressResolveOutput>(expectedResponsesCount: addresses.count)
 
@@ -154,7 +158,7 @@ extension EthereumNameService {
             parameters: [ENSRegistryResolverParameter],
             handler: @escaping (Int, ENSRegistryResolverParameter, Result<EthereumAddress, Multicall.CallError>) -> Void
         ) async throws {
-            guard let network = client.network, let ensRegistryAddress = registryAddress ?? ENSContracts.registryAddress(for: network) else {
+            guard let ensRegistryAddress = registryAddress ?? ENSContracts.registryAddress(for: network) else {
                 throw EthereumNameServiceError.noNetwork
             }
 

--- a/web3swift/src/ENS/EthereumNameService.swift
+++ b/web3swift/src/ENS/EthereumNameService.swift
@@ -66,9 +66,12 @@ public class EthereumNameService: EthereumNameServiceProtocol {
         self.maximumRedirections = maximumRedirections
     }
 
+    private var network: EthereumNetwork {
+        client.network
+    }
+
     public func resolve(address: EthereumAddress, mode: ResolutionMode) async throws -> String {
-        guard let network = client.network,
-              let registryAddress = registryAddress ?? ENSContracts.registryAddress(for: network) else {
+        guard let registryAddress = registryAddress ?? ENSContracts.registryAddress(for: network) else {
             throw EthereumNameServiceError.noNetwork
         }
 
@@ -87,8 +90,7 @@ public class EthereumNameService: EthereumNameServiceProtocol {
     }
 
     public func resolve(ens: String, mode: ResolutionMode) async throws -> EthereumAddress {
-        guard let network = client.network,
-              let registryAddress = registryAddress ?? ENSContracts.registryAddress(for: network) else {
+        guard let registryAddress = registryAddress ?? ENSContracts.registryAddress(for: network) else {
             throw EthereumNameServiceError.noNetwork
         }
         do {

--- a/web3swift/src/Multicall/Multicall.swift
+++ b/web3swift/src/Multicall/Multicall.swift
@@ -15,8 +15,12 @@ public struct Multicall {
         self.client = client
     }
 
+    private var network: EthereumNetwork {
+        client.network
+    }
+
     public func aggregate(calls: [Call]) async throws -> MulticallResponse {
-        guard let network = client.network, let contract = Contract.registryAddress(for: network) else {
+        guard let contract = Contract.registryAddress(for: network) else {
             throw MulticallError.contractUnavailable
         }
 

--- a/web3swift/src/SIWE/SiweVerifier.swift
+++ b/web3swift/src/SIWE/SiweVerifier.swift
@@ -62,7 +62,7 @@ public class SiweVerifier {
             }
         }
 
-        guard message.chainId == client.network?.intValue else {
+        guard message.chainId == client.network.intValue else {
             throw Error.differentNetwork
         }
 

--- a/web3swift/src/ZKSync/ZKSyncProvider.swift
+++ b/web3swift/src/ZKSync/ZKSyncProvider.swift
@@ -26,7 +26,7 @@ extension ZKSyncClientProtocol {
         var transaction = transaction
         transaction.nonce = nonce
 
-        if transaction.chainId == nil, let network = self.network {
+        if transaction.chainId == nil {
             transaction.chainId = network.intValue
         }
 
@@ -135,7 +135,7 @@ public class ZKSyncClient: BaseEthereumClient, ZKSyncClientProtocol {
         url: URL,
         sessionConfig: URLSessionConfiguration = URLSession.shared.configuration,
         logger: Logger? = nil,
-        network: EthereumNetwork? = nil
+        network: EthereumNetwork
     ) {
         let networkQueue = OperationQueue()
         networkQueue.name = "web3swift.client.networkQueue"


### PR DESCRIPTION
Using semaphores across Structured Concurrency Tasks is not safe, so need to remove it here