### PR TITLE
Fix EIP-712 array type encoding bugs in TypedData

### DIFF
--- a/web3sTests/Account/EthereumAccount+SignTypedTests.swift
+++ b/web3sTests/Account/EthereumAccount+SignTypedTests.swift
@@ -256,4 +256,82 @@ class EthereumAccount_SignTypedTests: XCTestCase {
         let signed = try? account.signMessage(message: typedData)
         XCTAssertEqual(signed, "0x4355c47d63924e8a72e509b65029052eb6c299d53a04e167c5775fd466751c9d07299936d304c153f6443dfa05f40ff007d72911b6f72307f996231605b915621c")
     }
+
+    // Regression test: encodeType(primaryType:) used to force-unwrap `types[type]!` using the raw,
+    // still-bracketed primaryType instead of stripping array brackets first (unlike the rest of the
+    // file, which already stripped them via getParsedType). Any custom-type array field with more
+    // than one bracket pair (e.g. "Item[2][2]") fell through encodeData's non-array fallback and
+    // reached encodeType with brackets still attached, crashing the process.
+    func test_GivenPrimaryTypeWithArrayBrackets_EncodeTypeStripsThemAndMatchesBareType() {
+        let json = """
+            {
+              "types": {
+                "EIP712Domain": [ { "name": "name", "type": "string" } ],
+                "Item": [ { "name": "value", "type": "uint256" } ]
+              },
+              "primaryType": "Item",
+              "domain": { "name": "Test" },
+              "message": { "value": "1" }
+            }
+            """.data(using: .utf8)!
+        let typedData = try! decoder.decode(TypedData.self, from: json)
+
+        XCTAssertEqual(
+            typedData.encodeType(primaryType: "Item[2][2][2]"),
+            typedData.encodeType(primaryType: "Item")
+        )
+    }
+
+    // A custom-type array field with more than one bracket pair still isn't encoded correctly end
+    // to end (encodeData's array fast paths only handle a single bracket pair), but after the fix
+    // above it must fail safely by throwing rather than crashing.
+    func test_GivenMultiDimensionalCustomTypeArray_ItThrowsInsteadOfCrashing() {
+        let json = """
+            {
+              "types": {
+                "EIP712Domain": [ { "name": "name", "type": "string" } ],
+                "Item": [ { "name": "value", "type": "uint256" } ],
+                "Container": [ { "name": "items", "type": "Item[2][2]" } ]
+              },
+              "primaryType": "Container",
+              "domain": { "name": "Test" },
+              "message": {
+                "items": [[{ "value": "1" }, { "value": "2" }], [{ "value": "3" }, { "value": "4" }]]
+              }
+            }
+            """.data(using: .utf8)!
+        let typedData = try! decoder.decode(TypedData.self, from: json)
+
+        XCTAssertThrowsError(try typedData.signableHash())
+    }
+
+    // Cross-verified against @metamask/eth-sig-util's TypedDataUtils.encodeData, which hashes each
+    // element of a struct-typed array individually before hashing the concatenation, identically for
+    // both dynamic (Type[]) and fixed-size (Type[N]) arrays. The fixed-size branch here used to skip
+    // the per-element hash, producing a different (incorrect) result than the dynamic branch would
+    // for the same logical array.
+    func test_GivenFixedSizeArrayOfCustomType_ItEncodesCorrectly() {
+        let json = """
+            {
+              "types": {
+                "EIP712Domain": [ { "name": "name", "type": "string" } ],
+                "Item": [ { "name": "value", "type": "uint256" } ],
+                "Container": [ { "name": "items", "type": "Item[2]" } ]
+              },
+              "primaryType": "Container",
+              "domain": { "name": "Test" },
+              "message": {
+                "items": [{ "value": "1" }, { "value": "2" }]
+              }
+            }
+            """.data(using: .utf8)!
+        let typedData = try! decoder.decode(TypedData.self, from: json)
+
+        // Expected value computed via @metamask/eth-sig-util's TypedDataUtils.encodeData for the
+        // identical types/message shape.
+        XCTAssertEqual(
+            try! typedData.encodeData(data: typedData.message, type: typedData.primaryType).web3.hexString,
+            "0x66d487afcb5ae933a736f0c863dcad471af77f7c568c8953f5db315c636c8836a362f4d704cfd7a900838c9292111c38c69ffbf07bcb368701c31b8f8d51625a"
+        )
+    }
 }

