### PR TITLE
tech: Run the test suite without repository secrets

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,6 +3,10 @@ name: CI
 on:
   pull_request:
     branches: [ develop ]
+  # Pull requests from forks run without secrets, so the tests that spend Ether skip there. Running
+  # again on the merge commit is what actually exercises them.
+  push:
+    branches: [ develop ]
   workflow_dispatch:
 
 permissions:
@@ -29,13 +33,12 @@ jobs:
     runs-on: macos-latest
 
     env:
+      # Empty for pull requests from forks, which GitHub never gives secrets to. The tests that
+      # spend Ether skip themselves when it is absent; everything else runs.
       TESTS_PRIVATEKEY: ${{ secrets.TESTS_PRIVATEKEY }}
 
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-    - name: SetupKey
-      run: ./scripts/setupKey.sh "${{ secrets.TESTS_PRIVATEKEY }}"
 
     - name: Build
       run: swift build
@@ -63,13 +66,12 @@ jobs:
       image: swift:6.0-jammy
 
     env:
+      # Empty for pull requests from forks, which GitHub never gives secrets to. The tests that
+      # spend Ether skip themselves when it is absent; everything else runs.
       TESTS_PRIVATEKEY: ${{ secrets.TESTS_PRIVATEKEY }}
 
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-    - name: SetupKey
-      run: ./scripts/setupKey.sh "${{ secrets.TESTS_PRIVATEKEY }}"
 
     - name: Build
       run: swift build

