### PR TITLE
feat: ethereum http client accept http headers

### DIFF
--- a/web3swift/src/Client/HTTP/EthereumHttpClient.swift
+++ b/web3swift/src/Client/HTTP/EthereumHttpClient.swift
@@ -15,6 +15,7 @@ public class EthereumHttpClient: BaseEthereumClient {
 
     public init(
         url: URL,
+        headers: [String: String]? = nil,
         sessionConfig: URLSessionConfiguration = URLSession.shared.configuration,
         logger: Logger? = nil,
         network: EthereumNetwork
@@ -25,6 +26,6 @@ public class EthereumHttpClient: BaseEthereumClient {
         self.networkQueue = networkQueue
 
         let session = URLSession(configuration: sessionConfig, delegate: nil, delegateQueue: networkQueue)
-        super.init(networkProvider: HttpNetworkProvider(session: session, url: url), url: url, logger: logger, network: network)
+        super.init(networkProvider: HttpNetworkProvider(session: session, url: url, headers: headers), url: url, logger: logger, network: network)
     }
 }

--- a/web3swift/src/Client/Models/EthereumBlockInfo.swift
+++ b/web3swift/src/Client/Models/EthereumBlockInfo.swift
@@ -3,8 +3,8 @@
 //  Copyright © 2022 Argent Labs Limited. All rights reserved.
 //
 
-import Foundation
 import BigInt
+import Foundation
 
 public struct EthereumBlockInfo: Equatable {
     public var number: EthereumBlock
@@ -40,15 +40,15 @@ extension EthereumBlockInfo: Codable {
         guard let transactions = try? container.decode([String].self, forKey: .transactions) else {
             throw JSONRPCError.decodingError
         }
-        
+
         guard let gasLimit = try? container.decode(String.self, forKey: .gasLimit) else {
             throw JSONRPCError.decodingError
         }
-        
+
         guard let gasUsed = try? container.decode(String.self, forKey: .gasUsed) else {
             throw JSONRPCError.decodingError
         }
-        
+
         let baseFeePerGas = try? container.decode(String.self, forKey: .baseFeePerGas)
 
         self.number = number

--- a/web3swift/src/Client/NetworkProviders/HttpNetworkProvider.swift
+++ b/web3swift/src/Client/NetworkProviders/HttpNetworkProvider.swift
@@ -13,7 +13,7 @@ public class HttpNetworkProvider: NetworkProviderProtocol {
     public let session: URLSession
     private let url: URL
     private let headers: [String: String]
-    
+
     public init(session: URLSession, url: URL, headers: [String: String]? = nil) {
         self.session = session
         self.url = url
@@ -38,7 +38,7 @@ public class HttpNetworkProvider: NetworkProviderProtocol {
         headers.forEach { key, value in
             request.addValue(value, forHTTPHeaderField: key)
         }
-        
+
         let id = 1
         let rpcRequest = JSONRPCRequest(jsonrpc: "2.0", method: method, params: params, id: id)
         guard let encoded = try? JSONEncoder().encode(rpcRequest) else {

--- a/web3swift/src/Client/NetworkProviders/HttpNetworkProvider.swift
+++ b/web3swift/src/Client/NetworkProviders/HttpNetworkProvider.swift
@@ -12,10 +12,12 @@ import Foundation
 public class HttpNetworkProvider: NetworkProviderProtocol {
     public let session: URLSession
     private let url: URL
-
-    public init(session: URLSession, url: URL) {
+    private let headers: [String: String]
+    
+    public init(session: URLSession, url: URL, headers: [String: String]? = nil) {
         self.session = session
         self.url = url
+        self.headers = headers ?? [:]
     }
 
     deinit {
@@ -33,6 +35,10 @@ public class HttpNetworkProvider: NetworkProviderProtocol {
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
         request.addValue("application/json", forHTTPHeaderField: "Accept")
 
+        headers.forEach { key, value in
+            request.addValue(value, forHTTPHeaderField: key)
+        }
+        
         let id = 1
         let rpcRequest = JSONRPCRequest(jsonrpc: "2.0", method: method, params: params, id: id)
         guard let encoded = try? JSONEncoder().encode(rpcRequest) else {


### PR DESCRIPTION
Specific RPC providers, such as [Klaytn API Service](https://www.klaytnapi.com/en/), include an authorization token in the HTTP header.
