### PR TITLE
fix: throw error from rpc on failed logs

### DIFF
--- a/web3sTests/Client/EthereumClientTests.swift
+++ b/web3sTests/Client/EthereumClientTests.swift
@@ -149,9 +149,27 @@ class EthereumClientTests: XCTestCase {
         do {
             let logs = try await client?.eth_getLogs(addresses: ["0x23d0a442580c01e420270fba6ca836a8b2353acb"], topics: nil, fromBlock: .Earliest, toBlock: .Latest)
             XCTAssertNotNil(logs, "Logs not available")
+            XCTAssertEqual(logs?.count, 0)
         } catch {
             XCTFail("Expected logs but failed \(error).")
         }
+    }
+
+    func testSimpleEthGetLogsWithFailingRequest() async {
+        guard let client = client else {
+            XCTFail()
+            return
+        }
+        await XCTAssertThrowsErrorAsync(
+            try await client.eth_getLogs(
+                addresses: ["0x3edf60dd017ace33a0220f78741b5581c385a1ba"],
+                topics: [try? ERC20Events.Transfer.signature()],
+                fromBlock: .Earliest,
+                toBlock: .Latest
+            ),
+            EthereumClientError.unexpectedReturnValue,
+            "Too many logs to receive. Should throw an error instead of defaulting to empty array"
+        )
     }
 
     func testOrTopicsEthGetLogs() async {
@@ -604,5 +622,20 @@ extension EthereumWebSocketClientTests: EthereumWebSocketClientDelegate {
     func onLog(subscription: EthereumSubscription, log: EthereumLog) {
         delegateExpectation?.fulfill()
         delegateExpectation = nil
+    }
+}
+
+func XCTAssertThrowsErrorAsync<T, R>(
+    _ expression: @autoclosure () async throws -> T,
+    _ errorThrown: @autoclosure () -> R,
+    _ message: @autoclosure () -> String = "This method should fail",
+    file: StaticString = #filePath,
+    line: UInt = #line
+) async where R: Equatable, R: Error  {
+    do {
+        let _ = try await expression()
+        XCTFail(message(), file: file, line: line)
+    } catch {
+        XCTAssertEqual(error as? R, errorThrown())
     }
 }

--- a/web3swift/src/Client/RecursiveLogCollector.swift
+++ b/web3swift/src/Client/RecursiveLogCollector.swift
@@ -37,9 +37,10 @@ struct RecursiveLogCollector {
                     throw EthereumClientError.unexpectedReturnValue
                 }
                 return lhs + rhs
+            } else {
+                throw error
             }
         }
-        return []
     }
 
     private func getLogs(addresses: [EthereumAddress]?, topics: Topics? = nil, from: EthereumBlock, to: EthereumBlock) async throws -> [EthereumLog] {


### PR DESCRIPTION
RPC get logs used to fail silently with empty array instead of throwing an error