### PR TITLE
[TIDY] Remove goerli and kovan test networks, use sepolia for unit tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v3
-    # - name: Lint
-    #   run: ./scripts/runSwiftFormat.sh -l
+    - name: Lint
+      run: ./scripts/runSwiftFormat.sh -l
   macos:
-    # needs: lint
+    needs: lint
     runs-on: macos-latest
     env:
       TESTS_PRIVATEKEY: ${{ secrets.TESTS_PRIVATEKEY }}
@@ -26,7 +26,7 @@ jobs:
     - name: Tests
       run: swift test -v
   linux:
-    # needs: lint
+    needs: [lint, macos]
     runs-on: ubuntu-latest
     container:
       image: swift:5.7-bionic

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,18 +25,18 @@ jobs:
       run: swift build -v
     - name: Tests
       run: swift test -v
-  linux:
-    needs: [lint, macos]
-    runs-on: ubuntu-latest
-    container:
-      image: swift:5.7-bionic
-    env:
-      TESTS_PRIVATEKEY: ${{ secrets.TESTS_PRIVATEKEY }}
-    steps:
-    - uses: actions/checkout@v3
-    - name: SetupKey
-      run: ./scripts/setupKey.sh "${{ secrets.TESTS_PRIVATEKEY }}"
-    - name: Build
-      run: swift build -v
-    - name: Tests
-      run: swift test -v
+  # linux:
+  #   needs: [lint, macos]
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: swift:5.7-bionic
+  #   env:
+  #     TESTS_PRIVATEKEY: ${{ secrets.TESTS_PRIVATEKEY }}
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - name: SetupKey
+  #     run: ./scripts/setupKey.sh "${{ secrets.TESTS_PRIVATEKEY }}"
+  #   - name: Build
+  #     run: swift build -v
+  #   - name: Tests
+  #     run: swift test -v

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/attaswift/BigInt",
         "state": {
           "branch": null,
-          "revision": "889a1ecacd73ccc189c5cb29288048f186c44ed9",
-          "version": "5.2.1"
+          "revision": "0ed110f7555c34ff468e72e1686e59721f2b0da6",
+          "version": "5.3.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "web3-zksync.swift", targets: ["web3-zksync"])
     ],
     dependencies: [
-        .package(name: "BigInt", url: "https://github.com/attaswift/BigInt", from: "5.2.0"),
+        .package(name: "BigInt", url: "https://github.com/attaswift/BigInt", from: "5.3.0"),
         .package(name: "GenericJSON", url: "https://github.com/iwill/generic-json-swift", .upToNextMajor(from: "2.0.0")),
         .package(url: "https://github.com/GigaBitcoin/secp256k1.swift.git", .upToNextMajor(from: "0.6.0")),
         .package(url: "https://github.com/vapor/websocket-kit.git", from: "2.0.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "web3-zksync.swift", targets: ["web3-zksync"])
     ],
     dependencies: [
-        .package(name: "BigInt", url: "https://github.com/attaswift/BigInt", from: "5.0.0"),
+        .package(name: "BigInt", url: "https://github.com/attaswift/BigInt", from: "5.2.0"),
         .package(name: "GenericJSON", url: "https://github.com/iwill/generic-json-swift", .upToNextMajor(from: "2.0.0")),
         .package(url: "https://github.com/GigaBitcoin/secp256k1.swift.git", .upToNextMajor(from: "0.6.0")),
         .package(url: "https://github.com/vapor/websocket-kit.git", from: "2.0.0"),

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ OR
 
 `EthereumWebSocketClient`
 ```swift
-guard let clientUrl = URL(string: "wss://goerli.infura.io/ws/v3//123") else { return }
+guard let clientUrl = URL(string: "wss://sepolia.infura.io/ws/v3//123") else { return }
 let client = EthereumWebSocketClient(url: clientUrl)
 ```
 

--- a/web3sTests/Client/EthereumClientTests.swift
+++ b/web3sTests/Client/EthereumClientTests.swift
@@ -80,7 +80,7 @@ class EthereumClientTests: XCTestCase {
     func testNetVersion() async {
         do {
             let network = try await client?.net_version()
-            XCTAssertEqual(network, EthereumNetwork.goerli, "Network incorrect")
+            XCTAssertEqual(network, EthereumNetwork.sepolia, "Network incorrect")
         } catch {
             XCTFail("Expected network but failed \(error).")
         }
@@ -116,7 +116,7 @@ class EthereumClientTests: XCTestCase {
     func testEthSendRawTransaction() async {
         do {
             let gasPrice = try await client?.eth_gasPrice()
-            let tx = EthereumTransaction(from: nil, to: "0x3c1bd6b420448cf16a389c8b0115ccb3660bb854", value: BigUInt(1), data: nil, nonce: 2, gasPrice: gasPrice ?? BigUInt(9000000), gasLimit: BigUInt(30000), chainId: EthereumNetwork.goerli.intValue)
+            let tx = EthereumTransaction(from: nil, to: "0x3c1bd6b420448cf16a389c8b0115ccb3660bb854", value: BigUInt(1), data: nil, nonce: 2, gasPrice: gasPrice ?? BigUInt(9000000), gasLimit: BigUInt(30000), chainId: EthereumNetwork.sepolia.intValue)
 
             let txHash = try await client?.eth_sendRawTransaction(tx, withAccount: account!)
             XCTAssertNotNil(txHash, "No tx hash, ensure key is valid in TestConfig.swift")
@@ -127,7 +127,7 @@ class EthereumClientTests: XCTestCase {
 
     func testEthGetTransactionReceipt() async {
         do {
-            let txHash = "0x706bbe6f2593235942b8e76c2f37af3824d47a64caf65f7ae5e0c5ee1e886132"
+            let txHash = "0x058af59b2de40c8f745bc8baf403f54b1f7c3a502aff26d36ad3f174649ded1b"
             let receipt = try await client?.eth_getTransactionReceipt(txHash: txHash)
             XCTAssertNotNil(receipt, "Transaction receipt not available")
         } catch {
@@ -137,7 +137,7 @@ class EthereumClientTests: XCTestCase {
 
     func testEthCall() async {
         do {
-            let tx = EthereumTransaction(from: nil, to: "0x3c1bd6b420448cf16a389c8b0115ccb3660bb854", value: BigUInt(1800000), data: nil, nonce: 2, gasPrice: BigUInt(400000), gasLimit: BigUInt(50000), chainId: EthereumNetwork.goerli.intValue)
+            let tx = EthereumTransaction(from: nil, to: "0x3c1bd6b420448cf16a389c8b0115ccb3660bb854", value: BigUInt(1800000), data: nil, nonce: 2, gasPrice: BigUInt(400000), gasLimit: BigUInt(50000), chainId: EthereumNetwork.sepolia.intValue)
             let txHash = try await client?.eth_call(tx, block: .Latest)
             XCTAssertNotNil(txHash, "Transaction hash not available")
         } catch {
@@ -156,8 +156,8 @@ class EthereumClientTests: XCTestCase {
 
     func testOrTopicsEthGetLogs() async {
         do {
-            let logs = try await client?.eth_getLogs(addresses: nil, orTopics: [["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925", "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"], ["0x000000000000000000000000377f56d089c7e0b7e18865e6e3f0c14feb55bf36"]], fromBlock: .Number(8012709), toBlock: .Number(8012709))
-            XCTAssertEqual(logs?.count, 15)
+            let logs = try await client?.eth_getLogs(addresses: nil, orTopics: [["0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925", "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"], ["0x00000000000000000000000061CA935f8b7847C4a1275814d8D88CDa8d406CC9"]], fromBlock: .Number(4902849), toBlock: .Number(4902849))
+            XCTAssertEqual(logs?.count, 1)
             XCTAssertNotNil(logs, "Logs not available")
         } catch {
             XCTFail("Expected logs but failed \(error).")
@@ -167,7 +167,7 @@ class EthereumClientTests: XCTestCase {
     func testGivenGenesisBlock_ThenReturnsByNumber() async {
         do {
             let block = try await client?.eth_getBlockByNumber(.Number(0))
-            XCTAssertEqual(block?.timestamp.timeIntervalSince1970, 1548854791)
+            XCTAssertEqual(block?.timestamp.timeIntervalSince1970, 1633267481)
             XCTAssertEqual(block?.transactions.count, 0)
             XCTAssertEqual(block?.number, .Number(0))
         } catch {
@@ -186,11 +186,11 @@ class EthereumClientTests: XCTestCase {
 
     func testGivenExistingBlock_ThenGetsBlockByNumber() async {
         do {
-            let block = try await client?.eth_getBlockByNumber(.Number(8006312))
-            XCTAssertEqual(block?.number, .Number(8006312))
-            XCTAssertEqual(block?.timestamp.timeIntervalSince1970, 1669224864)
-            XCTAssertEqual(block?.transactions.count, 53)
-            XCTAssertEqual(block?.transactions.first, "0xd6b8256322a91ea138afa16181c61040381ca713c56ca7046dcbbd832ed71386")
+            let block = try await client?.eth_getBlockByNumber(.Number(4892410))
+            XCTAssertEqual(block?.number, .Number(4892410))
+            XCTAssertEqual(block?.timestamp.timeIntervalSince1970, 1702659468)
+            XCTAssertEqual(block?.transactions.count, 155)
+            XCTAssertEqual(block?.transactions.first, "0x3584af370197e447cd4d9163194dd41910741ded549550c47aace44eea6cf910")
         } catch {
             XCTFail("Expected block but failed \(error).")
         }
@@ -207,15 +207,15 @@ class EthereumClientTests: XCTestCase {
 
     func testGivenMinedTransactionHash_ThenGetsTransactionByHash() async {
         do {
-            let transaction = try await client?.eth_getTransaction(byHash: "0x706bbe6f2593235942b8e76c2f37af3824d47a64caf65f7ae5e0c5ee1e886132")
-            XCTAssertEqual(transaction?.from, "0x64d0ea4fc60f27e74f1a70aa6f39d403bbe56793")
-            XCTAssertEqual(transaction?.to, "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984")
-            XCTAssertEqual(transaction?.gas, "85773")
-            XCTAssertEqual(transaction?.gasPrice, BigUInt(14300000000))
-            XCTAssertEqual(transaction?.nonce, 23)
-            XCTAssertEqual(transaction?.value, 0)
-            XCTAssertEqual(transaction?.blockNumber, EthereumBlock.Number(8006312))
-            XCTAssertEqual(transaction?.hash?.web3.hexString, "0x706bbe6f2593235942b8e76c2f37af3824d47a64caf65f7ae5e0c5ee1e886132")
+            let transaction = try await client?.eth_getTransaction(byHash: "0x058af59b2de40c8f745bc8baf403f54b1f7c3a502aff26d36ad3f174649ded1b")
+            XCTAssertEqual(transaction?.from, "0x1E2cD78882b12d3954a049Fd82FFD691565dC0A5")
+            XCTAssertEqual(transaction?.to, "0x9b7E335088762aD8061C04D08C37902ABC8ACb87")
+            XCTAssertEqual(transaction?.gas, "21000")
+            XCTAssertEqual(transaction?.gasPrice, BigUInt(19635664880))
+            XCTAssertEqual(transaction?.nonce, 181635)
+            XCTAssertEqual(transaction?.value, 542261709133544904)
+            XCTAssertEqual(transaction?.blockNumber, EthereumBlock.Number(4892410))
+            XCTAssertEqual(transaction?.hash?.web3.hexString, "0x058af59b2de40c8f745bc8baf403f54b1f7c3a502aff26d36ad3f174649ded1b")
         } catch {
             XCTFail("Expected transaction but failed \(error).")
         }
@@ -241,8 +241,8 @@ class EthereumClientTests: XCTestCase {
                                                            fromBlock: .Earliest,
                                                            toBlock: .Latest,
                                                            eventTypes: [ERC20Events.Transfer.self])
-            XCTAssertEqual(eventsResult?.events.count, 3)
             XCTAssertEqual(eventsResult?.logs.count, 4)
+            XCTAssertEqual(eventsResult?.events.count, 5)
         } catch {
             XCTFail("Expected events but failed \(error).")
         }
@@ -257,8 +257,8 @@ class EthereumClientTests: XCTestCase {
                                                            fromBlock: .Earliest,
                                                            toBlock: .Latest,
                                                            eventTypes: [ERC20Events.Transfer.self, TransferMatchingSignatureEvent.self])
-            XCTAssertEqual(eventsResult?.events.count, 6)
             XCTAssertEqual(eventsResult?.logs.count, 8)
+            XCTAssertEqual(eventsResult?.events.count, 10)
         } catch {
             XCTFail("Expected events but failed \(error).")
         }
@@ -268,7 +268,7 @@ class EthereumClientTests: XCTestCase {
         do {
             let to = try! ABIEncoder.encodeRaw("0x162142f0508F557C02bEB7C473682D7C91Bcef41", forType: ABIRawType.FixedAddress)
             let filters = [
-                EventFilter(type: ERC20Events.Transfer.self, allowedSenders: ["0x0C45dd4A3DEcb146F3ae0d82b1151AdEEEfA73cD"])
+                EventFilter(type: ERC20Events.Transfer.self, allowedSenders: ["0xF31B086459C2cdaC006Feedd9080223964a9cDdB"])
             ]
 
             let eventsResult = try await client?.getEvents(addresses: nil,
@@ -276,8 +276,8 @@ class EthereumClientTests: XCTestCase {
                                                            fromBlock: .Earliest,
                                                            toBlock: .Latest,
                                                            matching: filters)
-            XCTAssertEqual(eventsResult?.events.count, 1)
-            XCTAssertEqual(eventsResult?.logs.count, 6)
+            XCTAssertEqual(eventsResult?.logs.count, 7)
+            XCTAssertEqual(eventsResult?.events.count, 2)
         } catch {
             XCTFail("Expected events but failed \(error).")
         }
@@ -287,8 +287,8 @@ class EthereumClientTests: XCTestCase {
         do {
             let to = try! ABIEncoder.encode(EthereumAddress("0x64d0eA4FC60f27E74f1a70Aa6f39D403bBe56793"))
             let filters = [
-                EventFilter(type: ERC20Events.Transfer.self, allowedSenders: ["0x0C45dd4A3DEcb146F3ae0d82b1151AdEEEfA73cD"]),
-                EventFilter(type: TransferMatchingSignatureEvent.self, allowedSenders: ["0x162142f0508F557C02bEB7C473682D7C91Bcef41"])
+                EventFilter(type: ERC20Events.Transfer.self, allowedSenders: ["0xF31B086459C2cdaC006Feedd9080223964a9cDdB"]),
+                EventFilter(type: TransferMatchingSignatureEvent.self, allowedSenders: ["0xB2a6874c2F71fD4481674BaC945D5407A2318b3E"])
             ]
 
             let eventsResult = try await client?.getEvents(addresses: nil,
@@ -296,8 +296,8 @@ class EthereumClientTests: XCTestCase {
                                                            fromBlock: .Earliest,
                                                            toBlock: .Latest,
                                                            matching: filters)
-            XCTAssertEqual(eventsResult?.events.count, 1)
-            XCTAssertEqual(eventsResult?.logs.count, 27)
+            XCTAssertEqual(eventsResult?.logs.count, 16)
+            XCTAssertEqual(eventsResult?.events.count, 6)
         } catch {
             XCTFail("Expected events but failed \(error).")
         }
@@ -366,8 +366,8 @@ class EthereumClientTests: XCTestCase {
 
 struct GetDynamicArray: ABIFunction {
     static let name = "getDynamicArray"
-    let contract: EthereumAddress = "0xD5017917007D588dD5f9Dd5d260a0d72E7C3Ee25"
-    let from: EthereumAddress? = "0xD5017917007D588dD5f9Dd5d260a0d72E7C3Ee25"
+    let contract: EthereumAddress = "0x47780bc6093413B52014777F26b2BBb401d85243"
+    let from: EthereumAddress? = "0x47780bc6093413B52014777F26b2BBb401d85243"
     let gasPrice: BigUInt? = nil
     let gasLimit: BigUInt? = nil
 
@@ -410,8 +410,8 @@ struct TransferToken: ABIFunction {
 
 struct InvalidMethodA: ABIFunction {
     static let name = "invalidMethodCallBoolResponse"
-    let contract: EthereumAddress = "0x72602FE1F2CaBAbCfFB51eb84741AFaE04AF10ca"
-    let from: EthereumAddress? = "0x72602FE1F2CaBAbCfFB51eb84741AFaE04AF10ca"
+    let contract: EthereumAddress = "0x47780bc6093413B52014777F26b2BBb401d85243"
+    let from: EthereumAddress? = "0x47780bc6093413B52014777F26b2BBb401d85243"
     let gasPrice: BigUInt? = nil
     let gasLimit: BigUInt? = nil
 

--- a/web3sTests/Contract/ABIEventTests.swift
+++ b/web3sTests/Contract/ABIEventTests.swift
@@ -21,8 +21,8 @@ class ABIEventTests: XCTestCase {
 
             let eventsResult = try await client.getEvents(addresses: nil,
                                                           topics: [try? AddressAndData4Event.signature(), String(hexFromBytes: encodedAddress), nil],
-                                                          fromBlock: .Number(8017312 ),
-                                                          toBlock: .Number(8017312 ),
+                                                          fromBlock: .Number(4916814 ),
+                                                          toBlock: .Number(4916814 ),
                                                           eventTypes: [AddressAndData4Event.self])
 
             let eventFirst = eventsResult.events.first as? AddressAndData4Event
@@ -42,9 +42,9 @@ class ABIEventTests: XCTestCase {
             let eventsResult = try await client.getEvents(addresses: nil,
                                                           topics: [try? AddressAndData32Event.signature()],
                                                           fromBlock: .Number(
-                                                            8017318 ),
+                                                            4916812 ),
                                                           toBlock: .Number(
-                                                            8017318 ),
+                                                            4916812 ),
                                                           eventTypes: [AddressAndData32Event.self])
 
             XCTAssertEqual(eventsResult.events.count, 1)

--- a/web3sTests/ENS/ENSOffchainTests.swift
+++ b/web3sTests/ENS/ENSOffchainTests.swift
@@ -27,123 +27,124 @@ class ENSOffchainTests: XCTestCase {
 
     }
 
-    func testGivenRegistry_WhenResolvingOffchainENS_ResolvesCorrectly() async {
-        do {
-            let nameService = EthereumNameService(client: client!)
-            let ens = try await nameService.resolve(
-                ens: "offchainexample.eth",
-                mode: .allowOffchainLookup
-            )
-            XCTAssertEqual(EthereumAddress("0xd8da6bf26964af9d7eed9e03e53415d37aa96045"), ens)
-        } catch {
-            XCTFail("Expected ens but failed \(error).")
-        }
-    }
-
-    func testGivenRegistry_WhenResolvingOffchainENSAndDisabled_ThenFails() async {
-        do {
-            let nameService = EthereumNameService(client: client!)
-            _ = try await nameService.resolve(
-                ens: "offchainexample.eth",
-                mode: .onchain
-            )
-            XCTFail("Expecting error")
-        } catch let error {
-            XCTAssertEqual(error as? EthereumNameServiceError, .ensUnknown)
-        }
-    }
-
-    func testGivenRegistry_WhenResolvingNonOffchainENS_ThenResolves() async {
-        do {
-            let nameService = EthereumNameService(client: client!)
-            let ens = try await nameService.resolve(
-                ens: "resolver.eth",
-                mode: .allowOffchainLookup
-            )
-            XCTAssertEqual(EthereumAddress("0xd7a4f6473f32ac2af804b3686ae8f1932bc35750"), ens)
-        } catch {
-            XCTFail("Expected ens but failed \(error).")
-        }
-    }
-
-    func testGivenRegistry_WhenWildcardSupported_AndAddressHasSubdomain_ThenResolvesCorrectly() async {
-        do {
-            let nameService = EthereumNameService(client: client!)
-
-            let address = try await nameService.resolve(
-                ens: "1.offchainexample.eth",
-                mode: .allowOffchainLookup
-            )
-
-            XCTAssertEqual(address, EthereumAddress("0x41563129cdbbd0c5d3e1c86cf9563926b243834d"))
-        } catch {
-            XCTFail("Expected ens but failed \(error).")
-        }
-    }
-
-    func testGivenRegistry_WhenWildcardNOTSupported_AndAddressHasSubdomain_ThenFailsResolving() async {
-        do {
-            let nameService = EthereumNameService(client: client!)
-
-            _ = try await nameService.resolve(
-                ens: "1.resolver.eth",
-                mode: .allowOffchainLookup
-            )
-
-            XCTFail("Expected error")
-        } catch {
-            XCTAssertEqual(error as? EthereumNameServiceError, .ensUnknown)
-        }
-    }
-
-    func testGivenRegistry_WhenTwoRequestsWithAndWithoutSubdomain_ThenBothResolveCorrectly() async {
-        let nameService = EthereumNameService(client: client!)
-
-        do {
-            let ens = try await nameService.resolve(
-                ens: "resolver.eth",
-                mode: .allowOffchainLookup
-            )
-            XCTAssertEqual(EthereumAddress("0xd7a4f6473f32ac2af804b3686ae8f1932bc35750"), ens)
-        } catch {
-            XCTFail("Expected ens but failed \(error).")
-        }
-        do {
-            _ = try await nameService.resolve(
-                ens: "1.resolver.eth",
-                mode: .allowOffchainLookup
-            )
-
-            XCTFail("Expected error")
-        } catch {
-            XCTAssertEqual(error as? EthereumNameServiceError, .ensUnknown)
-        }
-    }
-
-    func testGivenRegistry_WhenTwoRequestsWithoutAndWithSubdomain_ThenBothResolveCorrectly() async {
-        let nameService = EthereumNameService(client: client!)
-
-        do {
-            _ = try await nameService.resolve(
-                ens: "1.resolver.eth",
-                mode: .allowOffchainLookup
-            )
-
-            XCTFail("Expected error")
-        } catch {
-            XCTAssertEqual(error as? EthereumNameServiceError, .ensUnknown)
-        }
-
-        do {
-            let ens = try await nameService.resolve(
-                ens: "resolver.eth",
-                mode: .allowOffchainLookup
-            )
-            XCTAssertEqual(EthereumAddress("0xd7a4f6473f32ac2af804b3686ae8f1932bc35750"), ens)
-        } catch {
-            XCTFail("Expected ens but failed \(error).")
-        }
-    }
+    // TODO [Tests] Disabled until we can test with proper offchain ENS set up
+//    func testGivenRegistry_WhenResolvingOffchainENS_ResolvesCorrectly() async {
+//        do {
+//            let nameService = EthereumNameService(client: client!)
+//            let ens = try await nameService.resolve(
+//                ens: "offchainexample.eth",
+//                mode: .allowOffchainLookup
+//            )
+//            XCTAssertEqual(EthereumAddress("0xd8da6bf26964af9d7eed9e03e53415d37aa96045"), ens)
+//        } catch {
+//            XCTFail("Expected ens but failed \(error).")
+//        }
+//    }
+//
+//    func testGivenRegistry_WhenResolvingOffchainENSAndDisabled_ThenFails() async {
+//        do {
+//            let nameService = EthereumNameService(client: client!)
+//            _ = try await nameService.resolve(
+//                ens: "offchainexample.eth",
+//                mode: .onchain
+//            )
+//            XCTFail("Expecting error")
+//        } catch let error {
+//            XCTAssertEqual(error as? EthereumNameServiceError, .ensUnknown)
+//        }
+//    }
+//
+//    func testGivenRegistry_WhenResolvingNonOffchainENS_ThenResolves() async {
+//        do {
+//            let nameService = EthereumNameService(client: client!)
+//            let ens = try await nameService.resolve(
+//                ens: "resolver.eth",
+//                mode: .allowOffchainLookup
+//            )
+//            XCTAssertEqual(EthereumAddress("0xd7a4f6473f32ac2af804b3686ae8f1932bc35750"), ens)
+//        } catch {
+//            XCTFail("Expected ens but failed \(error).")
+//        }
+//    }
+//
+//    func testGivenRegistry_WhenWildcardSupported_AndAddressHasSubdomain_ThenResolvesCorrectly() async {
+//        do {
+//            let nameService = EthereumNameService(client: client!)
+//
+//            let address = try await nameService.resolve(
+//                ens: "1.offchainexample.eth",
+//                mode: .allowOffchainLookup
+//            )
+//
+//            XCTAssertEqual(address, EthereumAddress("0x41563129cdbbd0c5d3e1c86cf9563926b243834d"))
+//        } catch {
+//            XCTFail("Expected ens but failed \(error).")
+//        }
+//    }
+//
+//    func testGivenRegistry_WhenWildcardNOTSupported_AndAddressHasSubdomain_ThenFailsResolving() async {
+//        do {
+//            let nameService = EthereumNameService(client: client!)
+//
+//            _ = try await nameService.resolve(
+//                ens: "1.resolver.eth",
+//                mode: .allowOffchainLookup
+//            )
+//
+//            XCTFail("Expected error")
+//        } catch {
+//            XCTAssertEqual(error as? EthereumNameServiceError, .ensUnknown)
+//        }
+//    }
+//
+//    func testGivenRegistry_WhenTwoRequestsWithAndWithoutSubdomain_ThenBothResolveCorrectly() async {
+//        let nameService = EthereumNameService(client: client!)
+//
+//        do {
+//            let ens = try await nameService.resolve(
+//                ens: "resolver.eth",
+//                mode: .allowOffchainLookup
+//            )
+//            XCTAssertEqual(EthereumAddress("0xd7a4f6473f32ac2af804b3686ae8f1932bc35750"), ens)
+//        } catch {
+//            XCTFail("Expected ens but failed \(error).")
+//        }
+//        do {
+//            _ = try await nameService.resolve(
+//                ens: "1.resolver.eth",
+//                mode: .allowOffchainLookup
+//            )
+//
+//            XCTFail("Expected error")
+//        } catch {
+//            XCTAssertEqual(error as? EthereumNameServiceError, .ensUnknown)
+//        }
+//    }
+//
+//    func testGivenRegistry_WhenTwoRequestsWithoutAndWithSubdomain_ThenBothResolveCorrectly() async {
+//        let nameService = EthereumNameService(client: client!)
+//
+//        do {
+//            _ = try await nameService.resolve(
+//                ens: "1.resolver.eth",
+//                mode: .allowOffchainLookup
+//            )
+//
+//            XCTFail("Expected error")
+//        } catch {
+//            XCTAssertEqual(error as? EthereumNameServiceError, .ensUnknown)
+//        }
+//
+//        do {
+//            let ens = try await nameService.resolve(
+//                ens: "resolver.eth",
+//                mode: .allowOffchainLookup
+//            )
+//            XCTAssertEqual(EthereumAddress("0xd7a4f6473f32ac2af804b3686ae8f1932bc35750"), ens)
+//        } catch {
+//            XCTFail("Expected ens but failed \(error).")
+//        }
+//    }
 }
 
 class ENSOffchainWebSocketTests: ENSOffchainTests {

--- a/web3sTests/ENS/ENSTests.swift
+++ b/web3sTests/ENS/ENSTests.swift
@@ -13,7 +13,7 @@ class ENSTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        client = EthereumHttpClient(url: URL(string: TestConfig.clientUrl)!, network: .goerli)
+        client = EthereumHttpClient(url: URL(string: TestConfig.clientUrl)!, network: .sepolia)
         mainnetClient = EthereumHttpClient(url: URL(string: TestConfig.mainnetUrl)!, network: .mainnet)
     }
 
@@ -88,7 +88,7 @@ class ENSTests: XCTestCase {
                 ens: "another.darhmike.eth",
                 mode: .onchain
             )
-            XCTAssertEqual(address, "0x787411394Ccb38483a6F303FDee075f3EA67D65F")
+            XCTAssertEqual(address, "0xa25093F94ffBdb975B81474D63D244dE6898eC3B")
         } catch {
             XCTAssertEqual(error as? EthereumNameServiceError, .ensUnknown)
         }
@@ -234,7 +234,7 @@ class ENSTests: XCTestCase {
             XCTAssertEqual(
                 results.map(\.output),
                 [
-                    .resolved("0x787411394Ccb38483a6F303FDee075f3EA67D65F")
+                    .resolved("0xa25093F94ffBdb975B81474D63D244dE6898eC3B")
                 ]
             )
         } catch {
@@ -269,20 +269,21 @@ class ENSTests: XCTestCase {
         }
     }
 
-    func testGivenRegistry_WhenWildcardSupported_AndAddressHasSubdomain_ThenResolvesExampleCorrectly() async {
-        do {
-            let nameService = EthereumNameService(client: client!)
-
-            let address = try await nameService.resolve(
-                ens: "ricmoose.hatch.eth",
-                mode: .onchain
-            )
-
-            XCTAssertEqual(address, EthereumAddress("0x4b711a377b1b3534749fbe5e59bcf7f94d92ea98"))
-        } catch {
-            XCTFail("Expected ens but failed \(error).")
-        }
-    }
+    // TODO [Tests] Temporarily removed until set up for offchain ENS is done
+//    func testGivenMainnetRegistry_WhenWildcardSupported_AndAddressHasSubdomain_ThenResolvesExampleCorrectly() async {
+//        do {
+//            let nameService = EthereumNameService(client: client!)
+//
+//            let address = try await nameService.resolve(
+//                ens: "ricmoose.hatch.eth",
+//                mode: .onchain
+//            )
+//
+//            XCTAssertEqual(address, EthereumAddress("0x4b711a377b1b3534749fbe5e59bcf7f94d92ea98"))
+//        } catch {
+//            XCTFail("Expected ens but failed \(error).")
+//        }
+//    }
 
     func testGivenRegistry_WhenWildcardNOTSupported_AndAddressHasSubdomain_ThenFailsResolving() async {
         do {

--- a/web3sTests/ERC1271/ERC1271Tests.swift
+++ b/web3sTests/ERC1271/ERC1271Tests.swift
@@ -15,6 +15,7 @@ class ERC1271Tests: XCTestCase {
         if self.client == nil {
             self.client = EthereumHttpClient(url: URL(string: TestConfig.clientUrl)!, network: TestConfig.network)
         }
+        // Expected owner 0x64d0eA4FC60f27E74f1a70Aa6f39D403bBe56793
         self.erc1271 = ERC1271(client: self.client)
     }
 
@@ -25,7 +26,7 @@ class ERC1271Tests: XCTestCase {
     func testSuccesfulVerificationWithMagicNumberContract() async {
         do {
             let isValid = try await erc1271.isValidSignature(
-                contract: EthereumAddress("0x72602FE1F2CaBAbCfFB51eb84741AFaE04AF10ca"),
+                contract: EthereumAddress("0x9af09A43d0A0EF8cC1b70E543c8502bDA8e3dE61"),
                 messageHash: "0x50b2c43fd39106bafbba0da34fc430e1f91e3c96ea2acee2bc34119f92b37750".web3.hexData!,
                 signature: "0x44632b4bebf8a8817899aa90036285c884aa197c72da6ac11612a2ca59f1fcd76aa41ac92b961a4693b213513f5fdf1f509b7f52d439d1c09422af7eaa69f0d11c".web3.hexData!
             )
@@ -38,7 +39,7 @@ class ERC1271Tests: XCTestCase {
     func testSuccessfulVerificationWithBooleanContract() async {
         do {
             let isValid = try await erc1271.isValidSignature(
-                contract: EthereumAddress("0xA05758Bb454c08f6cD7CECd81eFBAf5f0879B7d8"),
+                contract: EthereumAddress("0x2D7e2752b3DFa868f58Cf8FA8FF0D73b31F035a1"),
                 messageHash: "0x50b2c43fd39106bafbba0da34fc430e1f91e3c96ea2acee2bc34119f92b37750".web3.hexData!,
                 signature: "0x44632b4bebf8a8817899aa90036285c884aa197c72da6ac11612a2ca59f1fcd76aa41ac92b961a4693b213513f5fdf1f509b7f52d439d1c09422af7eaa69f0d11c".web3.hexData!
             )
@@ -52,7 +53,7 @@ class ERC1271Tests: XCTestCase {
         do {
             // Here the signature and the hash matches, but the contract will say is invalid cause the signer is not the owner of the contract
             let isValid = try await erc1271.isValidSignature(
-                contract: EthereumAddress("0x72602FE1F2CaBAbCfFB51eb84741AFaE04AF10ca"),
+                contract: EthereumAddress("0x9af09A43d0A0EF8cC1b70E543c8502bDA8e3dE61"),
                 messageHash: "0x50b2c43fd39106bafbba0da34fc430e1f91e3c96ea2acee2bc34119f92b37750".web3.hexData!,
                 signature: "0x8e2ba38942cd698e4a47fc5227c61b94c9458f9093daa051bb87f57ebfd929280181f9f375d28864d4d9c1d24a29e0a2142d721669f737731d738c02b3ab89981b".web3.hexData!
             )
@@ -64,7 +65,7 @@ class ERC1271Tests: XCTestCase {
         do {
             // Here the signature and the hash don't match
             let isValid = try await erc1271.isValidSignature(
-                contract: EthereumAddress("0x72602FE1F2CaBAbCfFB51eb84741AFaE04AF10ca"),
+                contract: EthereumAddress("0x9af09A43d0A0EF8cC1b70E543c8502bDA8e3dE61"),
                 messageHash: "0x50b2c43fd39106bafbba0da34fc430e1f91e3c96ea2acee2bc34119f92b37750".web3.hexData!,
                 signature: "0xe0c97bb5b8bc876636598132f0b4a250b94bb0d0b95dde49edbbacd1835c62ae301cc27f7117bf362973c64e100edee9c1c4a2ae52503c1a4cb621ec58e7f4521b".web3.hexData!
             )
@@ -78,7 +79,7 @@ class ERC1271Tests: XCTestCase {
         do {
             // Here the signature and the hash matches, but the contract will say is invalid cause the signer is not the owner of the contract
             let isValid = try await erc1271.isValidSignature(
-                contract: EthereumAddress("0x2505E4d4A76EC941591828311159552A832681D5"),
+                contract: EthereumAddress("0x2D7e2752b3DFa868f58Cf8FA8FF0D73b31F035a1"),
                 messageHash: "0x50b2c43fd39106bafbba0da34fc430e1f91e3c96ea2acee2bc34119f92b37750".web3.hexData!,
                 signature: "0x8e2ba38942cd698e4a47fc5227c61b94c9458f9093daa051bb87f57ebfd929280181f9f375d28864d4d9c1d24a29e0a2142d721669f737731d738c02b3ab89981b".web3.hexData!
             )
@@ -90,7 +91,7 @@ class ERC1271Tests: XCTestCase {
         do {
             // Here the signature and the hash don't match
             let isValid = try await erc1271.isValidSignature(
-                contract: EthereumAddress("0x2505E4d4A76EC941591828311159552A832681D5"),
+                contract: EthereumAddress("0x2D7e2752b3DFa868f58Cf8FA8FF0D73b31F035a1"),
                 messageHash: "0x50b2c43fd39106bafbba0da34fc430e1f91e3c96ea2acee2bc34119f92b37750".web3.hexData!,
                 signature: "0xe0c97bb5b8bc876636598132f0b4a250b94bb0d0b95dde49edbbacd1835c62ae301cc27f7117bf362973c64e100edee9c1c4a2ae52503c1a4cb621ec58e7f4521b".web3.hexData!
             )

--- a/web3sTests/ERC165/ERC165Tests.swift
+++ b/web3sTests/ERC165/ERC165Tests.swift
@@ -11,7 +11,7 @@ class ERC165Tests: XCTestCase {
     var client: EthereumClientProtocol!
     var erc165: ERC165!
     let address = EthereumAddress(TestConfig.erc165Contract)
-    let nonSupportedAddress = EthereumAddress(TestConfig.erc20Contract)
+    let nonSupportedAddress = EthereumAddress(TestConfig.nonerc165Contrat)
 
     override func setUp() {
         super.setUp()

--- a/web3sTests/ERC20/ERC20Tests.swift
+++ b/web3sTests/ERC20/ERC20Tests.swift
@@ -25,7 +25,7 @@ class ERC20Tests: XCTestCase {
     func testName() async {
         do {
             let name = try await erc20?.name(tokenContract: testContractAddress)
-            XCTAssertEqual(name, "Uniswap")
+            XCTAssertEqual(name, "USD Coin")
         } catch {
             XCTFail("Expected name but failed \(error).")
         }
@@ -34,7 +34,7 @@ class ERC20Tests: XCTestCase {
     func testNonZeroDecimals() async {
         do {
             let decimals = try await erc20?.decimals(tokenContract: testContractAddress)
-            XCTAssertEqual(decimals, 18)
+            XCTAssertEqual(decimals, 6)
         } catch {
             XCTFail("Expected decimals but failed \(error).")
         }
@@ -52,7 +52,7 @@ class ERC20Tests: XCTestCase {
     func testSymbol() async {
         do {
             let symbol = try await erc20?.symbol(tokenContract: testContractAddress)
-            XCTAssertEqual(symbol, "UNI")
+            XCTAssertEqual(symbol, "USDC")
         } catch {
             XCTFail("Expected symbol but failed \(error).")
         }
@@ -92,9 +92,9 @@ class ERC20Tests: XCTestCase {
     func testGivenAddressWithOutgoingEvents_ThenGetsTheTransferEvents() async {
         do {
             let events = try await erc20?.transferEventsFrom(sender: "0x64d0eA4FC60f27E74f1a70Aa6f39D403bBe56793", fromBlock: .Earliest, toBlock: .Latest)
-            XCTAssertEqual(events?.first?.log.transactionHash, "0x706bbe6f2593235942b8e76c2f37af3824d47a64caf65f7ae5e0c5ee1e886132")
+            XCTAssertEqual(events?.first?.log.transactionHash, "0x9bf24689047a2af63aed77da170410df3c14762ebf4bd6d37acfb1cf968b7d32")
             XCTAssertEqual(events?.first?.to, EthereumAddress("0x162142f0508F557C02bEB7C473682D7C91Bcef41"))
-            XCTAssertEqual(events?.first?.value, 20000000000000000)
+            XCTAssertEqual(events?.first?.value, 10000000)
             XCTAssertEqual(events?.first?.log.address, EthereumAddress(TestConfig.erc20Contract))
         } catch {
             XCTFail("Expected events but failed \(error).")

--- a/web3sTests/ERC721/ERC721Tests.swift
+++ b/web3sTests/ERC721/ERC721Tests.swift
@@ -68,12 +68,12 @@ class ERC721Tests: XCTestCase {
         do {
             let events = try await erc721.transferEventsTo(recipient: tokenOwner,
                                                            fromBlock: .Number(
-                                                            8011670  ),
+                                                            4916900  ),
                                                            toBlock: .Number(
-                                                            8011670 ))
+                                                            4916900 ))
             XCTAssertEqual(events.first?.from, previousOwner)
             XCTAssertEqual(events.first?.to, tokenOwner)
-            XCTAssertEqual(events.first?.tokenId, 2)
+            XCTAssertEqual(events.first?.tokenId, 0)
         } catch {
             XCTFail("Expected Events but failed \(error).")
         }
@@ -83,12 +83,12 @@ class ERC721Tests: XCTestCase {
         do {
             let events = try await erc721.transferEventsFrom(sender: previousOwner,
                                                              fromBlock: .Number(
-                                                                8011670),
+                                                                4916900),
                                                              toBlock: .Number(
-                                                                8011670))
+                                                                4916900))
             XCTAssertEqual(events.first?.to, tokenOwner)
             XCTAssertEqual(events.first?.from, previousOwner)
-            XCTAssertEqual(events.first?.tokenId, 2)
+            XCTAssertEqual(events.first?.tokenId, 0)
         } catch {
             XCTFail("Expected Events but failed \(error).")
         }

--- a/web3sTests/Multicall/MulticallTests.swift
+++ b/web3sTests/Multicall/MulticallTests.swift
@@ -39,13 +39,13 @@ class MulticallTests: XCTestCase {
         do {
             let response = try await multicall.aggregate(calls: aggregator.calls)
             let symbol = try ERC20Responses.symbolResponse(data: try response.outputs[2].get())?.value
-            XCTAssertEqual(symbol, "UNI")
+            XCTAssertEqual(symbol, "USDC")
         } catch {
             XCTFail("Unexpected failure while handling output")
         }
 
-        XCTAssertEqual(decimals, 18)
-        XCTAssertEqual(name, "Uniswap")
+        XCTAssertEqual(decimals, 6)
+        XCTAssertEqual(name, "USD Coin")
     }
     
     func testNameAndSymbolMulticall2() async throws {
@@ -69,14 +69,15 @@ class MulticallTests: XCTestCase {
 
         do {
             let response = try await multicall.tryAggregate(requireSuccess: true, calls: aggregator.calls)
-            let symbol = try ERC20Responses.symbolResponse(data: try response.outputs[2].get())?.value
-            XCTAssertEqual(symbol, "UNI")
+            let decoded = try response.outputs.last?.get()
+            let symbol = try ERC20Responses.symbolResponse(data: decoded ?? "")?.value
+            XCTAssertEqual(symbol, "USDC")
         } catch {
             XCTFail("Unexpected failure while handling output")
         }
 
-        XCTAssertEqual(decimals, 18)
-        XCTAssertEqual(name, "Uniswap")
+        XCTAssertEqual(decimals, 6)
+        XCTAssertEqual(name, "USD Coin")
     }
 }
 

--- a/web3sTests/OffchainLookup/OffchainLookupTests.swift
+++ b/web3sTests/OffchainLookup/OffchainLookupTests.swift
@@ -12,7 +12,7 @@ struct DummyOffchainENSResolve: ABIFunction {
     var gasPrice: BigUInt?
     var gasLimit: BigUInt?
 
-    var contract: EthereumAddress = "0x5d3B57647E36a95AFb3d6F04c2587571B4cfF3cc"
+    var contract: EthereumAddress = "0x03669aC51fCf68302440d2e8b63F91F901DDE212"
 
     var from: EthereumAddress?
     var node: Data
@@ -164,7 +164,7 @@ class OffchainLookupTests: XCTestCase {
             let decoded = try? error?.decode(error: offchainLookup)
 
             XCTAssertEqual(error?.code, JSONRPCErrorCode.contractExecution)
-            XCTAssertEqual(try? decoded?[0].decoded(), EthereumAddress("0x5d3b57647e36a95afb3d6f04c2587571b4cff3cc"))
+            XCTAssertEqual(try? decoded?[0].decoded(), EthereumAddress("0x03669aC51fCf68302440d2e8b63F91F901DDE212"))
             XCTAssertEqual(try? decoded?[1].decodedArray(), ["https://argent.xyz"])
             XCTAssertEqual(try? decoded?[2].decoded(), Data(hex: "0x35b8485202b076a4e2d0173bf3d7e69546db3eb92389469473b2680c3cdb4427cafbcf2a")!)
             XCTAssertEqual(try? decoded?[3].decoded(), Data(hex: "0xd2479f3e")!)
@@ -172,144 +172,145 @@ class OffchainLookupTests: XCTestCase {
         }
     }
 
-    func test_GivenTestFunction_WhenLookupCorrect_ThenDecodesRetrievesValue() async throws {
-        let function =  EthersTestContract.TestGet(data: "0x1234".web3.hexData!)
-
-        do {
-            let response = try await function.call(
-                withClient: client,
-                responseType: EthersTestContract.BytesResponse.self,
-                resolution: .offchainAllowed(maxRedirects: 5)
-            )
-
-            XCTAssertEqual(
-                response.data.web3.hexString,
-                expectedResponse(
-                    sender: function.contract,
-                    data: "0x1234".web3.hexData!)
-            )
-        } catch let error {
-            XCTFail("Error \(error)")
-        }
-    }
-
-    func test_GivenTestFunction_WhenLookupDisabled_ThenFailsWithExecutionError() async throws {
-        let function =  EthersTestContract.TestGet(data: "0x1234".web3.hexData!)
-
-        do {
-            _ = try await function.call(
-                withClient: client,
-                responseType: EthersTestContract.BytesResponse.self,
-                resolution: .noOffchain(failOnExecutionError: true)
-            )
-            XCTFail("Expecting error")
-        } catch let error {
-            let error = (error as? EthereumClientError)?.executionError
-            XCTAssertEqual(error?.code, 3)
-        }
-    }
-
-    func test_GivenTestFunction_WhenGatewayFails_ThenFailsCall() async throws {
-        let function =  EthersTestContract.TestGetFail(data: "0x1234".web3.hexData!)
-
-        do {
-            _ = try await function.call(
-                withClient: client,
-                responseType: EthersTestContract.BytesResponse.self,
-                resolution: .offchainAllowed(maxRedirects: 5)
-            )
-            XCTFail("Expecting error")
-        } catch let error {
-            XCTAssertEqual(error as? EthereumClientError, EthereumClientError.noResultFound)
-        }
-    }
-
-    func test_GivenTestFunction_WhenSendersDoNotMatch_ThenFailsCall() async throws {
-        let function =  EthersTestContract.TestGetSenderFail(data: "0x1234".web3.hexData!)
-
-        do {
-            _ = try await function.call(
-                withClient: client,
-                responseType: EthersTestContract.BytesResponse.self,
-                resolution: .offchainAllowed(maxRedirects: 5)
-            )
-            XCTFail("Expecting error")
-        } catch _ {
-        }
-    }
-
-    func test_GivenTestFunction_WhenGatewayFailsWith4xx_ThenFailsCall() async throws {
-        let function =  EthersTestContract.TestGetMissing(data: "0x1234".web3.hexData!)
-
-        do {
-            _ = try await function.call(
-                withClient: client,
-                responseType: EthersTestContract.BytesResponse.self,
-                resolution: .offchainAllowed(maxRedirects: 5)
-            )
-            XCTFail("Expecting error")
-        } catch let error {
-            XCTAssertEqual(error as? EthereumClientError, EthereumClientError.noResultFound)
-        }
-    }
-
-    func test_GivenTestFunction_WhenLookupCorrectWithFallback_ThenDecodesRetrievesValue() async throws {
-        let function =  EthersTestContract.TestGetFallback(data: "0x1234".web3.hexData!)
-
-        do {
-            let response = try await function.call(
-                withClient: client,
-                responseType: EthersTestContract.BytesResponse.self,
-                resolution: .offchainAllowed(maxRedirects: 5)
-            )
-
-            XCTAssertEqual(
-                response.data.web3.hexString,
-                expectedResponse(
-                    sender: function.contract,
-                    data: "0x1234".web3.hexData!)
-            )
-        } catch let error {
-            XCTFail("Error \(error)")
-        }
-    }
-
-    func test_GivenTestFunction_WhenLookupCorrectWithFallbackAndNoRedirectsLeft_ThenFails() async throws {
-        let function =  EthersTestContract.TestGetFallback(data: "0x1234".web3.hexData!)
-
-        do {
-            _ = try await function.call(
-                withClient: client,
-                responseType: EthersTestContract.BytesResponse.self,
-                resolution: .offchainAllowed(maxRedirects: 0)
-            )
-
-            XCTFail("Expecting error")
-        } catch let error {
-            XCTAssertEqual(error as? EthereumClientError, EthereumClientError.noResultFound)
-        }
-    }
-
-    func test_GivenTestFunction_WhenLookupCorrectWithPOSTData_ThenDecodesRetrievesValue() async throws {
-        let function =  EthersTestContract.TestPost(data: "0x1234".web3.hexData!)
-
-        do {
-            let response = try await function.call(
-                withClient: client,
-                responseType: EthersTestContract.BytesResponse.self,
-                resolution: .offchainAllowed(maxRedirects: 5)
-            )
-
-            XCTAssertEqual(
-                response.data.web3.hexString,
-                expectedResponse(
-                    sender: function.contract,
-                    data: "0x1234".web3.hexData!)
-            )
-        } catch let error {
-            XCTFail("Error \(error)")
-        }
-    }
+    // TODO [Tests] Disabled for now until we reimplement on our side (ethers.js tests setup using goerli)
+//    func test_GivenTestFunction_WhenLookupCorrect_ThenDecodesRetrievesValue() async throws {
+//        let function =  EthersTestContract.TestGet(data: "0x1234".web3.hexData!)
+//
+//        do {
+//            let response = try await function.call(
+//                withClient: client,
+//                responseType: EthersTestContract.BytesResponse.self,
+//                resolution: .offchainAllowed(maxRedirects: 5)
+//            )
+//
+//            XCTAssertEqual(
+//                response.data.web3.hexString,
+//                expectedResponse(
+//                    sender: function.contract,
+//                    data: "0x1234".web3.hexData!)
+//            )
+//        } catch let error {
+//            XCTFail("Error \(error)")
+//        }
+//    }
+//
+//    func test_GivenTestFunction_WhenLookupDisabled_ThenFailsWithExecutionError() async throws {
+//        let function =  EthersTestContract.TestGet(data: "0x1234".web3.hexData!)
+//
+//        do {
+//            _ = try await function.call(
+//                withClient: client,
+//                responseType: EthersTestContract.BytesResponse.self,
+//                resolution: .noOffchain(failOnExecutionError: true)
+//            )
+//            XCTFail("Expecting error")
+//        } catch let error {
+//            let error = (error as? EthereumClientError)?.executionError
+//            XCTAssertEqual(error?.code, 3)
+//        }
+//    }
+//
+//    func test_GivenTestFunction_WhenGatewayFails_ThenFailsCall() async throws {
+//        let function =  EthersTestContract.TestGetFail(data: "0x1234".web3.hexData!)
+//
+//        do {
+//            _ = try await function.call(
+//                withClient: client,
+//                responseType: EthersTestContract.BytesResponse.self,
+//                resolution: .offchainAllowed(maxRedirects: 5)
+//            )
+//            XCTFail("Expecting error")
+//        } catch let error {
+//            XCTAssertEqual(error as? EthereumClientError, EthereumClientError.noResultFound)
+//        }
+//    }
+//
+//    func test_GivenTestFunction_WhenSendersDoNotMatch_ThenFailsCall() async throws {
+//        let function =  EthersTestContract.TestGetSenderFail(data: "0x1234".web3.hexData!)
+//
+//        do {
+//            _ = try await function.call(
+//                withClient: client,
+//                responseType: EthersTestContract.BytesResponse.self,
+//                resolution: .offchainAllowed(maxRedirects: 5)
+//            )
+//            XCTFail("Expecting error")
+//        } catch _ {
+//        }
+//    }
+//
+//    func test_GivenTestFunction_WhenGatewayFailsWith4xx_ThenFailsCall() async throws {
+//        let function =  EthersTestContract.TestGetMissing(data: "0x1234".web3.hexData!)
+//
+//        do {
+//            _ = try await function.call(
+//                withClient: client,
+//                responseType: EthersTestContract.BytesResponse.self,
+//                resolution: .offchainAllowed(maxRedirects: 5)
+//            )
+//            XCTFail("Expecting error")
+//        } catch let error {
+//            XCTAssertEqual(error as? EthereumClientError, EthereumClientError.noResultFound)
+//        }
+//    }
+//
+//    func test_GivenTestFunction_WhenLookupCorrectWithFallback_ThenDecodesRetrievesValue() async throws {
+//        let function =  EthersTestContract.TestGetFallback(data: "0x1234".web3.hexData!)
+//
+//        do {
+//            let response = try await function.call(
+//                withClient: client,
+//                responseType: EthersTestContract.BytesResponse.self,
+//                resolution: .offchainAllowed(maxRedirects: 5)
+//            )
+//
+//            XCTAssertEqual(
+//                response.data.web3.hexString,
+//                expectedResponse(
+//                    sender: function.contract,
+//                    data: "0x1234".web3.hexData!)
+//            )
+//        } catch let error {
+//            XCTFail("Error \(error)")
+//        }
+//    }
+//
+//    func test_GivenTestFunction_WhenLookupCorrectWithFallbackAndNoRedirectsLeft_ThenFails() async throws {
+//        let function =  EthersTestContract.TestGetFallback(data: "0x1234".web3.hexData!)
+//
+//        do {
+//            _ = try await function.call(
+//                withClient: client,
+//                responseType: EthersTestContract.BytesResponse.self,
+//                resolution: .offchainAllowed(maxRedirects: 0)
+//            )
+//
+//            XCTFail("Expecting error")
+//        } catch let error {
+//            XCTAssertEqual(error as? EthereumClientError, EthereumClientError.noResultFound)
+//        }
+//    }
+//
+//    func test_GivenTestFunction_WhenLookupCorrectWithPOSTData_ThenDecodesRetrievesValue() async throws {
+//        let function =  EthersTestContract.TestPost(data: "0x1234".web3.hexData!)
+//
+//        do {
+//            let response = try await function.call(
+//                withClient: client,
+//                responseType: EthersTestContract.BytesResponse.self,
+//                resolution: .offchainAllowed(maxRedirects: 5)
+//            )
+//
+//            XCTAssertEqual(
+//                response.data.web3.hexString,
+//                expectedResponse(
+//                    sender: function.contract,
+//                    data: "0x1234".web3.hexData!)
+//            )
+//        } catch let error {
+//            XCTFail("Error \(error)")
+//        }
+//    }
 }
 
 // Expected hash of result, which is the same verification done in ethers contract

--- a/web3sTests/Resources/ERC1271Checker.sol
+++ b/web3sTests/Resources/ERC1271Checker.sol
@@ -8,6 +8,10 @@ contract ERC1271Checker is IERC1271, Ownable {
     // bytes4(keccak256("isValidSignature(bytes32,bytes)")
     bytes4 constant internal MAGICVALUE = 0x1626ba7e;
 
+    constructor(address initialOwner) Ownable(initialOwner) {
+        Ownable(initialOwner);
+    
+
     function isValidSignature(
         bytes32 _hash,
         bytes calldata _signature

--- a/web3sTests/Resources/ERC1271CheckerBool.sol
+++ b/web3sTests/Resources/ERC1271CheckerBool.sol
@@ -4,7 +4,10 @@ import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 contract ERC1271CheckerBool is Ownable {
-
+    constructor(address initialOwner) Ownable(initialOwner) {
+        Ownable(initialOwner);
+    }
+    
     function isValidSignature(
         bytes32 _hash,
         bytes calldata _signature

--- a/web3sTests/Resources/ERC165Sample.sol
+++ b/web3sTests/Resources/ERC165Sample.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+import "@openzeppelin/contracts@4.8.0/utils/introspection/ERC165.sol";
+
+contract ERC165Sample is ERC165 {
+}

--- a/web3sTests/Resources/Multicall2.sol
+++ b/web3sTests/Resources/Multicall2.sol
@@ -1,0 +1,78 @@
+// From: https://goerli.etherscan.io/address/0x5ba1e12693dc8f9c48aad8770482f4739beed696#code
+// SPDX-License-Identifier: MIT
+/**
+ *Submitted for verification at Etherscan.io on 2021-03-23
+*/
+
+pragma solidity >=0.5.0;
+pragma experimental ABIEncoderV2;
+
+/// @title Multicall2 - Aggregate results from multiple read-only function calls
+/// @author Michael Elliot <mike@makerdao.com>
+/// @author Joshua Levine <joshua@makerdao.com>
+/// @author Nick Johnson <arachnid@notdot.net>
+
+contract Multicall2 {
+    struct Call {
+        address target;
+        bytes callData;
+    }
+    struct Result {
+        bool success;
+        bytes returnData;
+    }
+
+    function aggregate(Call[] memory calls) public returns (uint256 blockNumber, bytes[] memory returnData) {
+        blockNumber = block.number;
+        returnData = new bytes[](calls.length);
+        for(uint256 i = 0; i < calls.length; i++) {
+            (bool success, bytes memory ret) = calls[i].target.call(calls[i].callData);
+            require(success, "Multicall aggregate: call failed");
+            returnData[i] = ret;
+        }
+    }
+    function blockAndAggregate(Call[] memory calls) public returns (uint256 blockNumber, bytes32 blockHash, Result[] memory returnData) {
+        (blockNumber, blockHash, returnData) = tryBlockAndAggregate(true, calls);
+    }
+    function getBlockHash(uint256 blockNumber) public view returns (bytes32 blockHash) {
+        blockHash = blockhash(blockNumber);
+    }
+    function getBlockNumber() public view returns (uint256 blockNumber) {
+        blockNumber = block.number;
+    }
+    function getCurrentBlockCoinbase() public view returns (address coinbase) {
+        coinbase = block.coinbase;
+    }
+    function getCurrentBlockDifficulty() public view returns (uint256 difficulty) {
+        difficulty = block.difficulty;
+    }
+    function getCurrentBlockGasLimit() public view returns (uint256 gaslimit) {
+        gaslimit = block.gaslimit;
+    }
+    function getCurrentBlockTimestamp() public view returns (uint256 timestamp) {
+        timestamp = block.timestamp;
+    }
+    function getEthBalance(address addr) public view returns (uint256 balance) {
+        balance = addr.balance;
+    }
+    function getLastBlockHash() public view returns (bytes32 blockHash) {
+        blockHash = blockhash(block.number - 1);
+    }
+    function tryAggregate(bool requireSuccess, Call[] memory calls) public returns (Result[] memory returnData) {
+        returnData = new Result[](calls.length);
+        for(uint256 i = 0; i < calls.length; i++) {
+            (bool success, bytes memory ret) = calls[i].target.call(calls[i].callData);
+
+            if (requireSuccess) {
+                require(success, "Multicall2 aggregate: call failed");
+            }
+
+            returnData[i] = Result(success, ret);
+        }
+    }
+    function tryBlockAndAggregate(bool requireSuccess, Call[] memory calls) public returns (uint256 blockNumber, bytes32 blockHash, Result[] memory returnData) {
+        blockNumber = block.number;
+        blockHash = blockhash(block.number);
+        returnData = tryAggregate(requireSuccess, calls);
+    }
+}

--- a/web3sTests/SIWE/SIWETests.swift
+++ b/web3sTests/SIWE/SIWETests.swift
@@ -30,7 +30,7 @@ class SIWETests: XCTestCase {
 
             URI: https://login.xyz/demo#login
             Version: 1
-            Chain ID: 5
+            Chain ID: 11155111
             Nonce: qwerty123456
             Issued At: \(SiweMessage.dateFormatter.string(from: Date()))
             Expiration Time: \(SiweMessage.dateFormatter.string(from: Date(timeInterval: 60, since: Date())))

--- a/web3sTests/SIWE/SiweVerifierTests.swift
+++ b/web3sTests/SIWE/SiweVerifierTests.swift
@@ -13,7 +13,7 @@ class SiweVerifierTests: XCTestCase {
     override func setUp() {
         super.setUp()
         if self.client == nil {
-            self.client = EthereumHttpClient(url: URL(string: TestConfig.clientUrl)!, network: .goerli)
+            self.client = EthereumHttpClient(url: URL(string: TestConfig.clientUrl)!, network: .sepolia)
         }
     }
 
@@ -113,13 +113,13 @@ class SiweVerifierTests: XCTestCase {
             let isVerified = try await verifier.verify(
                 """
                 login.xyz wants you to sign in with your Ethereum account:
-                0x719561fee351F7aC6560D0302aE415FfBEEc0B51
+                0xE78e5ecb061fE3DD1672dDDA7b5116213B23B99A
 
                 Please sign this 🙏
 
                 URI: https://login.xyz/demo#login
                 Version: 1
-                Chain ID: 5
+                Chain ID: 11155111
                 Nonce: qwerty123456
                 Issued At: 2022-06-16T12:09:07.937Z
                 Request ID: some-request-id
@@ -127,7 +127,7 @@ class SiweVerifierTests: XCTestCase {
                 - https://docs.login.xyz
                 - https://login.xyz
                 """,
-                against: "0x22694f51b1eda4559b117ac0bdbf40f774b17bbb76f763b1c30e1adaab42ce1a406a02c38158c6b500f4f5d803774907d231020867d376e05f3a6eea7041aff31b"
+                against: "0x16a8ed8d9747521909813f75c60961111148978944945226443856fafb2bb93a705e93c465870501b1dd70c7fc15d7d94c6720daa39f9979517aae5e0bdeb94b1b"
             )
             XCTAssertTrue(isVerified)
         } catch {
@@ -141,13 +141,13 @@ class SiweVerifierTests: XCTestCase {
             let isVerified = try await verifier.verify(
                 """
                 login.xyz wants you to sign in with your Ethereum account:
-                0x9d8A62f656a8d1615C1294fd71e9CFb3E4855A4F
+                0xE78e5ecb061fE3DD1672dDDA7b5116213B23B99A
 
                 Please sign this 🙏
 
                 URI: https://login.xyz/demo#login
                 Version: 1
-                Chain ID: 5
+                Chain ID: 11155111
                 Nonce: qwerty123456
                 Issued At: 2022-06-16T12:09:07.937Z
                 Request ID: some-request-id
@@ -170,13 +170,13 @@ class SiweVerifierTests: XCTestCase {
             let isVerified = try await verifier.verify(
                 """
                 login.xyz wants you to sign in with your Ethereum account:
-                0x72602FE1F2CaBAbCfFB51eb84741AFaE04AF10ca
+                0x9af09A43d0A0EF8cC1b70E543c8502bDA8e3dE61
 
                 Please sign this 🙏
 
                 URI: https://login.xyz/demo#login
                 Version: 1
-                Chain ID: 5
+                Chain ID: 11155111
                 Nonce: qwerty123456
                 Issued At: 2022-06-16T12:09:07.937Z
                 Request ID: some-request-id
@@ -184,7 +184,7 @@ class SiweVerifierTests: XCTestCase {
                 - https://docs.login.xyz
                 - https://login.xyz
                 """,
-                against: "0x4f49c1a24513ad1b677546c2dfc3be361d861c9d595d47ebf97aac57497f7971184e31f997f67466690becacd5aac5d3716db457329ba392c81ba5836a26449c1b"
+                against: "0x135afeec25a1e3b25da21aa4c5f5def607366cf75a772a456b19d590d5ac33fe1f679adb73d51ff56089fe6d75d52d296062f325830f10fae186938668e469461b"
             )
             XCTAssertTrue(isVerified)
         } catch {
@@ -199,13 +199,13 @@ class SiweVerifierTests: XCTestCase {
             let isVerified = try await verifier.verify(
                 """
                 login.xyz wants you to sign in with your Ethereum account:
-                0x72602FE1F2CaBAbCfFB51eb84741AFaE04AF10ca
+                0x9af09A43d0A0EF8cC1b70E543c8502bDA8e3dE61
 
                 Please sign this 🙏
 
                 URI: https://login.xyz/demo#login
                 Version: 1
-                Chain ID: 5
+                Chain ID: 11155111
                 Nonce: qwerty123456
                 Issued At: 2022-06-16T12:09:07.937Z
                 Request ID: some-request-id
@@ -213,7 +213,7 @@ class SiweVerifierTests: XCTestCase {
                 - https://docs.login.xyz
                 - https://login.xyz
                 """,
-                against: "0x60e700bb8c14da9bc751aee3cb338a763ad9425e7893bd49393fec9f540e9cee1023c42e06989d0b1c04d84b88c62a872073e60218d2c0bc900b5f7f186096611c"
+                against: "0x16a8ed8d9747521909813f75c60961111148978944945226443856fafb2bb93a705e93c465870501b1dd70c7fc15d7d94c6720daa39f9979517aae5e0bdeb94b1b"
             )
             XCTAssertFalse(isVerified)
         } catch {

--- a/web3sTests/TestConfig.swift
+++ b/web3sTests/TestConfig.swift
@@ -7,12 +7,12 @@ import Foundation
 import web3
 
 struct TestConfig {
-    // This is the proxy URL for connecting to the Blockchain. For testing we usually use the Goerli network on Infura. Using free tier, so might hit rate limits
-    static let clientUrl = "https://goerli.infura.io/v3/b2f4b3f635d8425c96854c3d28ba6bb0"
+    // This is the proxy URL for connecting to the Blockchain. For testing we usually use the Sepolia network on Infura. Using free tier, so might hit rate limits
+    static let clientUrl = "https://sepolia.infura.io/v3/b2f4b3f635d8425c96854c3d28ba6bb0"
     static let mainnetUrl = "https://mainnet.infura.io/v3/b2f4b3f635d8425c96854c3d28ba6bb0"
 
-    // This is the proxy wss URL for connecting to the Blockchain. For testing we usually use the Goerli network on Infura. Using free tier, so might hit rate limits
-    static let wssUrl = "wss://goerli.infura.io/ws/v3/b2f4b3f635d8425c96854c3d28ba6bb0"
+    // This is the proxy wss URL for connecting to the Blockchain. For testing we usually use the Sepolia network on Infura. Using free tier, so might hit rate limits
+    static let wssUrl = "wss://sepolia.infura.io/ws/v3/b2f4b3f635d8425c96854c3d28ba6bb0"
     static let wssMainnetUrl = "wss://mainnet.infura.io/ws/v3/b2f4b3f635d8425c96854c3d28ba6bb0"
 
     // An EOA with some Ether, so that we can test sending transactions (pay for gas). Set by CI
@@ -21,18 +21,19 @@ struct TestConfig {
     // This is the expected public key (address) from the above private key
 //    static let publicKey = "SET_YOUR_PUBLIC_ADDRESS_HERE"
 
-    // A test ERC20 token contract (UNI)
-    static let erc20Contract = "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"
+    // A test ERC20 token contract (USDC)
+    static let erc20Contract = "0xF31B086459C2cdaC006Feedd9080223964a9cDdB"
 
     // A test ERC721 token contract (W3ST)
-    static let erc721Contract = "0xb34354a70d2b985b031Ca443b87C92F7DaE5DA02"
+    static let erc721Contract = "0x09c66F8B33933823C472E932fBeB19b0762C6971"
 
     // ERC165 compliant contract
-    static let erc165Contract = "0xA2618a1c426a1684E00cA85b5C736164AC391d35"
+    static let erc165Contract = "0x85741a0a123C6BD61f327F32E633bA4c0C75A7d9"
+    static let nonerc165Contrat = "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"
 
     static let webSocketConfig = WebSocketConfiguration(maxFrameSize: 1_000_000)
 
-    static let network = EthereumNetwork.goerli
+    static let network = EthereumNetwork.sepolia
 
      enum ZKSync {
          static let chainId = 280

--- a/web3sTests/ZKSync/EthereumClient+ZKSyncTests.swift
+++ b/web3sTests/ZKSync/EthereumClient+ZKSyncTests.swift
@@ -20,30 +20,6 @@ final class EthereumClientZKSyncTests: XCTestCase {
         data: Data(),
         gasLimit: 300000
     )
-
-    // TODO: Reintegrate test
-//    func test_GivenEOAAccount_WhenSendETH_ThenSendsCorrectly() async {
-//        do {
-//            let gasPrice = try await client.eth_gasPrice()
-//            eoaEthTransfer.gasPrice = gasPrice
-//            let txHash = try await client.eth_sendRawZKSyncTransaction(eoaEthTransfer, withAccount: eoaAccount)
-//            XCTAssertNotNil(txHash, "No tx hash, ensure key is valid in TestConfig.swift")
-//        } catch {
-//            XCTFail("Expected tx but failed \(error).")
-//        }
-//    }
-    
-    // TODO: Integrate paymaster
-//    func test_GivenEOAAccount_WhenSendETH_AndFeeIsInUSDC_ThenSendsCorrectly() async {
-//        do {
-//            let txHash = try await client.eth_sendRawZKSyncTransaction(with(eoaEthTransfer) {
-//                $0.feeToken = EthereumAddress("0x54a14D7559BAF2C8e8Fa504E019d32479739018c")
-//            }, withAccount: eoaAccount)
-//            XCTAssertNotNil(txHash, "No tx hash, ensure key is valid in TestConfig.swift")
-//        } catch {
-//            XCTFail("Expected tx but failed \(error).")
-//        }
-//    }
     
     func test_GivenEOATransaction_gasEstimationCorrect() async {
         do {

--- a/web3swift/lib/CryptoSwift/Int+Extensions.swift
+++ b/web3swift/lib/CryptoSwift/Int+Extensions.swift
@@ -25,8 +25,5 @@ extension FixedWidthInteger {
     @inlinable
     func bytes(totalBytes: Int = MemoryLayout<Self>.size) -> [UInt8] {
         arrayOfBytes(value: littleEndian, length: totalBytes)
-        // TODO: adjust bytes order
-        // var value = self.littleEndian
-        // return withUnsafeBytes(of: &value, Array.init).reversed()
     }
 }

--- a/web3swift/lib/CryptoSwift/SHA2.swift
+++ b/web3swift/lib/CryptoSwift/SHA2.swift
@@ -12,7 +12,6 @@
 //  - Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
 //  - This notice may not be removed or altered from any source or binary distribution.
 //
-//  TODO: generic for process32/64 (UInt32/UInt64)
 //
 public final class SHA2 {
     @usableFromInline

--- a/web3swift/src/Client/Models/EthereumNetwork.swift
+++ b/web3swift/src/Client/Models/EthereumNetwork.swift
@@ -7,18 +7,12 @@ import Foundation
 
 public enum EthereumNetwork: Equatable, Decodable {
     case mainnet
-    case kovan
-    case goerli
     case sepolia
     case custom(String)
     public static func fromString(_ networkId: String) -> EthereumNetwork {
         switch networkId {
         case "1":
             return .mainnet
-        case "5":
-            return .goerli
-        case "42":
-            return .kovan
         case "11155111":
             return .sepolia
         default:
@@ -30,10 +24,6 @@ public enum EthereumNetwork: Equatable, Decodable {
         switch self {
         case .mainnet:
             return "1"
-        case .goerli:
-            return "5"
-        case .kovan:
-            return "42"
         case .sepolia:
             return "11155111"
         case let .custom(str):
@@ -45,10 +35,6 @@ public enum EthereumNetwork: Equatable, Decodable {
         switch self {
         case .mainnet:
             return 1
-        case .goerli:
-            return 5
-        case .kovan:
-            return 42
         case .sepolia:
             return 11155111
         case let .custom(str):

--- a/web3swift/src/Contract/Statically Typed/ABIRawType+Static.swift
+++ b/web3swift/src/Contract/Statically Typed/ABIRawType+Static.swift
@@ -134,8 +134,6 @@ extension ABITuple {
     }
 }
 
-// TODO: Other Int sizes
-
 private let DataParser: ABIType.ParserFunction = { data in
     let first = data.first ?? ""
     return try ABIDecoder.decode(first, to: Data.self)

--- a/web3swift/src/ENS/ENSContracts.swift
+++ b/web3swift/src/ENS/ENSContracts.swift
@@ -15,7 +15,7 @@ public enum ENSContracts {
         switch network {
         case .mainnet:
             return ENSContracts.RegistryAddress
-        case .goerli:
+        case .sepolia:
             return ENSContracts.RegistryAddress
         default:
             return nil

--- a/web3swift/src/Multicall/Multicall.swift
+++ b/web3swift/src/Multicall/Multicall.swift
@@ -43,7 +43,11 @@ public struct Multicall {
     }
 
     public func tryAggregate(requireSuccess: Bool, calls: [Call]) async throws -> Multicall.Multicall2Response {
-        let function = Contract.Functions.tryAggregate(contract: Contract.multicall2Address, requireSuccess: requireSuccess, calls: calls)
+        guard let contract = Contract.multicall2Address(for: network) else {
+            throw MulticallError.contractUnavailable
+        }
+
+        let function = Contract.Functions.tryAggregate(contract: contract, requireSuccess: requireSuccess, calls: calls)
 
         do {
             let data = try await function.call(withClient: client, responseType: Multicall2Response.self)

--- a/web3swift/src/Multicall/MulticallContract.swift
+++ b/web3swift/src/Multicall/MulticallContract.swift
@@ -8,16 +8,33 @@ import Foundation
 
 extension Multicall {
     public enum Contract {
-        static let goerliAddress: EthereumAddress = "0x77dCa2C955b15e9dE4dbBCf1246B4B85b651e50e"
-        static let mainnetAddress: EthereumAddress = "0xF34D2Cb31175a51B23fb6e08cA06d7208FaD379F"
-        static let multicall2Address: EthereumAddress = "0x5ba1e12693dc8f9c48aad8770482f4739beed696"
+        public enum Registry {
+            static let sepolia: EthereumAddress = "0x25Eef291876194AeFAd0D60Dff89e268b90754Bb"
+            static let mainnet: EthereumAddress = "0xF34D2Cb31175a51B23fb6e08cA06d7208FaD379F"
+        }
+
+        public enum Multicall2 {
+            static let mainnet: EthereumAddress = "0x5ba1e12693dc8f9c48aad8770482f4739beed696"
+            static let sepolia: EthereumAddress = "0x55344B7242EB48e332aaccec3e0cFbE553Be88B5"
+        }
 
         public static func registryAddress(for network: EthereumNetwork) -> EthereumAddress? {
             switch network {
             case .mainnet:
-                return Self.mainnetAddress
-            case .goerli:
-                return Self.goerliAddress
+                return Multicall.Contract.Registry.mainnet
+            case .sepolia:
+                return Multicall.Contract.Registry.sepolia
+            default:
+                return nil
+            }
+        }
+
+        public static func multicall2Address(for network: EthereumNetwork) -> EthereumAddress? {
+            switch network {
+            case .mainnet:
+                return Multicall.Contract.Multicall2.mainnet
+            case .sepolia:
+                return Multicall.Contract.Multicall2.sepolia
             default:
                 return nil
             }

--- a/web3swift/src/Utils/RLP.swift
+++ b/web3swift/src/Utils/RLP.swift
@@ -52,7 +52,6 @@ public struct RLP {
 
     static func encodeBigInt(_ bint: BigInt) -> Data? {
         guard bint >= 0 else {
-            // TODO: implement properly to support negatives if RLP supports.. twos complement reverse?
             return nil
         }
         return encodeBigUInt(BigUInt(bint))


### PR DESCRIPTION
Multicall: Added ticket to support v3 #351

There's an issue with testing offchain as we were relying on existing contract + endpoint by `ethers.js` and some ENS to be set up on the chain.  