--- a/web3swift/src/Account/TypedData.swift
+++ b/web3swift/src/Account/TypedData.swift
@@ -68,11 +68,15 @@ extension TypedData {
 
     /// Type encoding as per EIP712
     public func encodeType(primaryType: String) -> Data {
+        let parsedPrimaryType = getParsedType(primaryType: primaryType)
         var depSet = findDependencies(primaryType: primaryType)
-        depSet.remove(primaryType)
-        let sorted = [primaryType] + Array(depSet).sorted()
-        let encoded = sorted.map { type in
-            let param = types[type]!.map { "\($0.type) \($0.name)" }.joined(separator: ",")
+        depSet.remove(parsedPrimaryType)
+        let sorted = [parsedPrimaryType] + Array(depSet).sorted()
+        let encoded = sorted.compactMap { type -> String? in
+            guard let params = types[type] else {
+                return nil
+            }
+            let param = params.map { "\($0.type) \($0.name)" }.joined(separator: ",")
             return "\(type)(\(param))"
         }.joined()
 
@@ -109,7 +113,7 @@ extension TypedData {
                         throw ABIError.invalidValue
                     }
 
-                    let encoded = try json.arrayValue!.flatMap { try encodeData(data: $0, type: parsedType) }
+                    let encoded = try json.arrayValue!.flatMap { try encodeData(data: $0, type: parsedType).web3.keccak256.web3.bytes }
                     return Data(encoded).web3.keccak256.web3.bytes
                 }
 


### PR DESCRIPTION
## Context

Related to #279, which added support for custom-type array fields in `signableHash()`.

## Problem 1: crash on multi-dimensional array types

`encodeType(primaryType:)` builds its list of struct names to render like this:

```swift
var depSet = findDependencies(primaryType: primaryType)
depSet.remove(primaryType)
let sorted = [primaryType] + Array(depSet).sorted()
let encoded = sorted.map { type in
    let param = types[type]!.map { ... }   // force-unwrap
    ...
```

`depSet` (via `findDependencies`/`getParsedType`) already strips array brackets before using a type name as a dictionary key — but the `primaryType` argument prepended to `sorted` is used as-is, brackets and all.

For a normal (non-array) `primaryType` this is harmless, since the raw string already matches a dictionary key. But `encodeData`'s array handling only special-cases a single bracket pair (`components.count == 3`, i.e. `Type[]` or `Type[N]`). A custom-type array field with **more than one** bracket pair (e.g. `"Item[2][2]"`) falls through to the generic non-array fallback, which passes the type string — brackets still attached — straight into `encodeType`. `types[type]!` then force-unwraps `nil` and crashes.

**Fix:** strip brackets from `primaryType` the same way the rest of the function already does for its dependency set, and replace the force-unwrap with a `guard`/`compactMap` so any type that still isn't found fails to encode that segment instead of crashing.

This doesn't make multi-dimensional arrays *correctly* encode (the underlying array-handling logic in `encodeData` still only understands one bracket pair), but it turns a crash into a normal thrown error from `encodeData`'s existing `guard let valueTypes = types[type] else { throw ABIError.invalidType }`.

## Problem 2: fixed-size struct arrays hash incorrectly

`encodeData`'s two array branches handle `Type[]` (dynamic) and `Type[N]` (fixed) inconsistently:

```swift
// dynamic — hashes each element individually before concatenating
let encoded = try json.arrayValue!.flatMap { try encodeData(data: $0, type: parsedType).web3.keccak256.web3.bytes }
return Data(encoded).web3.keccak256.web3.bytes

// fixed-size — concatenates raw encodeData (no per-element hash!) before hashing once
let encoded = try json.arrayValue!.flatMap { try encodeData(data: $0, type: parsedType) }
return Data(encoded).web3.keccak256.web3.bytes
```

Per [EIP-712](https://eips.ethereum.org/EIPS/eip-712), `SomeType[5]` must encode identically to `SomeType[]` with 5 elements — each element gets `hashStruct`'d individually, then the concatenation of those hashes gets hashed once more. The fixed-size branch skips the per-element hash, producing a different (incorrect) result than the dynamic branch would for the same logical data.

I verified this against `@metamask/eth-sig-util`'s `TypedDataUtils.encodeData` (the implementation #279 says it was cross-verified against) using a `Container { items: Item[2] }` example — the real output matches "hash each element, then hash the concatenation," not the current fixed-size branch's behavior. Added `test_GivenFixedSizeArrayOfCustomType_ItEncodesCorrectly`, which asserts against that independently-computed expected value.

## Tests added

- `test_GivenPrimaryTypeWithArrayBrackets_EncodeTypeStripsThemAndMatchesBareType` — direct regression test for the crash fix.
- `test_GivenMultiDimensionalCustomTypeArray_ItThrowsInsteadOfCrashing` — confirms a still-unsupported multi-dimensional array field fails safely (throws) rather than crashing.
- `test_GivenFixedSizeArrayOfCustomType_ItEncodesCorrectly` — regression test for the hashing fix, expected value cross-checked against `@metamask/eth-sig-util`.

All existing tests in `EthereumAccount_SignTypedTests` continue to pass.