### PR TITLE
[SECURITY] Harden GitHub Actions workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+* @argentlabs/team-ios
+.github/workflows/** @argentlabs/team-ios-admin @dmcrodrigues
+scripts/ci/** @argentlabs/team-ios-admin @dmcrodrigues

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,10 @@ on:
     branches: [ develop ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  actions: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -14,7 +18,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Lint
       run: ./scripts/runSwiftFormat.sh -l
@@ -28,7 +32,7 @@ jobs:
       TESTS_PRIVATEKEY: ${{ secrets.TESTS_PRIVATEKEY }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: SetupKey
       run: ./scripts/setupKey.sh "${{ secrets.TESTS_PRIVATEKEY }}"
@@ -51,7 +55,7 @@ jobs:
       TESTS_PRIVATEKEY: ${{ secrets.TESTS_PRIVATEKEY }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: SetupKey
       run: ./scripts/setupKey.sh "${{ secrets.TESTS_PRIVATEKEY }}"


### PR DESCRIPTION
## Summary
- Add least-privilege permissions to CI workflow
- Pin third-party actions to immutable commit SHAs
- Protect workflow and CI script changes with stricter CODEOWNERS entries

Implemented following GitHub's [Secure use reference](https://docs.github.com/en/actions/reference/security/secure-use). Mirrors argentlabs/ios#7390.
