### PR TITLE
tech: Replace the deprecated NSKeyedArchiver calls

### DIFF
--- a/web3sTests/Account/EthereumKeyStorageTests.swift
+++ b/web3sTests/Account/EthereumKeyStorageTests.swift
@@ -74,6 +74,25 @@ class EthereumKeyStorageTests: XCTestCase {
         }
     }
     
+    // A key file written by NSKeyedArchiver.archiveRootObject(_:toFile:) — the call this library
+    // used before moving to archivedData(withRootObject:requiringSecureCoding:). Anyone upgrading
+    // has one of these on disk, so it has to keep loading.
+    func testLoadsAPrivateKeyArchivedByAnEarlierVersion() throws {
+        let legacyArchive = Data(base64Encoded: "YnBsaXN0MDDUAQIDBAUGBwpYJHZlcnNpb25ZJGFyY2hpdmVyVCR0b3BYJG9iamVjdHMSAAGGoF8QD05TS2V5ZWRBcmNoaXZlctEICVRyb290gAGiCwxVJG51bGxPECArfhUWKK7Spqv3FYgJz0883q2+7wARIjNEVWZ3iJmquwgRGiQpMjdJTFFTVlwAAAAAAAABAQAAAAAAAAANAAAAAAAAAAAAAAAAAAAAfw==")!
+        let expected = Data([
+            0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6, 0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0x3c,
+            0xde, 0xad, 0xbe, 0xef, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb
+        ])
+
+        let url = try XCTUnwrap(FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first)
+            .appendingPathComponent("ethereumkey")
+        try legacyArchive.write(to: url)
+
+        let keyStorage = EthereumKeyLocalStorage() as EthereumSingleKeyStorageProtocol
+
+        XCTAssertEqual(try keyStorage.loadPrivateKey(), expected)
+    }
+
     func testDeleteAllPrivateKeys() {
         let keyStorage = EthereumKeyLocalStorage()
         do {

--- a/web3swift/src/Account/EthereumKeyStorage.swift
+++ b/web3swift/src/Account/EthereumKeyStorage.swift
@@ -31,14 +31,11 @@ public class EthereumKeyLocalStorage: EthereumSingleKeyStorageProtocol, @uncheck
     private let address: ThreadSafeBox<EthereumAddress?> = ThreadSafeBox(nil)
     private let localFileName = "ethereumkey"
 
-    private var addressPath: String? {
+    private var addressURL: URL? {
         guard let address = address.value else {
             return nil
         }
-        if let url = folderPath {
-            return url.appendingPathComponent(address.asString()).path
-        }
-        return nil
+        return folderPath?.appendingPathComponent(address.asString())
     }
 
     private var folderPath: URL? {
@@ -48,37 +45,51 @@ public class EthereumKeyLocalStorage: EthereumSingleKeyStorageProtocol, @uncheck
         return nil
     }
 
-    private var localPath: String? {
-        if let url = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first {
-            return url.appendingPathComponent(localFileName).path
-        }
-        return nil
+    private var localURL: URL? {
+        folderPath?.appendingPathComponent(localFileName)
     }
 
     private let fileManager = FileManager.default
 
-    public func storePrivateKey(key: Data) throws {
-        guard let localPath else {
-            throw EthereumKeyStorageError.failedToSave
-        }
-
-        let success = NSKeyedArchiver.archiveRootObject(key, toFile: localPath)
-
-        if !success {
+    /// Writes the archive `NSKeyedArchiver.archiveRootObject(_:toFile:)` used to write.
+    ///
+    /// `requiringSecureCoding: false` is what keeps the on-disk format unchanged, so key files
+    /// written by earlier versions still load.
+    fileprivate func archive(_ key: Data, to url: URL) throws {
+        do {
+            let archived = try NSKeyedArchiver.archivedData(withRootObject: key, requiringSecureCoding: false)
+            try archived.write(to: url)
+        } catch {
             throw EthereumKeyStorageError.failedToSave
         }
     }
 
+    fileprivate func unarchive(from url: URL) throws -> Data {
+        do {
+            let archived = try Data(contentsOf: url)
+            guard let key = try NSKeyedUnarchiver.unarchivedObject(ofClass: NSData.self, from: archived) else {
+                throw EthereumKeyStorageError.failedToLoad
+            }
+            return key as Data
+        } catch {
+            throw EthereumKeyStorageError.failedToLoad
+        }
+    }
+
+    public func storePrivateKey(key: Data) throws {
+        guard let localURL else {
+            throw EthereumKeyStorageError.failedToSave
+        }
+
+        try archive(key, to: localURL)
+    }
+
     public func loadPrivateKey() throws -> Data {
-        guard let localPath else {
+        guard let localURL else {
             throw EthereumKeyStorageError.failedToLoad
         }
 
-        guard let data = NSKeyedUnarchiver.unarchiveObject(withFile: localPath) as? Data else {
-            throw EthereumKeyStorageError.failedToLoad
-        }
-
-        return data
+        return try unarchive(from: localURL)
     }
 }
 
@@ -112,15 +123,11 @@ extension EthereumKeyLocalStorage: EthereumMultipleKeyStorageProtocol {
             }
         }
 
-        guard let localPath = self.addressPath else {
+        guard let addressURL = self.addressURL else {
             throw EthereumKeyStorageError.failedToSave
         }
 
-        let success = NSKeyedArchiver.archiveRootObject(key, toFile: localPath)
-
-        if !success {
-            throw EthereumKeyStorageError.failedToSave
-        }
+        try archive(key, to: addressURL)
     }
 
     public func loadPrivateKey(for address: EthereumAddress) throws -> Data {
@@ -134,15 +141,11 @@ extension EthereumKeyLocalStorage: EthereumMultipleKeyStorageProtocol {
             }
         }
 
-        guard let localPath = self.addressPath else {
+        guard let addressURL = self.addressURL else {
             throw EthereumKeyStorageError.failedToLoad
         }
 
-        guard let data = NSKeyedUnarchiver.unarchiveObject(withFile: localPath) as? Data else {
-            throw EthereumKeyStorageError.failedToLoad
-        }
-
-        return data
+        return try unarchive(from: addressURL)
     }
 
     public func deleteAllKeys() throws {


### PR DESCRIPTION
Salvages the deprecation cleanup from #386, which is otherwise unrelated to that PR's dependency work.

`archiveRootObject(_:toFile:)` and `unarchiveObject(withFile:)` have been deprecated since macOS 10.14 and produce four warnings on every build. Replaced with `archivedData(withRootObject:requiringSecureCoding:)` plus an explicit write, and `unarchivedObject(ofClass:from:)`.

`requiringSecureCoding: false` is deliberate — it keeps the archive format byte-compatible with what the old call wrote, so key files already on disk still load. That is covered by a test whose fixture was produced by the deprecated API itself, rather than by a round trip through the new code, which would pass even if the format had changed.

The two path properties fed only these call sites, so they become URLs instead of gaining URL twins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)