### PR TITLE
Replace secp256k1 with CSecp256k1 library

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         .package(name: "BigInt", url: "https://github.com/attaswift/BigInt", from: "5.3.0"),
         .package(name: "GenericJSON", url: "https://github.com/iwill/generic-json-swift", .upToNextMajor(from: "2.0.0")),
-        .package(url: "https://github.com/GigaBitcoin/secp256k1.swift.git", .upToNextMajor(from: "0.6.0")),
+        .package(url: "https://github.com/tesseract-one/CSecp256k1.swift.git", .upToNextMajor(from: "0.2.0")),
         .package(url: "https://github.com/vapor/websocket-kit.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0")
     ],
@@ -29,7 +29,7 @@ let package = Package(
                     .target(name: "Internal_CryptoSwift_PBDKF2"),
                     "BigInt",
                     "GenericJSON",
-                    .product(name: "secp256k1", package: "secp256k1.swift"),
+                    .product(name: "CSecp256k1", package: "CSecp256k1.swift"),
                     .product(name: "WebSocketKit", package: "websocket-kit"),
                     .product(name: "Logging", package: "swift-log")
                 ],

--- a/web3swift/src/Utils/KeyUtil.swift
+++ b/web3swift/src/Utils/KeyUtil.swift
@@ -4,7 +4,7 @@
 //
 
 import Logging
-import secp256k1
+import CSecp256k1
 import Foundation
 
 public enum KeyUtilError: Error {


### PR DESCRIPTION
## Description
We are replacing secp256k1 with CSecp256k1 due to conflicting C headers used by two different packages that our main app depends on.

This PR aligns both packages to use the same downstream package.

Since web3 is not updated frequently (its last update was two years ago), it made more sense to fork this repository instead of the other one, which is updated more regularly.