### PR TITLE
Add fee info to EthereumBlockInfo

### DIFF
--- a/web3swift/src/Client/Models/EthereumBlockInfo.swift
+++ b/web3swift/src/Client/Models/EthereumBlockInfo.swift
@@ -4,11 +4,15 @@
 //
 
 import Foundation
+import BigInt
 
 public struct EthereumBlockInfo: Equatable {
     public var number: EthereumBlock
     public var timestamp: Date
     public var transactions: [String]
+    public var gasLimit: BigUInt
+    public var gasUsed: BigUInt
+    public var baseFeePerGas: BigUInt?
 }
 
 extension EthereumBlockInfo: Codable {
@@ -16,6 +20,9 @@ extension EthereumBlockInfo: Codable {
         case number
         case timestamp
         case transactions
+        case gasLimit
+        case gasUsed
+        case baseFeePerGas
     }
 
     public init(from decoder: Decoder) throws {
@@ -33,10 +40,25 @@ extension EthereumBlockInfo: Codable {
         guard let transactions = try? container.decode([String].self, forKey: .transactions) else {
             throw JSONRPCError.decodingError
         }
+        
+        guard let gasLimit = try? container.decode(String.self, forKey: .gasLimit) else {
+            throw JSONRPCError.decodingError
+        }
+        
+        guard let gasUsed = try? container.decode(String.self, forKey: .gasUsed) else {
+            throw JSONRPCError.decodingError
+        }
+        
+        let baseFeePerGas = try? container.decode(String.self, forKey: .baseFeePerGas)
 
         self.number = number
         self.timestamp = Date(timeIntervalSince1970: timestamp)
         self.transactions = transactions
+        self.gasLimit = BigUInt(hex: gasLimit) ?? BigUInt(0)
+        self.gasUsed = BigUInt(hex: gasUsed) ?? BigUInt(0)
+        if let baseFee = baseFeePerGas {
+            self.baseFeePerGas = BigUInt(hex: baseFee)
+        }
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -45,5 +67,10 @@ extension EthereumBlockInfo: Codable {
         try container.encode(number, forKey: .number)
         try container.encode(Int(timestamp.timeIntervalSince1970).web3.hexString, forKey: .timestamp)
         try container.encode(transactions, forKey: .transactions)
+        try container.encode(gasLimit.web3.hexString, forKey: .gasLimit)
+        try container.encode(gasUsed.web3.hexString, forKey: .gasUsed)
+        if let baseFee = baseFeePerGas {
+            try container.encode(baseFee.web3.hexString, forKey: .baseFeePerGas)
+        }
     }
 }


### PR DESCRIPTION
`EthereumBlockInfo` is quite slim, but some fee info would be very useful.
https://www.quicknode.com/docs/ethereum/eth_getBlockByNumber

Added `gasLimit`, `gasUsed`, and optional `baseFeePerGas`.