### PR TITLE
tech: Update BigInt to 5.7.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "6a7b6f94e12ad64740435b6a1f32724d65be46fe7a993e5ced1b75ca71949624",
+  "originHash" : "80ed2c9e91dc8e7d9e1f025daa79e73d3dd5175175107df2971608203af7c40a",
   "pins" : [
     {
       "identity" : "bigint",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/attaswift/BigInt",
       "state" : {
-        "revision" : "0ed110f7555c34ff468e72e1686e59721f2b0da6",
-        "version" : "5.3.0"
+        "revision" : "e07e00fa1fd435143a2dcf8b7eec9a7710b2fdfe",
+        "version" : "5.7.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "web3-zksync.swift", targets: ["web3-zksync"])
     ],
     dependencies: [
-        .package(url: "https://github.com/attaswift/BigInt", from: "5.3.0"),
+        .package(url: "https://github.com/attaswift/BigInt", .upToNextMajor(from: "5.7.0")),
         .package(url: "https://github.com/iwill/generic-json-swift", .upToNextMajor(from: "2.0.2")),
         .package(url: "https://github.com/GigaBitcoin/secp256k1.swift.git", .upToNextMajor(from: "0.6.0")),
         .package(url: "https://github.com/vapor/websocket-kit.git", from: "2.16.1"),

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "web3-zksync.swift", targets: ["web3-zksync"])
     ],
     dependencies: [
-        .package(url: "https://github.com/attaswift/BigInt", .upToNextMajor(from: "5.7.0")),
+        .package(url: "https://github.com/attaswift/BigInt", from: "5.7.0"),
         .package(url: "https://github.com/iwill/generic-json-swift", .upToNextMajor(from: "2.0.2")),
         .package(url: "https://github.com/GigaBitcoin/secp256k1.swift.git", .upToNextMajor(from: "0.6.0")),
         .package(url: "https://github.com/vapor/websocket-kit.git", from: "2.16.1"),

--- a/Package@swift-6.1.swift
+++ b/Package@swift-6.1.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "web3-zksync.swift", targets: ["web3-zksync"])
     ],
     dependencies: [
-        .package(url: "https://github.com/attaswift/BigInt", from: "5.3.0"),
+        .package(url: "https://github.com/attaswift/BigInt", .upToNextMajor(from: "5.7.0")),
         .package(url: "https://github.com/iwill/generic-json-swift", .upToNextMajor(from: "2.0.2")),
         .package(url: "https://github.com/GigaBitcoin/secp256k1.swift.git", .upToNextMajor(from: "0.6.0")),
         .package(url: "https://github.com/vapor/websocket-kit.git", from: "2.16.1"),

--- a/Package@swift-6.1.swift
+++ b/Package@swift-6.1.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "web3-zksync.swift", targets: ["web3-zksync"])
     ],
     dependencies: [
-        .package(url: "https://github.com/attaswift/BigInt", .upToNextMajor(from: "5.7.0")),
+        .package(url: "https://github.com/attaswift/BigInt", from: "5.7.0"),
         .package(url: "https://github.com/iwill/generic-json-swift", .upToNextMajor(from: "2.0.2")),
         .package(url: "https://github.com/GigaBitcoin/secp256k1.swift.git", .upToNextMajor(from: "0.6.0")),
         .package(url: "https://github.com/vapor/websocket-kit.git", from: "2.16.1"),

--- a/web3sTests/Extensions/HexExtensionsTests.swift
+++ b/web3sTests/Extensions/HexExtensionsTests.swift
@@ -46,6 +46,16 @@ class HexExtensionsTests: XCTestCase {
         XCTAssertEqual(BigInt(hex: "0x2A521C551E7F200D")!, 3049531049592692749)
     }
 
+    // Nodes return a bare "0x" for zero, so it has to parse. BigInt 5.7 stopped accepting the
+    // empty string, which is what this and the two cases above guard against.
+    func testBigIntegersFromABareHexPrefix() {
+        XCTAssertEqual(BigUInt(hex: "0x")!, 0)
+        XCTAssertEqual(BigInt(hex: "0x")!, 0)
+
+        // Int deliberately does not follow: it has always returned nil for an empty string.
+        XCTAssertNil(Int(hex: "0x"))
+    }
+
     func testBigIntToHexStringNoLeadingZeros() {
         XCTAssertEqual(BigUInt(5000000000).web3.hexStringNoLeadingZeroes, "0x12a05f200")
     }

--- a/web3swift/src/Contract/Statically Typed/ABIRawType+Static.swift
+++ b/web3swift/src/Contract/Statically Typed/ABIRawType+Static.swift
@@ -44,9 +44,6 @@ extension EthereumAddress: ABIType {
     }
 }
 
-extension BigInt: @unchecked Sendable {}
-extension BigUInt: @unchecked Sendable {}
-
 extension BigInt: ABIType {
     public static var rawType: ABIRawType { .FixedInt(256) }
     public static var parser: ParserFunction {

--- a/web3swift/src/Extensions/HexExtensions.swift
+++ b/web3swift/src/Extensions/HexExtensions.swift
@@ -8,7 +8,7 @@ import Foundation
 
 public extension BigUInt {
     init?(hex: String) {
-        self.init(hex.web3.noHexPrefix.lowercased(), radix: 16)
+        self.init(hex.web3.digitsOrZero, radix: 16)
     }
 }
 
@@ -24,7 +24,19 @@ public extension Web3Extensions where Base == BigUInt {
 
 public extension BigInt {
     init?(hex: String) {
-        self.init(hex.web3.noHexPrefix.lowercased(), radix: 16)
+        self.init(hex.web3.digitsOrZero, radix: 16)
+    }
+}
+
+extension Web3Extensions where Base == String {
+    /// The hex digits, with an empty string standing in for zero.
+    ///
+    /// `"0x"` means zero on the wire and these initialisers have always read it that way. BigInt
+    /// 5.7 stopped parsing the empty string, so spell the substitution out. `Int(hex:)`
+    /// deliberately does not use this — it still returns nil for an empty string.
+    var digitsOrZero: String {
+        let digits = base.web3.noHexPrefix.lowercased()
+        return digits.isEmpty ? "0" : digits
     }
 }
 


### PR DESCRIPTION
Supersedes the BigInt half of #386.

Two things break in 5.7.0:

- It adds Swift 6 strict concurrency, so `BigInt`/`BigUInt` declare `Sendable` themselves and our `@unchecked` conformances became duplicates. The build had been warning this would happen.
- It stopped parsing the empty string, breaking `BigUInt(hex:)`/`BigInt(hex:)` for a bare `"0x"` — the test process aborted on a force unwrap. Nodes return `"0x"` for zero and these initialisers have always read it that way, so the fix substitutes a zero digit rather than changing the contract. `Int(hex:)` still returns nil for an empty string, as its test already pinned.

Staying on 5.7.0 rather than 6.0.0: that release only carries a WASI `_mantissa` fix and extra CI runners, and its manifest declares swift-tools-version 6.3 — which would impose a Swift 6.3 floor on every consumer of this library.

Note this does **not** close #372. That issue asks for the **podspec** dependency to be bumped, which is a separate change — and CocoaPods only ever published BigInt up to 5.2.0, so the podspec cannot track SPM here regardless.

macOS 435 / Linux 334, 0 failures, lint clean. The first CI run failed on two mainnet ENS tests — a different one per platform, both `ensUnknown` after ~110s against the public RPC — and re-running the same commit was green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)