### PR TITLE
bump: update bigint in podspec

### DIFF
--- a/web3.swift.podspec
+++ b/web3.swift.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.preserve_paths = 'web3swift/lib/**/module.map'
 
 
-  s.dependency 'BigInt', '~> 5.0.0'
+  s.dependency 'BigInt', '~> 5.2'
   s.dependency 'secp256k1.swift', '~> 0.1'
   s.dependency 'GenericJSON', '~> 2.0'
   s.dependency 'Logging', '~> 1.0.0'


### PR DESCRIPTION
BigInt 5.3 (as defined in the spm package) is not backwards compatible beyond 5.2 (as defined in the cocoapods package).

There are missing extensions.