--- a/.gitignore
+++ b/.gitignore
@@ -66,4 +66,7 @@ fastlane/screenshots
 fastlane/test_output
 
 scripts/bin/*
+
+# No longer generated — the funded key comes from TESTS_PRIVATEKEY now. Kept ignored so a stale
+# copy in an existing clone does not get committed by accident.
 TestConfig_private.swift

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,7 @@ scripts/bin/*
 # No longer generated — the funded key comes from TESTS_PRIVATEKEY now. Kept ignored so a stale
 # copy in an existing clone does not get committed by accident.
 TestConfig_private.swift
+
+# Where TESTS_PRIVATEKEY tends to end up locally, via direnv or a sourced file.
+.envrc
+.env

--- a/README.md
+++ b/README.md
@@ -172,9 +172,19 @@ Take a look at [ZKSyncTransaction](https://github.com/argentlabs/web3.swift/blob
 
 ### Running Tests
 
-Some of the tests require a private key, which is not stored in the repository. You can ignore these while testing locally, as CI will use the encrypted secret key from Github.
+`swift test` works on a fresh clone with no setup. The tests hit public RPC endpoints and sign with a
+throwaway key that is committed in `TestConfig.swift`, so nothing has to be configured.
 
-It's better to run only the tests you need, instead of the whole test suite while developing. If you ever need to set up the key locally, take a look at `TestConfig.swift` where you can manually set it up. Alternatively you can set it up by calling the script `setupKey.sh` and passing the value (adding 0x) so it's written to an ignored file.
+One test spends Ether and needs the funded account, whose key is a repository secret. It skips
+unless the key is present, which is the normal case locally and on pull requests from forks — GitHub
+never gives secrets to forks. If you do have the key:
+
+```sh
+export TESTS_PRIVATEKEY=0x...
+swift test
+```
+
+While developing it is usually quicker to run only the tests you need, with `swift test --filter`.
 
 ## Dependencies
 

--- a/scripts/setupKey.sh
+++ b/scripts/setupKey.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-# write first argument to a Test
-echo "extension TestConfig {\nstatic let privateKey = \"$1\"\nstatic let publicKey = \"0xE78e5ecb061fE3DD1672dDDA7b5116213B23B99A\"\n}" > web3sTests/TestConfig_private.swift

--- a/web3sTests/Account/EthereumAccountTests.swift
+++ b/web3sTests/Account/EthereumAccountTests.swift
@@ -16,14 +16,14 @@ class EthereumAccountTests: XCTestCase {
     }
     
     func testLoadAccountAndAddress() {
-        let account = try! EthereumAccount(keyStorage: TestEthereumKeyStorage(privateKey: TestConfig.privateKey))
-        XCTAssertEqual(account.address, EthereumAddress(TestConfig.publicKey), "Failed to load private key. Ensure key is valid in TestConfig.swift")
+        let account = try! EthereumAccount(keyStorage: TestEthereumKeyStorage(privateKey: TestConfig.signingPrivateKey))
+        XCTAssertEqual(account.address, EthereumAddress(TestConfig.signingPublicKey))
     }
 
     func testLoadAccountAndAddressMultiple() {
-        let storage = TestEthereumMultipleKeyStorage(privateKey: TestConfig.privateKey)
-        let account = try! EthereumAccount(addressString: TestConfig.publicKey, keyStorage: storage)
-        XCTAssertEqual(account.address, EthereumAddress(TestConfig.publicKey), "Failed to load private key. Ensure key is valid in TestConfig.swift")
+        let storage = TestEthereumMultipleKeyStorage(privateKey: TestConfig.signingPrivateKey)
+        let account = try! EthereumAccount(addressString: TestConfig.signingPublicKey, keyStorage: storage)
+        XCTAssertEqual(account.address, EthereumAddress(TestConfig.signingPublicKey))
     }
 
     func testCreateAccount() {

--- a/web3sTests/Client/EthereumClientTests.swift
+++ b/web3sTests/Client/EthereumClientTests.swift
@@ -31,17 +31,19 @@ struct TransferMatchingSignatureEvent: ABIEvent {
 
 class EthereumClientTests: XCTestCase {
     var client: EthereumClientProtocol?
-    var account: EthereumAccount?
-    
+
+    // The funded account's address. These read-only calls assert against its on-chain history,
+    // which is public, so they need the address but not the key.
+    let fundedAddress = EthereumAddress(TestConfig.publicKey)
+
     override func setUp() {
         super.setUp()
         client = TestConfig.makeClient(url: TestConfig.clientUrl, network: TestConfig.network)
-        account = try? EthereumAccount(keyStorage: TestEthereumKeyStorage(privateKey: TestConfig.privateKey))
     }
 
     func testEthGetTransactionCount() async {
         do {
-            let count = try await client?.eth_getTransactionCount(address: account!.address, block: .Latest)
+            let count = try await client?.eth_getTransactionCount(address: fundedAddress, block: .Latest)
             XCTAssertNotEqual(count, 0)
         } catch {
             XCTFail("Expected count but failed \(error).")
@@ -50,7 +52,7 @@ class EthereumClientTests: XCTestCase {
 
     func testEthGetTransactionCountPending() async {
         do {
-            let count = try await client?.eth_getTransactionCount(address: account!.address, block: .Pending)
+            let count = try await client?.eth_getTransactionCount(address: fundedAddress, block: .Pending)
             XCTAssertNotEqual(count, 0)
         } catch {
             XCTFail("Expected count but failed \(error).")
@@ -59,7 +61,7 @@ class EthereumClientTests: XCTestCase {
 
     func testEthGetBalance() async throws {
         do {
-            let balance = try await client?.eth_getBalance(address: account?.address ?? .zero, block: .Latest)
+            let balance = try await client?.eth_getBalance(address: fundedAddress, block: .Latest)
             XCTAssertNotNil(balance, "Balance not available")
         } catch {
             XCTFail("Expected balance but failed \(error).")
@@ -117,13 +119,16 @@ class EthereumClientTests: XCTestCase {
         }
     }
 
-    func testEthSendRawTransaction() async {
+    // The only test in the suite that spends Ether, so the only one that needs the funded key.
+    func testEthSendRawTransaction() async throws {
+        let account = try EthereumAccount(keyStorage: TestEthereumKeyStorage(privateKey: try requireFundedPrivateKey()))
+
         do {
             let gasPrice = try await client?.eth_gasPrice()
             let tx = EthereumTransaction(from: nil, to: "0x3c1bd6b420448cf16a389c8b0115ccb3660bb854", value: BigUInt(1), data: nil, nonce: 2, gasPrice: gasPrice ?? BigUInt(9000000), gasLimit: BigUInt(30000), chainId: EthereumNetwork.sepolia.intValue)
 
-            let txHash = try await client?.eth_sendRawTransaction(tx, withAccount: account!)
-            XCTAssertNotNil(txHash, "No tx hash, ensure key is valid in TestConfig.swift")
+            let txHash = try await client?.eth_sendRawTransaction(tx, withAccount: account)
+            XCTAssertNotNil(txHash, "No tx hash returned for the funded account")
         } catch {
             XCTFail("Expected tx but failed \(error).")
         }

--- a/web3sTests/OffchainLookup/OffchainLookupTests.swift
+++ b/web3sTests/OffchainLookup/OffchainLookupTests.swift
@@ -140,13 +140,11 @@ extension EthereumClientError {
 
 class OffchainLookupTests: XCTestCase {
     var client: EthereumClientProtocol!
-    var account: EthereumAccount!
     var offchainLookup = OffchainLookup(address: .zero, urls: [], callData: Data(), callbackFunction: Data(), extraData: Data())
-    
+
     override func setUp() {
         super.setUp()
         client = TestConfig.makeClient(url: TestConfig.clientUrl, network: TestConfig.network)
-        account = try? EthereumAccount(keyStorage: TestEthereumKeyStorage(privateKey: TestConfig.privateKey))
     }
 
     func test_GivenFunctionWithOffchainLookupError_ThenDecodesLookupParamsCorrectly() async throws {

--- a/web3sTests/TestConfig.swift
+++ b/web3sTests/TestConfig.swift
@@ -4,7 +4,26 @@
 //
 
 import Foundation
+import XCTest
 import web3
+
+/// The funded account's key, or a skip.
+///
+/// Call this from any test that has to spend Ether. Outside contributors and fresh clones do not
+/// have the key, and a skip tells them that plainly instead of failing on something they cannot
+/// fix.
+func requireFundedPrivateKey() throws -> String {
+    guard let key = TestConfig.fundedPrivateKey else {
+        throw XCTSkip(
+            """
+            Skipping: this test spends Ether and needs the funded account. Export TESTS_PRIVATEKEY \
+            to run it. Pull requests from forks never receive repository secrets, so it is expected \
+            to skip there.
+            """
+        )
+    }
+    return key
+}
 
 struct TestConfig: Sendable {
     // RPC endpoints.
@@ -28,11 +47,36 @@ struct TestConfig: Sendable {
     static let wssUrl = "wss://sepolia.gateway.tenderly.co"
     static let wssMainnetUrl = "wss://mainnet.gateway.tenderly.co"
 
-    // An EOA with some Ether, so that we can test sending transactions (pay for gas). Set by CI
-//    static let privateKey = "SET_YOUR_KEY_HERE"
+    // A throwaway key, committed on purpose. It holds nothing on any network and never will.
+    //
+    // Most of what used to need "the" key only needs *a* key: deriving an address, producing a
+    // deterministic signature, unlocking a fake key store. Those use this one, so the suite runs
+    // on a fresh clone with no setup, and on pull requests from forks, which GitHub never gives
+    // secrets to.
+    //
+    // This is the well-known Anvil/Hardhat account #0. It is public by design — never put
+    // anything in it.
+    static let signingPrivateKey = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 
-    // This is the expected public key (address) from the above private key
-//    static let publicKey = "SET_YOUR_PUBLIC_ADDRESS_HERE"
+    // The address `signingPrivateKey` derives to.
+    static let signingPublicKey = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+
+    // The address of the funded account. An address is not a secret, and the log and nonce tests
+    // need this specific one because the fixtures they assert against are its on-chain history.
+    static let publicKey = "0xE78e5ecb061fE3DD1672dDDA7b5116213B23B99A"
+
+    // The key for the account above, which holds real Sepolia Ether. Supplied through the
+    // environment so it never has to be written to a file: CI passes the repository secret,
+    // and locally you can `export TESTS_PRIVATEKEY=0x...` if you have it.
+    //
+    // Nil whenever it is absent, which is the normal case for outside contributors. The handful
+    // of tests that have to pay gas skip themselves rather than failing.
+    static let fundedPrivateKey: String? = {
+        guard let key = ProcessInfo.processInfo.environment["TESTS_PRIVATEKEY"], !key.isEmpty else {
+            return nil
+        }
+        return key
+    }()
 
     // Block window used by the log and event tests.
     //

--- a/web3sTests/ZKSync/EthereumClient+ZKSyncTests.swift
+++ b/web3sTests/ZKSync/EthereumClient+ZKSyncTests.swift
@@ -11,7 +11,6 @@ import BigInt
 
 
 final class EthereumClientZKSyncTests: XCTestCase {
-    let eoaAccount = try! EthereumAccount(keyStorage: TestEthereumKeyStorage(privateKey: TestConfig.privateKey))
     let client = ZKSyncClient(url: TestConfig.ZKSync.clientURL, network: TestConfig.ZKSync.network)
     var eoaEthTransfer = ZKSyncTransaction(
         from: .init(TestConfig.publicKey),

--- a/web3sTests/ZKSync/ZKSyncTransactionTests.swift
+++ b/web3sTests/ZKSync/ZKSyncTransactionTests.swift
@@ -21,7 +21,8 @@ final class ZKSyncTransactionTests: XCTestCase {
     let from = EthereumAddress(TestConfig.publicKey)
     let to = EthereumAddress("0x64d0eA4FC60f27E74f1a70Aa6f39D403bBe56793")
 
-    let eoaAccount = try! EthereumAccount(keyStorage: TestEthereumKeyStorage(privateKey: TestConfig.privateKey))
+    // Signing needs a key but not a funded one, so this uses the committed throwaway account.
+    let eoaAccount = try! EthereumAccount(keyStorage: TestEthereumKeyStorage(privateKey: TestConfig.signingPrivateKey))
     
     let eoaTransfer = ZKSyncTransaction(
         from: .init(TestConfig.publicKey),
@@ -41,11 +42,24 @@ final class ZKSyncTransactionTests: XCTestCase {
         XCTAssertEqual(signed.raw?.web3.hexString, "0x71f891048405f5e1008405f5e10083080a229464d0ea4fc60f27e74f1a70aa6f39d403bbe56793865af3107a400080820118808082011894e78e5ecb061fe3dd1672ddda7b5116213b23b99a82c350c0b84155943b2228183717fd3be583bde0f6ec168247ea8d304eb13b3e7e76ebf6bf2c3c77734e163711c5963ac25a15f95d9ac63b82c2c427fd4eb011c5e3a22f89221bc0")
     }
     
-    func test_GivenETHTransfer_WhenSigningWithEOAAccount_ThenSignsAndEncodesCorrectly()  {
-        let signed = try? eoaAccount.sign(zkTransaction: eoaTransfer)
-        
-        XCTAssertEqual(signed?.raw?.web3.hexString,
-                       "0x71f891048405f5e1008405f5e10083080a229464d0ea4fc60f27e74f1a70aa6f39d403bbe56793865af3107a400080820118808082011894e78e5ecb061fe3dd1672ddda7b5116213b23b99a82c350c0b841c956ba7bfdf54a6d3f3b21c51465ad37df22b6258835b6e162259d6d3eec02ae11f9d17c3aafd47df49bd77e33befed87bbaff44e4c497228bfa8bcc9fa64bc31bc0")
+    // Signed by the committed throwaway account rather than the funded one, so the expected value
+    // differs from the pre-recorded `signature` used by the encode-only tests above. ECDSA here is
+    // deterministic (RFC 6979), so this stays stable.
+    func test_GivenETHTransfer_WhenSigningWithEOAAccount_ThenSignsAndEncodesCorrectly() throws {
+        let transfer = with(eoaTransfer) { $0.from = .init(TestConfig.signingPublicKey) }
+
+        let signed = try XCTUnwrap(try? eoaAccount.sign(zkTransaction: transfer))
+
+        // Check the signature is the right one rather than only that it has not changed: recover
+        // the signer from the EIP-712 digest and confirm it is the account that signed.
+        let signer = try KeyUtil.recoverPublicKey(
+            message: try transfer.eip712Representation.signableHash(),
+            signature: signed.signature.raw
+        )
+        XCTAssertEqual(signer, TestConfig.signingPublicKey.lowercased())
+
+        XCTAssertEqual(signed.raw?.web3.hexString,
+                       "0x71f891048405f5e1008405f5e10083080a229464d0ea4fc60f27e74f1a70aa6f39d403bbe56793865af3107a400080820118808082011894f39fd6e51aad88f6f4ce6ab8827279cfffb9226682c350c0b841f507c970595e5f6a3ea175b52a152b99f7234659f4331c1bcdd0a69ce76d54b2088b306121ee4b0630f8e94e3610de6bda693cc3a2127b2fdee5875640b644f01cc0")
     }
 
     func test_GivenERC20Transfer_EncodesCorrectly() {

--- a/web3sTests/ZKSync/ZKSyncTransactionTests.swift
+++ b/web3sTests/ZKSync/ZKSyncTransactionTests.swift
@@ -42,16 +42,11 @@ final class ZKSyncTransactionTests: XCTestCase {
         XCTAssertEqual(signed.raw?.web3.hexString, "0x71f891048405f5e1008405f5e10083080a229464d0ea4fc60f27e74f1a70aa6f39d403bbe56793865af3107a400080820118808082011894e78e5ecb061fe3dd1672ddda7b5116213b23b99a82c350c0b84155943b2228183717fd3be583bde0f6ec168247ea8d304eb13b3e7e76ebf6bf2c3c77734e163711c5963ac25a15f95d9ac63b82c2c427fd4eb011c5e3a22f89221bc0")
     }
     
-    // Signed by the committed throwaway account rather than the funded one, so the expected value
-    // differs from the pre-recorded `signature` used by the encode-only tests above. ECDSA here is
-    // deterministic (RFC 6979), so this stays stable.
     func test_GivenETHTransfer_WhenSigningWithEOAAccount_ThenSignsAndEncodesCorrectly() throws {
         let transfer = with(eoaTransfer) { $0.from = .init(TestConfig.signingPublicKey) }
 
         let signed = try XCTUnwrap(try? eoaAccount.sign(zkTransaction: transfer))
 
-        // Check the signature is the right one rather than only that it has not changed: recover
-        // the signer from the EIP-712 digest and confirm it is the account that signed.
         let signer = try KeyUtil.recoverPublicKey(
             message: try transfer.eip712Representation.signableHash(),
             signature: signed.signature.raw


### PR DESCRIPTION
Makes the suite runnable with no credentials, so pull requests from forks get a real CI signal and a fresh clone can run `swift test` immediately.

Unblocks #392, which is currently red through no fault of its own.

## The problem

GitHub never gives repository secrets to pull requests from forks. `setupKey.sh` therefore wrote `privateKey = ""`, which compiles — so this was never a build failure, despite appearances. The suite got as far as the first test that force-unwrapped an account built from that key and died:

```
error: Process ... exited with unexpected signal code 6
```

Signal 6 is an abort, and it takes the whole test process with it, so every suite after it never ran. Same pattern as the Linux abort in #395: what looks like a couple of failing tests is actually most of the suite never executing.

## What actually needed the key

Three different needs were hidden behind one secret. Only the first is secret at all:

| need | tests | secret? |
|---|---|---|
| Pay for gas | `testEthSendRawTransaction` | **yes** |
| A specific key — derive an address, produce a deterministic signature | `testLoadAccountAndAddress`, `…Multiple`, zkSync signing test | no: needs *a* key, not *the* key |
| Name an address on chain | `getTransactionCount` ×2, `getBalance` | no: an address is public |

Two further suites — `OffchainLookupTests` and `EthereumClientZKSyncTests` — built accounts from the key and **never used them**. That is most of why the abort had such a wide blast radius.

## Changes

- **Funded key → `TESTS_PRIVATEKEY` environment variable.** `setupKey.sh` and the generated `TestConfig_private.swift` are deleted; CI already exported this variable alongside running the script.
- **Throwaway key committed** as `TestConfig.signingPrivateKey` — the well-known Anvil/Hardhat account #0, public by design and holding nothing. Used wherever a key is needed but funds are not.
- **Funded address committed** as `TestConfig.publicKey`, unchanged in value. It was already in `setupKey.sh` in the clear; an address is not a secret, and the nonce and log fixtures are its on-chain history.
- **One skip.** `testEthSendRawTransaction` calls `requireFundedPrivateKey()`, which throws `XCTSkip` with an explanation when the variable is absent.
- **Dead accounts deleted** from `OffchainLookupTests` and `EthereumClientZKSyncTests`.
- **CI runs on pushes to `develop`**, since a fork's PR cannot exercise the funded test before it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)