### PR TITLE
fix: Surface eth_getLogs failures instead of returning no logs

### DIFF
--- a/web3sTests/Client/RecursiveLogCollectorTests.swift
+++ b/web3sTests/Client/RecursiveLogCollectorTests.swift
@@ -1,0 +1,263 @@
+//
+//  web3.swift
+//  Copyright © Argent Labs Limited. All rights reserved.
+//
+
+import BigInt
+import Foundation
+import XCTest
+@testable import web3
+
+#if canImport(FoundationNetworking)
+    import FoundationNetworking
+#endif
+
+// MARK: - Stub network provider
+
+private struct ScriptedError: Sendable {
+    let code: Int
+    let message: String
+
+    static let tooManyResults = ScriptedError(code: -32005, message: "query returned more than 10000 results")
+    static let rangeExceeded = ScriptedError(code: -32602, message: "range 20000 exceeds limit of 10000")
+    static let invalidParams = ScriptedError(code: -32602, message: "invalid argument 0: hex string has length 39")
+    static let generic = ScriptedError(code: -32000, message: "header not found")
+}
+
+/// Answers `eth_getLogs` from a scripted block range rather than the network.
+///
+/// Requests spanning more than `rangeLimit` blocks fail with `overLimitError`; anything
+/// narrower returns a single log stamped with its `fromBlock`, so callers can assert on
+/// how a query was split and re-aggregated.
+private final class StubNetworkProvider: NetworkProviderProtocol, @unchecked Sendable {
+    let session = URLSession(configuration: .ephemeral)
+
+    private let rangeLimit: Int
+    private let overLimitError: ScriptedError
+    private let headBlock: Int
+    /// Sub-ranges starting at or above this block fail with `.generic` even when they are
+    /// inside the range limit. Expressed as a threshold rather than exact block numbers so
+    /// the test does not depend on where the split happens to land.
+    private let failFromBlocksAtOrAbove: Int?
+
+    private let lock = NSLock()
+    private var _requestedRanges: [ClosedRange<Int>] = []
+
+    init(
+        rangeLimit: Int = 10000,
+        overLimitError: ScriptedError = .rangeExceeded,
+        headBlock: Int = 40000,
+        failFromBlocksAtOrAbove: Int? = nil
+    ) {
+        self.rangeLimit = rangeLimit
+        self.overLimitError = overLimitError
+        self.headBlock = headBlock
+        self.failFromBlocksAtOrAbove = failFromBlocksAtOrAbove
+    }
+
+    // Locking lives in synchronous methods: NSLock cannot be taken directly inside an
+    // async context, and `withLock` availability differs across platforms.
+    var requestedRanges: [ClosedRange<Int>] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _requestedRanges
+    }
+
+    private func record(_ range: ClosedRange<Int>) {
+        lock.lock()
+        defer { lock.unlock() }
+        _requestedRanges.append(range)
+    }
+
+    func send<P: Encodable, U: Decodable>(method: String, params: P, receive _: U.Type) async throws -> Any {
+        switch method {
+        case "eth_blockNumber":
+            return "0x" + String(headBlock, radix: 16)
+        case "eth_getLogs":
+            let (from, to) = try decodeRange(params)
+            record(from ... max(from, to))
+
+            if to - from > rangeLimit {
+                throw jsonRPCError(overLimitError)
+            }
+            if let threshold = failFromBlocksAtOrAbove, from >= threshold {
+                throw jsonRPCError(.generic)
+            }
+            return [log(atBlock: from)]
+        default:
+            throw JSONRPCError.noResult
+        }
+    }
+
+    // MARK: Helpers
+
+    private func jsonRPCError(_ scripted: ScriptedError) -> JSONRPCError {
+        .executionError(
+            JSONRPCErrorResult(
+                id: 1,
+                jsonrpc: "2.0",
+                error: JSONRPCErrorDetail(code: scripted.code, message: scripted.message, data: nil)
+            )
+        )
+    }
+
+    private func log(atBlock block: Int) -> EthereumLog {
+        EthereumLog(
+            logIndex: 0,
+            transactionIndex: 0,
+            transactionHash: "0x\(String(block, radix: 16))",
+            blockHash: "0x0",
+            blockNumber: EthereumBlock(rawValue: block),
+            address: EthereumAddress("0x23d0a442580c01e420270fba6ca836a8b2353acb"),
+            data: "0x",
+            topics: [],
+            removed: false
+        )
+    }
+
+    /// `eth_getLogs` params encode as `[{fromBlock, toBlock, ...}]`.
+    private func decodeRange(_ params: some Encodable) throws -> (Int, Int) {
+        let data = try JSONEncoder().encode(params)
+        guard
+            let array = try JSONSerialization.jsonObject(with: data) as? [Any],
+            let filter = array.first as? [String: Any],
+            let fromRaw = filter["fromBlock"] as? String,
+            let toRaw = filter["toBlock"] as? String
+        else {
+            throw JSONRPCError.encodingError
+        }
+        return (try blockNumber(fromRaw), try blockNumber(toRaw))
+    }
+
+    private func blockNumber(_ raw: String) throws -> Int {
+        switch raw {
+        case "earliest": return 0
+        case "latest", "pending": return headBlock
+        default:
+            guard let value = Int(hex: raw) else { throw JSONRPCError.decodingError }
+            return value
+        }
+    }
+}
+
+private func makeClient(_ provider: StubNetworkProvider) -> BaseEthereumClient {
+    BaseEthereumClient(
+        networkProvider: provider,
+        url: URL(string: "https://stub.invalid")!,
+        network: .mainnet
+    )
+}
+
+// MARK: - Tests
+
+final class RecursiveLogCollectorTests: XCTestCase {
+    /// T1 — the incident. An error the collector cannot handle must surface, never
+    /// become an empty result the caller reads as "this wallet has no events".
+    func testUnhandledErrorThrowsInsteadOfReturningEmpty() async {
+        let provider = StubNetworkProvider(overLimitError: .generic)
+        let collector = RecursiveLogCollector(ethClient: makeClient(provider))
+
+        do {
+            let logs = try await collector.getAllLogs(
+                addresses: nil,
+                topics: nil,
+                from: EthereumBlock(rawValue: 0),
+                to: EthereumBlock(rawValue: 40000)
+            )
+            XCTFail("Expected a thrown error, got \(logs.count) logs")
+        } catch {
+            // Expected.
+        }
+    }
+
+    /// T2 — existing behaviour: `-32005` still triggers the split.
+    func testTooManyResultsSplitsAndAggregates() async throws {
+        let provider = StubNetworkProvider(overLimitError: .tooManyResults)
+        let collector = RecursiveLogCollector(ethClient: makeClient(provider))
+
+        let logs = try await collector.getAllLogs(
+            addresses: nil,
+            topics: nil,
+            from: EthereumBlock(rawValue: 0),
+            to: EthereumBlock(rawValue: 40000)
+        )
+
+        XCTAssertGreaterThan(logs.count, 1, "Expected the query to be split into several sub-ranges")
+        XCTAssertTrue(
+            provider.requestedRanges.contains { $0.upperBound - $0.lowerBound <= 10000 },
+            "Expected at least one sub-range within the limit"
+        )
+    }
+
+    /// T3 — the new mapping: Infura's `-32602` range-cap error must split, not fail.
+    func testRangeLimitErrorSplitsAndAggregates() async throws {
+        let provider = StubNetworkProvider(overLimitError: .rangeExceeded)
+        let collector = RecursiveLogCollector(ethClient: makeClient(provider))
+
+        let logs = try await collector.getAllLogs(
+            addresses: nil,
+            topics: nil,
+            from: EthereumBlock(rawValue: 0),
+            to: EthereumBlock(rawValue: 40000)
+        )
+
+        XCTAssertGreaterThan(logs.count, 1, "Expected the query to be split into several sub-ranges")
+        XCTAssertTrue(
+            provider.requestedRanges.allSatisfy { $0.lowerBound >= 0 },
+            "Sub-ranges should stay within the requested window"
+        )
+    }
+
+    /// T4 — `.Earliest` must resolve to a concrete block so the split can start.
+    func testEarliestFromBlockResolvesAndSplits() async throws {
+        let provider = StubNetworkProvider(overLimitError: .rangeExceeded)
+        let collector = RecursiveLogCollector(ethClient: makeClient(provider))
+
+        let logs = try await collector.getAllLogs(
+            addresses: nil,
+            topics: nil,
+            from: .Earliest,
+            to: .Latest
+        )
+
+        XCTAssertGreaterThan(logs.count, 1, "Expected .Earliest to resolve rather than abort the split")
+    }
+
+    /// T5 — `-32602` is generic "invalid params". Only the range-cap message may recurse;
+    /// a genuinely malformed request must surface immediately.
+    func testInvalidParamsErrorThrowsWithoutRecursing() async {
+        let provider = StubNetworkProvider(overLimitError: .invalidParams)
+        let collector = RecursiveLogCollector(ethClient: makeClient(provider))
+
+        do {
+            let logs = try await collector.getAllLogs(
+                addresses: nil,
+                topics: nil,
+                from: EthereumBlock(rawValue: 0),
+                to: EthereumBlock(rawValue: 40000)
+            )
+            XCTFail("Expected a thrown error, got \(logs.count) logs")
+        } catch {
+            XCTAssertEqual(provider.requestedRanges.count, 1, "Expected no recursion on a non-range error")
+        }
+    }
+
+    /// T6 — a failure inside one half of a split must propagate, not be swallowed by `try?`.
+    func testFailureWithinSplitPropagates() async {
+        // The left half of the split succeeds; anything in the upper quarter fails.
+        let provider = StubNetworkProvider(overLimitError: .rangeExceeded, failFromBlocksAtOrAbove: 30000)
+        let collector = RecursiveLogCollector(ethClient: makeClient(provider))
+
+        do {
+            let logs = try await collector.getAllLogs(
+                addresses: nil,
+                topics: nil,
+                from: EthereumBlock(rawValue: 0),
+                to: EthereumBlock(rawValue: 40000)
+            )
+            XCTFail("Expected the sub-range failure to propagate, got \(logs.count) logs")
+        } catch {
+            // Expected.
+        }
+    }
+}

--- a/web3swift/src/Client/NetworkProviders/JSONRPC.swift
+++ b/web3swift/src/Client/NetworkProviders/JSONRPC.swift
@@ -58,7 +58,33 @@ public struct JSONRPCErrorResult: Sendable, Decodable {
 public enum JSONRPCErrorCode: Sendable {
     public static let invalidInput = -32000
     public static let tooManyResults = -32005
+    public static let invalidParams = -32602
     public static let contractExecution = 3
+}
+
+extension JSONRPCErrorDetail {
+    /// Whether this error means "your log query covers too much ground, narrow it".
+    ///
+    /// Nodes disagree on how to say it. Some use the dedicated `-32005`; others reject the
+    /// request as generic invalid params (`-32602`) and only name the block-range limit in
+    /// the message. Both are recoverable by splitting the range, so both map to
+    /// `EthereumClientError.tooManyResults`.
+    ///
+    /// `-32602` on its own is *not* enough — it is also returned for genuinely malformed
+    /// requests, which must surface rather than send the caller into a pointless recursion.
+    var isLogRangeLimited: Bool {
+        if code == JSONRPCErrorCode.tooManyResults {
+            return true
+        }
+        guard code == JSONRPCErrorCode.invalidParams else {
+            return false
+        }
+        let text = message.lowercased()
+        return text.contains("exceeds limit")
+            || text.contains("block range")
+            || text.contains("range is too large")
+            || text.contains("query returned more than")
+    }
 }
 
 public enum JSONRPCError: Sendable, Error {

--- a/web3swift/src/Client/Protocols/EthereumProvider.swift
+++ b/web3swift/src/Client/Protocols/EthereumProvider.swift
@@ -244,9 +244,14 @@ extension EthereumRPCProtocol {
             }
         } catch {
             if let error = error as? JSONRPCError,
-               case let .executionError(innerError) = error,
-               innerError.error.code == JSONRPCErrorCode.tooManyResults {
-                throw EthereumClientError.tooManyResults
+               case let .executionError(innerError) = error {
+                if innerError.error.isLogRangeLimited {
+                    throw EthereumClientError.tooManyResults
+                }
+                // Keep the node's code and message. Flattening every failure to
+                // `unexpectedReturnValue` here is what made range-limit rejections
+                // indistinguishable from any other error further up the stack.
+                throw EthereumClientError.executionError(innerError.error)
             } else {
                 throw EthereumClientError.unexpectedReturnValue
             }

--- a/web3swift/src/Client/RecursiveLogCollector.swift
+++ b/web3swift/src/Client/RecursiveLogCollector.swift
@@ -26,50 +26,60 @@ struct RecursiveLogCollector {
     func getAllLogs(addresses: [EthereumAddress]?, topics: Topics?, from: EthereumBlock, to: EthereumBlock) async throws -> [EthereumLog] {
         do {
             return try await getLogs(addresses: addresses, topics: topics, from: from, to: to)
-        } catch {
-            if let error = error as? EthereumClientError, error == .tooManyResults {
-                guard let middleBlock = await getMiddleBlock(from: from, to: to) else {
-                    throw EthereumClientError.unexpectedReturnValue
-                }
-
-                guard let lhs = try? await getAllLogs(addresses: addresses, topics: topics, from: from, to: middleBlock),
-                      let rhs = try? await getAllLogs(addresses: addresses, topics: topics, from: middleBlock, to: to) else {
-                    throw EthereumClientError.unexpectedReturnValue
-                }
-                return lhs + rhs
-            }
+        } catch let error as EthereumClientError where error == .tooManyResults {
+            return try await splitAndCollect(addresses: addresses, topics: topics, from: from, to: to)
         }
-        return []
+        // Any other error propagates. Returning an empty array here would be
+        // indistinguishable from "this range genuinely contains no logs".
+    }
+
+    /// Halves the range and collects both sides. Only called for errors that narrowing can fix.
+    private func splitAndCollect(
+        addresses: [EthereumAddress]?,
+        topics: Topics?,
+        from: EthereumBlock,
+        to: EthereumBlock
+    ) async throws -> [EthereumLog] {
+        guard
+            let fromBlock = await resolveBlockNumber(from),
+            let toBlock = await resolveBlockNumber(to),
+            // Below two blocks there is nothing left to halve, so recursing would not
+            // terminate. Surface the original error instead.
+            toBlock - fromBlock >= 2 else {
+            throw EthereumClientError.tooManyResults
+        }
+
+        let middle = fromBlock + (toBlock - fromBlock) / 2
+
+        let lhs = try await getAllLogs(
+            addresses: addresses,
+            topics: topics,
+            from: EthereumBlock(rawValue: fromBlock),
+            to: EthereumBlock(rawValue: middle)
+        )
+        let rhs = try await getAllLogs(
+            addresses: addresses,
+            topics: topics,
+            // Start after `middle`; both halves including it would duplicate its logs.
+            from: EthereumBlock(rawValue: middle + 1),
+            to: EthereumBlock(rawValue: toBlock)
+        )
+        return lhs + rhs
+    }
+
+    /// Resolves a block to a concrete number so the range can be halved.
+    /// `.Earliest` is block zero; `.Latest` and `.Pending` resolve to the current head.
+    private func resolveBlockNumber(_ block: EthereumBlock) async -> Int? {
+        if let number = block.intValue {
+            return number
+        }
+        if block == .Earliest {
+            return 0
+        }
+        return try? await ethClient.eth_blockNumber()
     }
 
     private func getLogs(addresses: [EthereumAddress]?, topics: Topics? = nil, from: EthereumBlock, to: EthereumBlock) async throws -> [EthereumLog] {
         try await ethClient.getLogs(addresses: addresses, topics: topics, fromBlock: from, toBlock: to)
-    }
-
-    private func getMiddleBlock(from: EthereumBlock, to: EthereumBlock) async -> EthereumBlock? {
-        func toBlockNumber() async -> Int? {
-            if let toBlockNumber = to.intValue {
-                toBlockNumber
-            } else if let currentBlock = try? await getCurrentBlock(), let currentBlockNumber = currentBlock.intValue {
-                currentBlockNumber
-            } else {
-                nil
-            }
-        }
-
-        guard let fromBlockNumber = from.intValue, let toBlockNumber = await toBlockNumber() else {
-            return nil
-        }
-
-        return EthereumBlock(rawValue: fromBlockNumber + (toBlockNumber - fromBlockNumber) / 2)
-    }
-
-    private func getCurrentBlock() async throws -> EthereumBlock {
-        do {
-            let block = try await ethClient.eth_blockNumber()
-            return EthereumBlock(rawValue: block)
-        } catch {
-            throw EthereumClientError.unexpectedReturnValue
-        }
     }
 }


### PR DESCRIPTION
## Why

`RecursiveLogCollector.getAllLogs` catches every error but only handles `.tooManyResults`. Anything else falls out of the `catch` and hits **`return []`** — no throw, no log. A failed query becomes indistinguishable from a range that genuinely contains no logs.

This is currently causing a production incident. Infura began capping `eth_getLogs` at a **10,000 block range**, rejecting wider requests with **`-32602`** rather than the `-32005` the collector recognises:

```
{"error":{"code":-32602,"message":"range 20000 exceeds limit of 10000"}}   # 20k → reject
                                                                            # 9k  → 200 OK
```

So every log-driven read — token discovery, ERC-20 transfers, wallet events, the module registry — silently returned nothing. Users saw empty balances and missing assets with no error surfaced anywhere.

**This is an Infura-side restriction, not an Ethereum protocol or geth limit.** The same query against a self-hosted node is unaffected by this rule. Note that providers which do impose their own caps signal them differently — Cloudflare, for example, returns `-32047` with `"range too large. Max range: 800"`. `isLogRangeLimited` therefore recognises the Infura shape specifically; for other providers this PR still converts a silent `[]` into a surfaced error, it just won't auto-split them.

## What changed

**`RecursiveLogCollector`**
- Rethrow unhandled errors instead of `return []`. This is the core fix.
- Stop swallowing failures from either half of a split (`try?` → `try`).
- Resolve `.Earliest` to block zero so a split can actually start from it. Previously `Earliest.intValue` was `nil`, so `getMiddleBlock` returned `nil` and threw.
- Halt splitting below a two-block range, so a misclassified error cannot recurse forever.
- Start the right half at `middle + 1`. Both halves previously included the midpoint and duplicated its logs.
- Removed `getMiddleBlock` / `getCurrentBlock`, now unused.

**`JSONRPC`**
- `JSONRPCErrorDetail.isLogRangeLimited` treats `-32602` as a range limit **only when the message names one**. `-32602` is also generic "invalid params", so gating on the bare code would send genuinely malformed requests into pointless recursion.

**`EthereumProvider.getLogs`**
- Preserve the node's code and message as `.executionError(detail)` rather than flattening every failure to `.unexpectedReturnValue`.

No new `EthereumClientError` case — this reuses `.tooManyResults`, so no exhaustive switch in any consumer breaks.

### Credit

@mdab121 identified this and submitted the same core fix in **#387** ("RPC get logs used to fail silently with empty array instead of throwing an error") back in October 2025. That PR is still open with no reviews — had it landed, the incident above would not have happened.

This PR supersedes it, keeping the same central change (`throw` instead of `return []`) and adding the `-32602` mapping, `.Earliest` resolution, the termination guard and test coverage. #387 can be closed once this merges.

## Reviewer callouts — two behaviour changes affecting all consumers

1. **Non-range JSON-RPC errors from `getLogs` now surface as `.executionError(detail)`** instead of `.unexpectedReturnValue`. Anyone matching on `.unexpectedReturnValue` will see different values.
2. **The midpoint log is no longer duplicated** across split halves. Anyone deduplicating downstream will see one fewer log.

Both are improvements, but they are visible.

## Tests

New `RecursiveLogCollectorTests`, using a stubbed `NetworkProviderProtocol` injected through `BaseEthereumClient.init` — no node required.

| Test | Covers |
|---|---|
| `testUnhandledErrorThrowsInsteadOfReturningEmpty` | The incident. Fails on `develop` (returns `[]`). |
| `testTooManyResultsSplitsAndAggregates` | `-32005` behaviour preserved. |
| `testRangeLimitErrorSplitsAndAggregates` | `-32602` range-cap now splits. |
| `testEarliestFromBlockResolvesAndSplits` | `.Earliest` resolves rather than aborting. |
| `testInvalidParamsErrorThrowsWithoutRecursing` | Malformed `-32602` surfaces, no recursion. |
| `testFailureWithinSplitPropagates` | Sub-range failure is not swallowed. |

Written before the fix: 5 of 6 failed on unmodified `develop`, with `got 0 logs`.

## Verification

- 6/6 unit tests pass locally, offline.
- **Live against mainnet Infura:** a 25,000-block over-cap range returned **8,934 logs** (previously 0). A malformed request correctly threw `-32602` instead of returning empty. (Throwaway check, not committed.)
- `./scripts/runSwiftFormat.sh -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


